### PR TITLE
Video duration is fetched from ffprobe json

### DIFF
--- a/alembic/versions/8bdb48a486b9_video_ffprobe_json.py
+++ b/alembic/versions/8bdb48a486b9_video_ffprobe_json.py
@@ -1,0 +1,35 @@
+"""Video ffprobe json.
+
+Revision ID: 8bdb48a486b9
+Revises: bf704baa185d
+Create Date: 2023-07-24 10:59:17.426100
+
+"""
+import os
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+# revision identifiers, used by Alembic.
+revision = '8bdb48a486b9'
+down_revision = 'bf704baa185d'
+branch_labels = None
+depends_on = None
+
+DOCKERIZED = True if os.environ.get('DOCKER', '').lower().startswith('t') else False
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    session.execute('ALTER TABLE video ADD COLUMN ffprobe_json JSON')
+    # Re-index all videos so the ffprobe data is fetched.
+    session.execute("UPDATE file_group SET indexed=false WHERE mimetype like 'video/%'")
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    session.execute('ALTER TABLE video DROP COLUMN IF EXISTS ffprobe_json')

--- a/app/src/Events.js
+++ b/app/src/Events.js
@@ -16,6 +16,8 @@ function handleEvents(events) {
         const {event, message, subject, dt, url} = e;
         document.dispatchEvent(new CustomEvent(apiEventName, {detail: e}));
 
+        console.debug(`Got event: ${event}`);
+
         if (event === 'directory_refresh') {
             eventToast(
                 'Refresh started',
@@ -26,7 +28,7 @@ function handleEvents(events) {
         if (subject && newestEvents[subject] && newestEvents[subject] > dt) {
             console.debug(`Already handled newer event of "${subject}".`);
             return;
-        } else if (event === 'global_refresh_completed') {
+        } else if (event === 'refresh_completed') {
             eventToast('Refresh completed', 'All files have been refreshed.');
         }
 

--- a/app/src/api.js
+++ b/app/src/api.js
@@ -539,23 +539,17 @@ export async function filesSearch(offset, limit, searchStr, mimetypes, model, ta
     }
 }
 
-export async function refreshFiles() {
-    return await apiPost(`${API_URI}/files/refresh`);
-}
-
-export async function refreshDirectoryFiles(paths) {
-    let body = {paths: paths};
-    try {
-        return await apiPost(`${API_URI}/files/refresh`, body);
-    } catch (e) {
-        console.error(e);
-        toast({
-            type: 'error',
-            title: 'Unable to refresh directory',
-            description: 'Cannot refresh the files in the directory.  See server logs.',
-            time: 5000,
-        });
+export async function refreshFiles(paths) {
+    let response;
+    if (paths && paths.constructor === Array) {
+        const body = {paths};
+        console.debug(`Refreshing: ${paths}`);
+        response = await apiPost(`${API_URI}/files/refresh`, body);
+    } else {
+        console.debug(`Refreshing all files`);
+        response = await apiPost(`${API_URI}/files/refresh`);
     }
+    return response;
 }
 
 export async function makeDirectory(path) {

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -131,11 +131,11 @@ function ArchivePage() {
         historyList = <FileCards files={history}/>;
     }
 
-    const domain = data.domain ? data.domain.domain : null;
+    const domain = data.domain ? data.domain : null;
     let domainHeader;
     if (domain) {
         const domainUrl = `/archive?domain=${domain}`;
-        domainHeader = <Header as='h5'>
+        domainHeader = <Header as='h4'>
             <CardLink to={domainUrl}>
                 {domain}
             </CardLink>
@@ -272,7 +272,7 @@ export function DomainsPage() {
         filteredDomains = domains.filter(i => re.test(i['domain']));
     }
 
-    const row = ({domain, url_count}) => {
+    const domainRow = ({domain, url_count, size}) => {
         return <TableRow key={domain}>
             <TableCell>
                 <Link to={`/archive?domain=${domain}`}>
@@ -280,12 +280,14 @@ export function DomainsPage() {
                 </Link>
             </TableCell>
             <TableCell>{url_count}</TableCell>
+            <TableCell>{humanFileSize(size)}</TableCell>
         </TableRow>
     }
 
     const headers = [
         {key: 'domain', text: 'Domain', sortBy: 'domain', width: 12},
         {key: 'archives', text: 'Archives', sortBy: 'url_count', width: 2},
+        {key: 'Size', text: 'Size', sortBy: 'size', width: 2},
     ];
 
     return <>
@@ -298,7 +300,7 @@ export function DomainsPage() {
         <SortableTable
             tableProps={{unstackable: true}}
             data={filteredDomains}
-            rowFunc={(i, sortData) => row(i)}
+            rowFunc={(i, sortData) => domainRow(i)}
             rowKey='domain'
             tableHeaders={headers}
         />
@@ -362,11 +364,10 @@ function ArchivesPage() {
         }
     }
 
-    const onDelete = async (e) => {
-        e.preventDefault();
+    const onDelete = async () => {
         setDeleteOpen(false);
         const archiveIds = archives.filter(i => selectedArchives.indexOf(i['primary_path']) >= 0)
-            .map(i => i['archive']['id']);
+            .map(i => i['data']['id']);
         await deleteArchives(archiveIds);
         await fetchArchives();
         setSelectedArchives([]);
@@ -383,18 +384,13 @@ function ArchivesPage() {
     }
 
     const selectElm = <div style={{marginTop: '0.5em'}}>
-        <Button
+        <APIButton
             color='red'
             disabled={_.isEmpty(selectedArchives)}
-            onClick={() => setDeleteOpen(true)}
-        >Delete</Button>
-        <Confirm
-            open={deleteOpen}
-            content='Are you sure you want to delete these archives files?  This cannot be undone.'
             confirmButton='Delete'
-            onCancel={() => setDeleteOpen(false)}
-            onConfirm={onDelete}
-        />
+            confirmContent='Are you sure you want to delete these archives files?  This cannot be undone.'
+            onClick={onDelete}
+        >Delete</APIButton>
         <Button
             color='grey'
             onClick={invertSelection}

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -541,6 +541,7 @@ export function CardPoster({to, file}) {
     const {s} = useContext(ThemeContext);
     // Used to center posters in CardIcon.
     const style = {display: 'flex', justifyContent: 'center', ...s['style']};
+    const navigate = useNavigate();
 
     const cardTagIcon = <div className="ui green left corner label">
         <i aria-hidden="true" className="tag icon"></i>
@@ -549,8 +550,27 @@ export function CardPoster({to, file}) {
 
     let posterPath = findPosterPath(file);
 
-    if (!posterPath) {
-        // No poster, use a FileIcon.
+    if (!posterPath && to && (to.startsWith('/download/') || to.startsWith('/media/'))) {
+        // No poster, link is to download a file directly.
+        return <ExternalCardLink to={to}>
+            <CardIcon onClick={() => {
+                window.location.href = to;
+                return null
+            }}>
+                {imageLabel}
+                <FileIcon file={file}/>
+            </CardIcon>
+        </ExternalCardLink>
+    } else if (!posterPath && to) {
+        // No poster, link to the full page.
+        return <Link to={to}>
+            <CardIcon onClick={() => navigate(to)}>
+                {imageLabel}
+                <FileIcon file={file}/>
+            </CardIcon>
+        </Link>
+    } else if (!posterPath) {
+        // No poster, no to, use a Preview.
         return <PreviewLink file={file}>
             <CardIcon>
                 {imageLabel}

--- a/app/src/components/DonatePage.js
+++ b/app/src/components/DonatePage.js
@@ -61,6 +61,22 @@ export function DonatePage() {
         <Segment>
             <Header as='h1'>Donate</Header>
             <Header as='h3'>We appreciate any support you can provide to WROLPi!</Header>
+
+            <p>
+                <Button
+                    size='huge'
+                    icon='paypal'
+                    as='a'
+                    color='blue'
+                    href='https://www.paypal.com/donate/?hosted_button_id=ZH2CN92SMJ66N'
+                    label={{
+                        basic: true,
+                        content: 'Donate on PayPal',
+                        color: 'blue'
+                    }}
+                />
+            </p>
+
             <CoinRow header='Monero' qrCodeValue={moneroContent} address={moneroAddress} buttonColor='orange'/>
             <CoinRow header='Litecoin' qrCodeValue={litecoinContent} address={litecoinAddress} buttonColor='grey'/>
             <CoinRow header='Ethereum' qrCodeValue={ethereumContent} address={ethereumAddress} buttonColor='blue'/>

--- a/app/src/components/VideoPlayer.js
+++ b/app/src/components/VideoPlayer.js
@@ -21,6 +21,7 @@ import {ThemeContext} from "../contexts/contexts";
 import {Button, darkTheme, Header, Icon, Segment, Tab, TabPane} from "./Theme";
 import {VideoCard} from "./Videos";
 import {TagsSelector} from "../Tags";
+import {Label} from "semantic-ui-react";
 
 const MEDIA_PATH = '/media';
 
@@ -109,6 +110,9 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
 
             <h3>Censored</h3>
             <p>{video.censored ? 'Yes' : 'No'}</p>
+
+            <h3>Codec Names</h3>
+            <>{video.codec_names ? video.codec_names.map(i => <Label>{i}</Label>) : 'N/A'}</>
         </TabPane>
     }
 
@@ -133,7 +137,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
 
             <h4>Caption Files</h4>
             {caption_files &&
-                caption_files.map(i => <PreviewPath key={i['path']} {...i}>{i['path']}</PreviewPath>)
+                caption_files.map(i => <p key={i['path']}><PreviewPath {...i}>{i['path']}</PreviewPath></p>)
             }
 
             <h4>Poster File</h4>
@@ -161,6 +165,13 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
         await fetchVideo();
     }
 
+    let videoSource = <source src={videoUrl}/>;
+    if (video.codec_names && video.codec_names.indexOf('mp4') >= 0) {
+        videoSource = <source src={videoUrl} type="video/mp4"/>
+    } else if (video.codec_names && video.codec_names.indexOf('vp9') >= 0) {
+        videoSource = <source src={videoUrl} type='video/mp4;codecs="vp9, vorbis"'/>
+    }
+
     return <>
         <Container style={{margin: '1em'}}>
             <BackButton/>
@@ -174,7 +185,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
                style={{maxWidth: '100%'}}
                ref={videoRef}
         >
-            <source src={videoUrl} type="video/mp4"/>
+            {videoSource}
             {/* Only WebVTT captions can be displayed. */}
             {captionUrls.map(i => <track key={i} kind="captions" label="English" src={i} srcLang="en" default/>)}
         </video>

--- a/app/src/hooks/customHooks.js
+++ b/app/src/hooks/customHooks.js
@@ -735,6 +735,11 @@ export const StatusProvider = (props) => {
     </StatusContext.Provider>
 }
 
+export const useStatusFlag = (flag) => {
+    const {status} = useContext(StatusContext);
+    return status && status['flags'] && status['flags'].indexOf(flag) >= 0;
+}
+
 
 export const useVideoStatistics = () => {
     const [statistics, setStatistics] = useState({});

--- a/modules/archive/api.py
+++ b/modules/archive/api.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from sanic import response, Request
 from sanic_ext import validate
 from sanic_ext.extensions.openapi import openapi
+from sanic_ext.extensions.openapi.definitions import Response
 
 from wrolpi.common import logger, wrol_mode_check, api_param_limiter
 from wrolpi.errors import ValidationError
@@ -43,7 +44,9 @@ async def delete_archive(_: Request, archive_ids: str):
 
 
 @bp.get('/domains')
-async def fetch_domains(_: Request):
+@openapi.summary('Get a list of all Domains and their Archive statistics')
+@openapi.response(200, schema.GetDomainsResponse, "The list of domains")
+async def get_domains(_: Request):
     domains = lib.get_domains()
     return json_response({'domains': domains, 'totals': {'domains': len(domains)}})
 

--- a/modules/archive/conftest.py
+++ b/modules/archive/conftest.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import pathlib
+from typing import List
 from uuid import uuid4
 
 import pytest
@@ -28,9 +29,11 @@ def archive_factory(test_session, archive_directory, make_files_structure):
     now = time_generator()
 
     def _(domain: str = None, url: str = None, title: str = 'NA', contents: str = None,
-          singlefile_contents: str = None) -> Archive:
+          singlefile_contents: str = None, tag_names: List[str] = None) -> Archive:
         if domain:
             assert '/' not in domain
+
+        tag_names = tag_names or list()
 
         title = title or str(uuid4())
         domain_dir = domain or title
@@ -76,6 +79,9 @@ def archive_factory(test_session, archive_directory, make_files_structure):
         archive.archive_datetime = next(now)
         archive.domain = domain
         archive.validate()
+
+        for tag_name in tag_names:
+            archive.add_tag(tag_name)
 
         return archive
 

--- a/modules/archive/models.py
+++ b/modules/archive/models.py
@@ -11,11 +11,11 @@ from sqlalchemy.orm.collections import InstrumentedList
 
 from wrolpi.common import ModelHelper, Base, logger
 from wrolpi.dates import TZDateTime
-from modules.archive import InvalidArchive
 from wrolpi.files.models import FileGroup
 from wrolpi.media_path import MediaPathType
 from wrolpi.tags import Tag, TagFile
 from wrolpi.vars import PYTEST
+from .errors import InvalidArchive
 
 logger = logger.getChild(__name__)
 

--- a/modules/archive/schema.py
+++ b/modules/archive/schema.py
@@ -19,8 +19,14 @@ class ArchiveDict:
 
 @dataclass
 class DomainDict:
-    id: int
     domain: str
+    url_count: int
+    size: int
+
+
+@dataclass
+class GetDomainsResponse:
+    domains: List[DomainDict]
 
 
 @dataclass

--- a/modules/videos/__init__.py
+++ b/modules/videos/__init__.py
@@ -37,6 +37,9 @@ async def video_modeler():
                         session.add(video)
                         session.flush([video])
                     video_id = video.id
+                    # Extract ffprobe data.
+                    await video.get_ffprobe_json()
+                    # Validate and index subtitles.
                     video.validate()
                 except Exception as e:
                     if PYTEST:

--- a/modules/videos/lib.py
+++ b/modules/videos/lib.py
@@ -119,7 +119,11 @@ def validate_video(video: Video, channel_generate_poster: bool):
 
     if video_path and not video.duration:
         # Duration was not retrieved during poster generation.
-        video.duration = get_video_duration(video_path)
+        if video.ffprobe_json and (video_streams := video.get_streams_by_codec_type('video')):
+            video.duration = float(video_streams[0]['duration'])
+        else:
+            # Slowest method.
+            video.duration = get_video_duration(video_path)
 
     if video_path and not video.caption_paths and video.file_group.d_text and not EXTRACT_SUBTITLES:
         # Caption file was deleted, clear out old captions.

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -366,6 +366,8 @@ async def test_download_result(test_session, test_directory, video_download_mana
         mock_prepare_filename.return_value = [video_file, {'id': 'foo'}]
         video_download_manager.create_download('https://example.com', video_downloader.name)
         await video_download_manager.wait_for_all_downloads()
+        # Sleep to allow background tasks to finish.
+        await asyncio.sleep(1)
 
     download: Download = test_session.query(Download).one()
     assert download.url == 'https://example.com'

--- a/modules/videos/test/test_models.py
+++ b/modules/videos/test/test_models.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.mark.asyncio()
+async def test_ffprobe_stream_methods(simple_video):
+    """ffprobe data can be used to get data about specific streams in the video file."""
+    assert await simple_video.get_ffprobe_json()
+
+    assert simple_video.get_streams_by_codec_type('video')
+    assert simple_video.get_streams_by_codec_type('audio')
+    assert simple_video.get_streams_by_codec_type('subtitle')
+
+    assert simple_video.get_streams_by_codec_name('h264')
+    assert simple_video.get_streams_by_codec_name('aac')
+    assert simple_video.get_streams_by_codec_name('mov_text')

--- a/pi-gen/stage2/04-wrolpi/01-packages
+++ b/pi-gen/stage2/04-wrolpi/01-packages
@@ -50,6 +50,7 @@ libtool
 libxml2-dev
 lua5.1
 mapnik-utils
+netcat
 network-manager
 nginx-doc
 nginx-full

--- a/scripts/find_corrupt_videos.py
+++ b/scripts/find_corrupt_videos.py
@@ -1,0 +1,132 @@
+#! /usr/bin/env python3
+"""
+Searches the DB for Video records which do not have both video and audio streams.  If a Video still exists at its URL,
+it will be automatically re-downloaded.  If a Video cannot be re-downloaded (it has been deleted from its host) you
+will be prompted to delete it.
+"""
+import argparse
+import asyncio
+import logging
+import sys
+from typing import List
+
+from yt_dlp.utils import YoutubeDLError
+
+from modules.videos.downloader import VideoDownloader, extract_info
+from modules.videos.models import Video
+from wrolpi.db import get_db_session, get_db_curs
+from wrolpi.downloader import download_manager
+
+logger = logging.getLogger()
+
+
+def get_total_corrupted_videos() -> int:
+    with get_db_curs() as curs:
+        stmt = '''
+            WITH all_videos AS (
+                select v.id, array_agg(s ->> 'codec_type')::TEXT[] AS codec_types
+                from video v
+                         cross join lateral json_array_elements(ffprobe_json -> 'streams') s
+                group by v.id)
+            SELECT COUNT(all_videos.id)
+            FROM all_videos
+            WHERE NOT all_videos.codec_types @> '{audio,video}'::TEXT[]
+        '''
+        curs.execute(stmt)
+        return int(curs.fetchone()[0])
+
+
+def get_corrupt_videos(limit: int, offset: int) -> List[dict]:
+    params = dict(limit=limit, offset=offset)
+    with get_db_curs() as curs:
+        stmt = '''
+            WITH all_videos AS (
+                -- Extract 'codec_type' from all 'stream' objects of each video.
+                -- {'streams': [{'codec_type': 'video'}, {'codec_type': 'audio'}]} -> {video,audio}
+                select v.id, array_agg(s ->> 'codec_type')::TEXT[] AS codec_types
+                from video v
+                         cross join lateral json_array_elements(ffprobe_json -> 'streams') s
+                group by v.id)
+            SELECT all_videos.id AS video_id, fg.primary_path, all_videos.codec_types
+            FROM all_videos
+                     LEFT JOIN video v ON v.id = all_videos.id
+                     LEFT JOIN public.file_group fg on fg.id = v.file_group_id
+            -- Filter out videos that have video AND audio streams.
+            WHERE NOT all_videos.codec_types @> '{video,audio}'::TEXT[]
+              AND fg.primary_path like '/media/wrolpi/videos/%%'
+            ORDER BY all_videos.id
+            LIMIT %(limit)s
+            OFFSET %(offset)s
+        '''
+        curs.execute(stmt, params)
+        return [dict(i) for i in curs.fetchall()]
+
+
+def iterate_corrupt_videos() -> List[dict]:
+    limit = 20
+    offset = 0
+    while True:
+        videos = get_corrupt_videos(limit, offset)
+        offset += limit
+        if len(videos) < limit:
+            # Ran out of corrupt videos.
+            break
+        yield videos
+
+
+def confirm(msg: str) -> bool:
+    while True:
+        input_ = input(msg)
+        if input_ == 'y':
+            return True
+        if input_ == 'q':
+            print('Quitting...')
+            sys.exit(0)
+        if not input_ or input_ == 'n':
+            return False
+
+
+async def find_corrupt_videos():
+    total_corrupted = get_total_corrupted_videos()
+    count = 0
+
+    with get_db_session() as session:
+        for chunk in iterate_corrupt_videos():
+            video_ids = [i['video_id'] for i in chunk]
+            videos = session.query(Video).filter(Video.id.in_(video_ids)).all()
+            for video in videos:
+                print()
+                print(f'Video (remaining: {total_corrupted - count}): {video}')
+                count += 1
+                streams = (await video.get_ffprobe_json())['streams']
+                codec_names = [i['codec_name'] for i in streams]
+                print(f'codecs: {codec_names}')
+
+                url = video.url
+                if url:
+                    try:
+                        extract_info(url)
+                        print(f'Re-downloading')
+                        download_manager.create_download(url, VideoDownloader.name, session=session)
+                        video.delete()
+                        session.commit()
+                        continue
+                    except YoutubeDLError:
+                        logger.error(f'Video cannot be downloaded: {url}')
+                        if confirm(f'Delete?  (y/N)'):
+                            video.delete()
+                            session.commit()
+                            continue
+
+                if confirm('Delete?  (y/N)'):
+                    video.delete()
+                    session.commit()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args()
+
+    loop = asyncio.get_event_loop()
+    coro = find_corrupt_videos()
+    loop.run_until_complete(coro)

--- a/scripts/install_debian_11.sh
+++ b/scripts/install_debian_11.sh
@@ -23,6 +23,7 @@ apt-get install -y \
   kiwix \
   kiwix-tools \
   libpq-dev \
+  netcat \
   network-manager \
   nginx-doc \
   nginx-full \

--- a/scripts/install_raspberrypios.sh
+++ b/scripts/install_raspberrypios.sh
@@ -23,6 +23,7 @@ apt-get install -y \
   kiwix \
   kiwix-tools \
   libpq-dev \
+  netcat \
   network-manager \
   nginx-doc \
   nginx-full \

--- a/scripts/start_kiwix_serve.sh
+++ b/scripts/start_kiwix_serve.sh
@@ -1,16 +1,25 @@
 #! /usr/bin/env bash
-# This file imports all *.zim files in the media directory, then starts kiwix-serve.
+# This file imports all *.zim files in the Zim media directory, then starts kiwix-serve.
 
 [ ! -d /media/wrolpi ] && echo "Cannot start kiwix without media directory mounted" && exit 1
 
 LIBRARY=/media/wrolpi/zims/library.xml
+
+# Wait for the zims directory to be mounted.
+COUNT=0
+while [ ${COUNT} -lt 30 ]; do
+  if [ -d /media/wrolpi/zims ]; then
+    break
+  fi
+  sleep 1
+done
 
 # Create the zim directory, if necessary.
 [ ! -d /media/wrolpi/zims ] && mkdir /media/wrolpi/zims
 # We will replace the library file.
 rm -f ${LIBRARY}
 # Find all Zim files and import them.
-find /media/wrolpi -iname '*.zim' -exec kiwix-manage ${LIBRARY} add {} \;
+find /media/wrolpi/zims -iname '*.zim' -exec kiwix-manage ${LIBRARY} add {} \;
 
 [ ! -f ${LIBRARY} ] && echo "Could not find any Zim files to import" && exit 2
 

--- a/wrolpi/conftest.py
+++ b/wrolpi/conftest.py
@@ -13,7 +13,7 @@ import zipfile
 from abc import ABC
 from datetime import datetime
 from itertools import zip_longest
-from typing import List, Callable, Union, Dict, Sequence
+from typing import List, Callable, Dict, Sequence
 from typing import Tuple, Set
 from unittest import mock
 from unittest.mock import MagicMock
@@ -241,8 +241,17 @@ def test_downloader(test_download_manager):
 @pytest.fixture
 def video_file(test_directory) -> pathlib.Path:
     """Return a copy of the example Big Buck Bunny video in the `test_directory`."""
-    destination = test_directory / f'{uuid4()}.mp4'
+    destination = test_directory / f'video-{uuid4()}.mp4'
     shutil.copy(PROJECT_DIR / 'test/big_buck_bunny_720p_1mb.mp4', destination)
+
+    yield destination
+
+
+@pytest.fixture
+def corrupted_video_file(test_directory) -> pathlib.Path:
+    """Return a copy of a corrupted video file in the `test_directory`."""
+    destination = test_directory / f'corrupted-{uuid4()}.mp4'
+    shutil.copy(PROJECT_DIR / 'test/corrupted.mp4', destination)
 
     yield destination
 

--- a/wrolpi/events.py
+++ b/wrolpi/events.py
@@ -22,8 +22,8 @@ class Events:
         send_event('global_refresh_started', message, subject='refresh')
 
     @staticmethod
-    def send_global_refresh_completed(message: str = None):
-        send_event('global_refresh_completed', message, subject='refresh')
+    def send_refresh_completed(message: str = None):
+        send_event('refresh_completed', message, subject='refresh')
 
     @staticmethod
     def send_global_refresh_modeling_completed(message: str = None):

--- a/wrolpi/files/api.py
+++ b/wrolpi/files/api.py
@@ -389,7 +389,7 @@ async def post_upload(request: Request):
     if chunk_num == total_chunks:
         # File upload is complete.
         del UPLOADED_FILES[output_str]
-        background_task(lib.refresh_files([output]))
+        background_task(lib.refresh_files([output.parent]))
         return response.empty(HTTPStatus.CREATED)
 
     # Request the next chunk.

--- a/wrolpi/files/test/test_lib.py
+++ b/wrolpi/files/test/test_lib.py
@@ -184,10 +184,10 @@ async def test__upsert_files(test_session, make_files_structure, test_directory,
              {'path': srt_file3, 'size': 951, 'suffix': '.en.srt', 'mimetype': 'text/srt'},
              {'path': video_file, 'size': 1056318, 'suffix': '.mp4', 'mimetype': 'video/mp4'},
          ]},
-        {'primary_path': bar, 'idempotency': idempotency,
+        {'primary_path': bar, 'idempotency': idempotency, 'indexed': False,
          'files': [{'path': bar, 'size': 0, 'suffix': '.txt', 'mimetype': 'inode/x-empty'}]
          },
-        {'primary_path': baz, 'idempotency': idempotency,
+        {'primary_path': baz, 'idempotency': idempotency, 'indexed': False,
          'files': [{'path': baz, 'size': 8, 'suffix': '.txt', 'mimetype': 'text/plain'}]
          },
     ])
@@ -211,10 +211,10 @@ async def test__upsert_files(test_session, make_files_structure, test_directory,
              {'path': srt_file3, 'size': 951, 'suffix': '.en.srt', 'mimetype': 'text/srt'},
              {'path': video_file, 'size': 1056318, 'suffix': '.mp4', 'mimetype': 'video/mp4'},
          ]},
-        {'primary_path': bar, 'idempotency': idempotency,
+        {'primary_path': bar, 'idempotency': idempotency, 'indexed': False,
          'files': [{'path': bar, 'size': 0, 'suffix': '.txt', 'mimetype': 'inode/x-empty'}],
          },
-        {'primary_path': baz, 'idempotency': idempotency,
+        {'primary_path': baz, 'idempotency': idempotency, 'indexed': False,
          'files': [{'path': baz, 'size': 7, 'suffix': '.txt', 'mimetype': 'text/plain'}],
          },
     ])
@@ -224,6 +224,17 @@ async def test__upsert_files(test_session, make_files_structure, test_directory,
     lib._upsert_files([video_file, bar, baz], idempotency)
     video_file_group: FileGroup = test_session.query(FileGroup).filter_by(primary_path=str(video_file)).one()
     assert len(video_file_group.files) == 1, 'SRT file was not removed from files'
+    assert_file_groups([
+        # Video is no longer indexed because SRT was removed.
+        {'primary_path': video_file, 'idempotency': idempotency, 'modification_datetime': foo_mtime, 'indexed': False,
+         'files': [{'path': video_file, 'size': 1056318, 'suffix': '.mp4', 'mimetype': 'video/mp4'}]},
+        {'primary_path': bar, 'idempotency': idempotency, 'indexed': False,
+         'files': [{'path': bar, 'size': 0, 'suffix': '.txt', 'mimetype': 'inode/x-empty'}],
+         },
+        {'primary_path': baz, 'idempotency': idempotency, 'indexed': False,
+         'files': [{'path': baz, 'size': 7, 'suffix': '.txt', 'mimetype': 'text/plain'}],
+         },
+    ])
 
 
 @pytest.mark.asyncio

--- a/wrolpi/test/test_events.py
+++ b/wrolpi/test/test_events.py
@@ -28,7 +28,7 @@ def test_events_api_feed(test_session, test_client, example_pdf):
     assert (result := response.json.get('events'))
 
     expected = [
-        dict(event='global_refresh_completed', subject='refresh'),
+        dict(event='refresh_completed', subject='refresh'),
         dict(event='global_after_refresh_completed', subject='refresh'),
         dict(event='global_refresh_indexing_completed', subject='refresh'),
         dict(event='global_refresh_modeling_completed', subject='refresh'),


### PR DESCRIPTION
- Creating Video.ffprobe_json column which stores ffprobe information about the video file.
- Creating find_corrupt_videos.py script which automatically re-downloads videos which do not have both video and audio streams.
- Creating APIButton which displays loading icon while an API action is performed.