### PR TITLE
Recover downloads orphaned in the "pending" state

### DIFF
--- a/wrolpi/contexts.py
+++ b/wrolpi/contexts.py
@@ -138,6 +138,7 @@ def reset_shared_contexts(app: Sanic):
         processing_domains=[],
         killed_downloads=[],
         download_progress={},
+        running_downloads={},
     ))
 
     # Configs

--- a/wrolpi/downloader.py
+++ b/wrolpi/downloader.py
@@ -99,6 +99,33 @@ def clear_download_progress(download_id: int):
     api_app.shared_ctx.download_manager_data.update(data)
 
 
+# `running_downloads` lives in shared_ctx (alongside processing_domains/killed_downloads/download_progress) and
+# maps download_id -> start time for downloads whose worker is currently running.  It is cleared on startup (see
+# contexts.py), so any Download that is `pending` in the DB but absent here belongs to a worker that died or was
+# cancelled without finalizing.  `DownloadManager.reap_orphaned_downloads` uses it to recover such orphans.
+def register_running_download(download_id: int):
+    """Record that a download worker for `download_id` is running."""
+    data = dict(api_app.shared_ctx.download_manager_data)
+    running = dict(data.get('running_downloads', {}))
+    running[download_id] = time.time()
+    data['running_downloads'] = running
+    api_app.shared_ctx.download_manager_data.update(data)
+
+
+def unregister_running_download(download_id: int):
+    """Record that the download worker for `download_id` has stopped (finished, failed, or cancelled)."""
+    data = dict(api_app.shared_ctx.download_manager_data)
+    running = dict(data.get('running_downloads', {}))
+    running.pop(download_id, None)
+    data['running_downloads'] = running
+    api_app.shared_ctx.download_manager_data.update(data)
+
+
+def running_download_ids() -> set:
+    """Return the ids of downloads whose workers are currently running."""
+    return set(api_app.shared_ctx.download_manager_data.get('running_downloads', {}))
+
+
 def make_progress_callback(report: Callable[[dict], None], parse_fn: callable) -> callable:
     """Create a stdout callback that parses progress lines and forwards them to `report`.
 
@@ -1062,6 +1089,12 @@ class DownloadManager:
             return
 
         try:
+            # Recover downloads left `pending` by a worker that died/was cancelled without finalizing.
+            self.reap_orphaned_downloads()
+        except Exception as e:
+            self.log_error(f'Unable to reap orphaned downloads!', exc_info=e)
+
+        try:
             self.renew_recurring_downloads()
         except Exception as e:
             self.log_error(f'Unable to renew downloads!', exc_info=e)
@@ -1157,6 +1190,27 @@ class DownloadManager:
             query = query.limit(limit)
         downloads = query.all()
         return downloads
+
+    def reap_orphaned_downloads(self):
+        """Renew any `pending` Download that no live worker is running.
+
+        `Download.started()` sets a Download to `pending` when a worker picks it up.  If that worker dies
+        (process restart, OOM-kill) or is cancelled (shutdown) without reaching the status-update block in
+        `signal_download_download`, the row is left `pending` forever: `dispatch_downloads` only queries `new`
+        Downloads, and `renew_recurring_downloads` deliberately skips `pending` ones.  The `running_downloads`
+        registry is cleared on startup and tracks live workers, so any `pending` Download whose id is absent from
+        it belongs to a worker that no longer exists; renew it so it will be retried."""
+        running = running_download_ids()
+        reaped = []
+        with get_db_session(commit=True) as session:
+            pending = session.query(Download).filter(Download.status == DownloadStatus.pending).all()
+            for download in pending:
+                if download.id not in running:
+                    download.renew()
+                    download.error = 'Download was interrupted before it finished and has been restarted'
+                    reaped.append(download.url)
+        if reaped:
+            self.log_warning(f'Reaped {len(reaped)} orphaned download(s) left pending by a stopped worker: {reaped}')
 
     def renew_recurring_downloads(self):
         """Mark any recurring downloads that are due for download as "new".  Start a download."""
@@ -1543,6 +1597,10 @@ async def signal_download_download(download_id: int, download_url: str):
         try:
             worker_logger.debug(f'Got download {download_id}')
 
+            # Record liveness BEFORE marking the Download `pending` so reap_orphaned_downloads never mistakes a
+            # running download for an orphan.  These happen with no await between them.
+            register_running_download(download_id)
+
             with get_db_session(commit=True) as session:
                 # Mark the download as started in new session so the change is committed.
                 download = Download.find_by_id(session, download_id)
@@ -1671,15 +1729,37 @@ async def signal_download_download(download_id: int, download_url: str):
                     pass  # shared_ctx not initialized
         except asyncio.CancelledError as e:
             worker_logger.warning('Canceled!', exc_info=e)
+            # The worker was cancelled (e.g. shutdown) before finalizing.  Renew the Download so it is not left
+            # stuck `pending` forever.  Best-effort: the event loop may be tearing down.
+            _renew_interrupted_download(download_id, 'Download was canceled before it finished')
             return
         except Exception as e:
             worker_logger.warning(f'Unexpected error', exc_info=e)
+            # An error escaped the normal handling above, leaving the Download `pending`.  Renew it so it retries.
+            _renew_interrupted_download(download_id, str(traceback.format_exc()))
         finally:
+            # This worker is no longer running this download.
+            unregister_running_download(download_id)
             # Remove this domain from the running list.
             if download_domain:
                 download_manager._delete_processing_domain(download_domain)
             # Ensure download progress is always cleaned up.
             clear_download_progress(download_id)
+
+
+def _renew_interrupted_download(download_id: int, error: str):
+    """Best-effort: renew a Download that is still `pending` because its worker was interrupted.
+
+    Guarded on `is_pending` so a Download whose status was already finalized (complete/failed/deferred) is not
+    clobbered.  Swallows all errors because this runs on cancellation/shutdown paths where the DB may be gone."""
+    try:
+        with get_db_session(commit=True) as session:
+            download = Download.get_by_id(session, download_id)
+            if download and download.is_pending:
+                download.renew()
+                download.error = error
+    except Exception:
+        pass
 
 
 @dataclass

--- a/wrolpi/test/test_downloader.py
+++ b/wrolpi/test/test_downloader.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import pathlib
 from abc import ABC
@@ -149,6 +150,81 @@ async def test_cancel_wrapper_outer_cancellation(test_session, test_download_man
 
     # The inner coroutine should have been cancelled too.
     assert inner_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_reap_orphaned_downloads(test_session, test_download_manager, test_downloader):
+    """A Download left `pending` by a worker that died is renewed; one with a live worker is left alone.
+
+    `Download.started()` sets a Download to `pending`.  If the worker process dies (restart, OOM) or is
+    cancelled without finalizing, the row is stuck `pending` forever (dispatch only queries `new`, and
+    renew_recurring skips `pending`).  reap_orphaned_downloads uses the in-process running registry to tell a
+    live download apart from an orphan."""
+    from wrolpi import downloader as downloader_module
+
+    orphan = test_download_manager.create_download(test_session, 'https://example.com/orphan', test_downloader.name)
+    live = test_download_manager.create_download(test_session, 'https://example.com/live', test_downloader.name)
+    fresh = test_download_manager.create_download(test_session, 'https://example.com/fresh', test_downloader.name)
+    orphan.started()  # pending, but no worker is running it (the worker died).
+    live.started()  # pending, and a worker is actively running it.
+    test_session.commit()
+    assert orphan.status == 'pending' and live.status == 'pending' and fresh.status == 'new'
+
+    # Simulate that `live` is actively being downloaded in this process.
+    downloader_module.register_running_download(live.id)
+    try:
+        test_download_manager.reap_orphaned_downloads()
+    finally:
+        downloader_module.unregister_running_download(live.id)
+
+    test_session.expire_all()
+    assert orphan.status == 'new', 'Orphaned pending download should be renewed.'
+    assert orphan.error and 'interrupted' in orphan.error
+    assert live.status == 'pending', 'Download with a live worker should be left alone.'
+    assert fresh.status == 'new', 'A new download is unaffected.'
+
+
+@pytest.mark.asyncio
+async def test_do_downloads_recovers_orphaned_download(test_session, test_download_manager, test_downloader, fake_now):
+    """do_downloads reaps an orphaned `pending` download so it is retried without a process restart."""
+    test_downloader.set_test_success()
+    download = test_download_manager.recurring_download(test_session, 'https://example.com/orphan',
+                                                        DownloadFrequency.daily, test_downloader.name)
+    download.started()  # Stuck pending, no live worker (its worker crashed).
+    test_session.commit()
+    assert download.status == 'pending'
+
+    # do_downloads reaps the orphan (-> new) and dispatches it.
+    await test_download_manager.do_downloads()
+    await test_download_manager.wait_for_all_downloads()
+
+    test_session.expire_all()
+    assert download.is_complete, f'Orphaned download should be recovered and completed, got {download.status}'
+
+
+@pytest.mark.asyncio
+async def test_signal_download_cancelled_renews_download(test_session, test_download_manager, test_downloader):
+    """If the download worker task is cancelled mid-flight, the Download is renewed, not left pending."""
+    from wrolpi.downloader import signal_download_download, running_download_ids
+
+    download = test_download_manager.create_download(test_session, 'https://example.com/cancelme',
+                                                     test_downloader.name)
+    test_session.commit()
+    test_downloader.set_test_success()  # sleeps 1s inside execute_download
+
+    task = asyncio.create_task(signal_download_download(download.id, download.url))
+    await asyncio.sleep(0.3)  # Let the worker reach `started()` and enter execute_download.
+    test_session.expire_all()
+    assert download.status == 'pending'
+    assert download.id in running_download_ids()
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    test_session.expire_all()
+    assert download.status == 'new', f'Cancelled download should be renewed, got {download.status}'
+    assert download.id not in running_download_ids(), 'Cancelled download must be unregistered.'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A download on a production host appeared **perpetually `pending`** (recurring `video_channel` download for a YouTube channel). Diagnosis:

- `Download.started()` sets a download to `pending` when a worker picks it up. If that worker dies (process restart, OOM-kill) or is cancelled (shutdown) before reaching the status-update block in `signal_download_download`, the row is left `pending` forever.
- Nothing in the normal loop rescues it: `dispatch_downloads` only queries `status='new'`, and `renew_recurring_downloads` deliberately skips `new` **and** `pending`.
- The only reset path, `retry_downloads()`, runs at startup **only when `flags.refresh_complete` is set** (`main.py`). Since that flag is DB-persisted, recovery was effectively coupled to a process restart — a long-uptime host never reconciled.

Confirmed on the affected row: its `sub_downloader` was `null` while all 25 completed `video_channel` downloads had `sub_downloader='video'` (set in `finalize_download`), proving the worker died mid-run before finalizing.

## Fix

**Runtime supervision (the orphan reaper)**
- A `running_downloads` registry in `shared_ctx.download_manager_data` (alongside the existing `processing_domains` / `killed_downloads` / `download_progress`) tracks which downloads have a live worker. It is cleared on startup (`reset_shared_contexts`), so a `pending` row absent from it is provably an orphan — no DB migration required.
- `DownloadManager.reap_orphaned_downloads()` renews those orphans and runs every `do_downloads()` cycle (~5s), so recovery no longer needs a restart.
- `signal_download_download` registers liveness **before** `started()` (no `await` between), so a live download is never mistaken for an orphan (zero false positives).

**Graceful finalization**
- The `CancelledError` and unexpected-error handlers now renew the row (guarded on `is_pending` so a finalized status is never clobbered) and always unregister liveness, instead of leaking a `pending` row.

The two compose: finalization handles graceful interruption immediately; the reaper is the backstop for hard kills/restarts where no cleanup code can run.

## Tests (TDD)
- `test_reap_orphaned_downloads` — orphan renewed; live download left alone; new untouched.
- `test_do_downloads_recovers_orphaned_download` — end-to-end recovery without a restart.
- `test_signal_download_cancelled_renews_download` — a cancelled worker renews and unregisters.

## Verification
- Full backend suite: 1467 passed, 5 skipped. (`test_events_api_feed` is a pre-existing `-nauto` flake — passes in isolation; unrelated to downloads.)
- No schema change → no alembic migration. Backend-only → no frontend/Cypress impact.

## Deliberately out of scope
- Left the `refresh_complete`-gated startup `retry_downloads` as-is (the runtime reaper supersedes it).
- No wall-clock "hang killer" for alive-but-wedged tasks — a fixed timeout risks killing legitimately long downloads; would need a progress-stall heartbeat (possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)