### PR TITLE
Using charset utf-8 and including mime.types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,8 @@ http {
     default upgrade;
     '' close;
   }
+  charset utf-8;
+  include mime.types;
 
   server {
     location /favicon.ico {

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -7,6 +7,8 @@ http {
     default upgrade;
     '' close;
   }
+  charset utf-8;
+  include mime.types;
 
   server {
     location /favicon.ico {


### PR DESCRIPTION
Using charset utf-8 and including mime.types so HTML files and images are displayed correctly.