### PR TITLE
Warn in the navbar when a drive's SMART health is failing

### DIFF
--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -6,6 +6,7 @@ import {DarkModeToggle, HotspotStatusIcon, useLocalStorage} from "./Common";
 import {ShareButton} from "./Share";
 import {
     useCPUTemperature,
+    useDriveHealth,
     useDriveTemperature,
     useIOStats,
     useLoad,
@@ -197,6 +198,20 @@ export function NavBar() {
         driveTemperatureIcon = <Popup content={`${hotDrive}: ${driveTemperature.toFixed()}°C`} trigger={link}/>;
     }
 
+    // A drive's SMART self-assessment is failing — imminent drive failure.
+    // Always displayed (like power); too important to hide behind a transient
+    // warning in the priority chain.
+    const {failingDevices, failing: driveFailing} = useDriveHealth();
+    let driveHealthIcon;
+    if (driveFailing) {
+        const icon = <Icon data-testid='driveHealthIcon' name='warning sign' size='large' color={highWarningColor}/>;
+        const link = <Link to='/admin/status'>{icon}</Link>;
+        const message = failingDevices.length === 1
+            ? `Drive ${failingDevices[0]} is failing its SMART health check! Back up your data.`
+            : `Drives failing SMART health check: ${failingDevices.join(', ')}. Back up your data.`;
+        driveHealthIcon = <Popup content={message} trigger={link}/>;
+    }
+
     // Power issues, this is always displayed if detected.
     const {underVoltage, overCurrent} = usePowerStats();
     let powerIcon;
@@ -274,6 +289,7 @@ export function NavBar() {
         <NavIconWrapper>{apiDownIcon}</NavIconWrapper>
         <NavIconWrapper>{processingIcon}</NavIconWrapper>
         <NavIconWrapper>{upgradeIcon}</NavIconWrapper>
+        <NavIconWrapper>{driveHealthIcon}</NavIconWrapper>
         <NavIconWrapper>{powerIcon}</NavIconWrapper>
         <NavIconWrapper>{warningIcon}</NavIconWrapper>
         <NavIconWrapper><ShareButton/></NavIconWrapper>

--- a/app/src/hooks/customHooks.js
+++ b/app/src/hooks/customHooks.js
@@ -1357,6 +1357,18 @@ export const useDriveTemperature = () => {
     }
 }
 
+// Reports drives whose SMART self-assessment is failing, so the navbar can
+// warn of an imminent drive failure.  pySMART reports 'PASS', 'FAIL', or null
+// (unknown); only 'FAIL' is a problem.
+export const useDriveHealth = () => {
+    const {status} = React.useContext(StatusContext);
+    const drives = Array.isArray(status?.smart_stats?.drives) ? status.smart_stats.drives : [];
+    const failingDevices = drives
+        .filter((d) => d.assessment === 'FAIL')
+        .map((d) => d.device);
+    return {failingDevices, failing: failingDevices.length > 0};
+}
+
 export const useLoad = () => {
     const {status} = React.useContext(StatusContext);
     let minute_1 = status?.load_stats?.minute_1;

--- a/app/src/hooks/customHooks.test.js
+++ b/app/src/hooks/customHooks.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {act, renderHook} from '@testing-library/react';
 import {render, screen} from '@testing-library/react';
-import {usePages, useDriveTemperature} from './customHooks';
+import {usePages, useDriveTemperature, useDriveHealth} from './customHooks';
 import {QueryContext, StatusContext} from '../contexts/contexts';
 import {Paginator} from '../components/Common';
 
@@ -159,6 +159,69 @@ describe('useDriveTemperature', () => {
             {wrapper: makeStatusWrapper(status)});
         expect(result.current.device).toBeNull();
         expect(result.current.temperature).toBe(0);
+    });
+});
+
+describe('useDriveHealth', () => {
+    const makeStatusWrapper = (status) => ({children}) => (
+        <StatusContext.Provider value={{status}}>
+            {children}
+        </StatusContext.Provider>
+    );
+
+    test('flags drives whose SMART assessment is FAIL', () => {
+        const status = {
+            smart_stats: {
+                drives: [
+                    {device: 'sda', assessment: 'PASS'},
+                    {device: 'sdb', assessment: 'FAIL'},
+                ],
+            },
+        };
+        const {result} = renderHook(() => useDriveHealth(),
+            {wrapper: makeStatusWrapper(status)});
+        expect(result.current.failing).toBe(true);
+        expect(result.current.failingDevices).toEqual(['sdb']);
+    });
+
+    test('reports every failing drive', () => {
+        const status = {
+            smart_stats: {
+                drives: [
+                    {device: 'sda', assessment: 'FAIL'},
+                    {device: 'sdb', assessment: 'FAIL'},
+                ],
+            },
+        };
+        const {result} = renderHook(() => useDriveHealth(),
+            {wrapper: makeStatusWrapper(status)});
+        expect(result.current.failingDevices).toEqual(['sda', 'sdb']);
+    });
+
+    test('does not warn when all drives PASS', () => {
+        const status = {
+            smart_stats: {drives: [{device: 'sda', assessment: 'PASS'}]},
+        };
+        const {result} = renderHook(() => useDriveHealth(),
+            {wrapper: makeStatusWrapper(status)});
+        expect(result.current.failing).toBe(false);
+        expect(result.current.failingDevices).toEqual([]);
+    });
+
+    test('ignores drives with an unknown (null) assessment', () => {
+        const status = {
+            smart_stats: {drives: [{device: 'sda', assessment: null}]},
+        };
+        const {result} = renderHook(() => useDriveHealth(),
+            {wrapper: makeStatusWrapper(status)});
+        expect(result.current.failing).toBe(false);
+    });
+
+    test('does not warn when smart_stats is absent', () => {
+        const {result} = renderHook(() => useDriveHealth(),
+            {wrapper: makeStatusWrapper({})});
+        expect(result.current.failing).toBe(false);
+        expect(result.current.failingDevices).toEqual([]);
     });
 });
 


### PR DESCRIPTION
## Summary
Adds a navbar warning when a drive's SMART self-assessment is **failing**, completing the disk-health warnings alongside the temperature warning from #470. A failing SMART assessment predicts imminent drive failure, so the warning is prominent and persistent.

## Changes (frontend-only)
The `assessment` field (pySMART reports `PASS` / `FAIL` / `null`) is already present in the cached `smart_stats` payload, so no backend change is needed.
- **`useDriveHealth()`** (`customHooks.js`): flags any drive whose `assessment === 'FAIL'`; `null` (unknown) is ignored.
- **`Nav.js`**: renders a red `warning sign` icon in its **own always-on slot** (next to the power warning), rather than the single-slot priority chain where a transient high temperature could mask it. Popup names the failing drive(s) and links to `/admin/status`.

## Testing (TDD)
Added 5 `useDriveHealth` tests first (failing → red), then implemented:
- detects a `FAIL` drive, reports every failing drive, stays silent when all `PASS`, ignores `null` assessment, handles absent `smart_stats`.
- Frontend Jest: **470 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)