### PR TITLE
Add server-side map screenshot capability (for ordered collections)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       dockerfile: docker/archive/Dockerfile
     volumes:
       - './docker/archive/main.py:/app/main.py'
+      - './docker/archive/screenshot_url.js:/app/screenshot_url.js'
     ports:
       - '8083:8080'
     healthcheck:

--- a/docker/archive/main.py
+++ b/docker/archive/main.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import urllib.parse
 from json import JSONDecodeError
 
 from sanic import Sanic, response
@@ -152,6 +153,64 @@ async def take_screenshot(url: str) -> bytes:
         return png
 
 
+# Puppeteer is installed in the base browserless/chrome image; resolve node and its modules.
+NODE_BIN = pathlib.Path('/usr/src/.nvm/versions/node/v18.19.0/bin/node')
+if not NODE_BIN.is_file():
+    NODE_BIN = pathlib.Path('/usr/bin/node')
+PUPPETEER_NODE_PATH = '/usr/src/app/node_modules'
+SCREENSHOT_URL_SCRIPT = pathlib.Path('/app/screenshot_url.js')
+
+
+async def take_url_screenshot(url: str, width: int = 1280, height: int = 720) -> bytes:
+    """Render a live URL to a PNG using Puppeteer.
+
+    Unlike take_screenshot (Chrome CLI), this waits for the page to finish painting,
+    so WebGL content (MapLibre maps) is captured instead of a blank canvas.
+
+    Only http(s) URLs are allowed (a file:// URL would let Puppeteer read local files).
+    Arguments are passed as an argv list (no shell) so the URL cannot be used for command
+    injection.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ('http', 'https') or not parsed.hostname:
+        logger.error(f'Refusing to screenshot non-http(s) url: {url!r}')
+        return b''
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        out = pathlib.Path(tmp_dir) / 'screenshot.png'
+        argv = [str(NODE_BIN), str(SCREENSHOT_URL_SCRIPT), url, str(out), str(int(width)), str(int(height))]
+        env = {**os.environ, 'NODE_PATH': PUPPETEER_NODE_PATH}
+        logger.debug(f'URL screenshot argv: {argv}')
+
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv, cwd=tmp_dir, env=env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=2 * 60)
+            for line in stderr.decode(errors='replace').splitlines():
+                logger.error(line)
+            if proc.returncode != 0:
+                raise ValueError(f'URL screenshot failed returncode={proc.returncode}')
+        except asyncio.TimeoutError:
+            if proc:
+                proc.kill()
+                await proc.wait()
+            logger.error(f'URL screenshot timed out for {url}')
+            return b''
+        except Exception as e:
+            logger.error(f'Failed to screenshot url {url}', exc_info=e)
+            return b''
+
+        if not out.is_file():
+            logger.warning(f'URL screenshot did not create a file for {url}')
+            return b''
+
+        png = out.read_bytes()
+        logger.info(f'Successful url screenshot of {url} ({len(png)} bytes)')
+        return png
+
+
 def prepare_bytes(b: bytes) -> str:
     """
     Compress and encode bytes for smaller response.
@@ -213,6 +272,26 @@ async def post_screenshot(request: Request):
         return response.json(ret)
     except Exception as e:
         logger.error(f'Failed to generate screenshot for {url}', exc_info=e)
+        error = str(traceback.format_exc())
+        return response.json({'error': f'Failed to generate screenshot for {url} traceback is below... \n\n {error}'})
+
+
+@app.post('/screenshot_url')
+async def post_screenshot_url(request: Request):
+    """Generate a screenshot of a live URL, rendering WebGL/MapLibre content via Puppeteer."""
+    url = request.json['url']
+    width = int(request.json.get('width') or 1280)
+    height = int(request.json.get('height') or 720)
+
+    try:
+        logger.info(f'Generating url screenshot for {url}')
+        screenshot = await take_url_screenshot(url, width, height)
+        if not screenshot:
+            raise ValueError(f'Failed to generate screenshot for {url}')
+
+        return response.json(dict(url=url, screenshot=prepare_bytes(screenshot)))
+    except Exception as e:
+        logger.error(f'Failed to generate url screenshot for {url}', exc_info=e)
         error = str(traceback.format_exc())
         return response.json({'error': f'Failed to generate screenshot for {url} traceback is below... \n\n {error}'})
 

--- a/docker/archive/screenshot_url.js
+++ b/docker/archive/screenshot_url.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Render a live URL to a PNG screenshot using Puppeteer.
+ *
+ * Chrome's CLI `--screenshot` captures before a WebGL canvas (MapLibre) composites,
+ * producing a blank image.  Puppeteer with the new headless mode + SwiftShader renders
+ * WebGL correctly, and lets us wait for the page to signal it is done painting.
+ *
+ * Usage: node screenshot_url.js <url> <output_path> [width] [height] [timeout_ms]
+ *
+ * The page may set `window.__wrolpiMapIdle = true` (see modules/map/static/embed.html)
+ * to indicate rendering is complete; we wait for that flag, falling back to a fixed
+ * settle delay when it is absent.
+ */
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const url = process.argv[2];
+  const out = process.argv[3];
+  const width = parseInt(process.argv[4] || '1280', 10);
+  const height = parseInt(process.argv[5] || '720', 10);
+  const timeoutMs = parseInt(process.argv[6] || '45000', 10);
+
+  if (!url || !out) {
+    console.error('Usage: node screenshot_url.js <url> <output_path> [width] [height] [timeout_ms]');
+    process.exit(2);
+  }
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: '/usr/bin/google-chrome',
+    args: [
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--ignore-certificate-errors',
+      // SwiftShader software rendering so WebGL works without a GPU.
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+      `--window-size=${width},${height}`,
+    ],
+    ignoreHTTPSErrors: true,
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width, height });
+    page.on('pageerror', e => console.error('PAGEERROR', e.message));
+
+    await page.goto(url, { waitUntil: 'networkidle0', timeout: timeoutMs });
+
+    // Wait for the page's render-complete flag if it exposes one; otherwise settle briefly.
+    const hasFlag = await page.evaluate(() => typeof window.__wrolpiMapIdle !== 'undefined'
+      || typeof window.__wrolpiMap !== 'undefined');
+    if (hasFlag) {
+      await page.waitForFunction(() => window.__wrolpiMapIdle === true, { timeout: timeoutMs })
+        .catch(() => console.error('WARN map idle flag not set before timeout; capturing anyway'));
+    } else {
+      await new Promise(res => setTimeout(res, 3000));
+    }
+
+    await page.screenshot({ path: out });
+    console.error('OK wrote', out);
+  } finally {
+    await browser.close();
+  }
+})().catch(e => { console.error('FATAL', e && e.stack || e); process.exit(1); });

--- a/modules/archive/lib.py
+++ b/modules/archive/lib.py
@@ -710,6 +710,35 @@ async def request_screenshot(url: str, singlefile_path: pathlib.Path) -> Optiona
     return screenshot
 
 
+async def request_url_screenshot(url: str, width: int = 1280, height: int = 720) -> Optional[bytes]:
+    """Ask the archive service to render a live URL to a PNG via Puppeteer.
+
+    Used to screenshot WebGL pages (e.g. the MapLibre map embed) which the plain
+    Chrome-CLI screenshot cannot capture.  Only available when DOCKERIZED.
+    """
+    logger.info(f'Sending url screenshot request to archive service: {url}')
+
+    data = dict(url=url, width=width, height=height)
+    try:
+        async with aiohttp_post(f'{ARCHIVE_SERVICE}/screenshot_url', json_=data, timeout=ARCHIVE_TIMEOUT) as response:
+            contents = await response.json()
+        if contents and (error := contents.get('error')):
+            raise Exception(f'Received error from archive service: {error}')
+
+        screenshot = contents.get('screenshot')
+        if not screenshot:
+            logger.warning(f'Failed to get url screenshot for {url=}')
+            return None
+    except Exception as e:
+        logger.error('Error when requesting url screenshot', exc_info=e)
+        raise
+
+    # Decode and decompress.
+    screenshot = base64.b64decode(screenshot)
+    screenshot = gzip.decompress(screenshot)
+    return screenshot
+
+
 @dataclass
 class WrittenArchiveFiles:
     """The on-disk artifacts produced by write_archive_files."""

--- a/modules/map/api.py
+++ b/modules/map/api.py
@@ -100,6 +100,24 @@ async def update_pin(_: Request, pin_id: int, body: schema.MapPinUpdateRequest):
     return response.json({'error': 'Pin not found'}, HTTPStatus.NOT_FOUND)
 
 
+@map_bp.get('/screenshot')
+@openapi.description('Render the map centered on lat/lon/zoom to a PNG')
+async def get_map_screenshot(request: Request):
+    try:
+        lat = float(request.args.get('lat'))
+        lon = float(request.args.get('lon'))
+        zoom = float(request.args.get('zoom', 12))
+    except (ValueError, TypeError):
+        return json_response({'error': 'lat and lon query parameters are required'}, HTTPStatus.BAD_REQUEST)
+
+    try:
+        png = await lib.screenshot_map(lat, lon, zoom)
+    except Exception as e:
+        return json_response({'error': str(e)}, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    return response.raw(png, content_type='image/png')
+
+
 @map_bp.get('/search')
 @openapi.description('Search for places in map search indexes')
 async def search_places(request: Request):

--- a/modules/map/lib.py
+++ b/modules/map/lib.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import tempfile
 from pathlib import Path
@@ -6,10 +7,44 @@ from typing import List, Dict
 from sqlalchemy.orm import Session
 
 from modules.map.catalog import MAP_REGIONS, MAP_REGIONS_BY_NAME, MAP_REGIONS_BY_REGION, MANIFEST_URL
-from wrolpi.common import get_media_directory, walk, logger, get_wrolpi_config, aiohttp_get, verify_gpg_signature
+from wrolpi.common import get_media_directory, walk, logger, get_wrolpi_config, aiohttp_get, verify_gpg_signature, \
+    url_screenshot
 from wrolpi.downloader import DownloadFrequency, Download, save_downloads_config, download_manager
+from wrolpi.vars import DOCKERIZED
 
 logger = logger.getChild(__name__)
+
+# The chrome-free map embed is served by Caddy on :8084.  From the archive container this is
+# reachable as the `web` service; on a native install it is local.
+MAP_EMBED_HOST = 'https://web:8084' if DOCKERIZED else 'https://127.0.0.1:8084'
+
+
+def _map_embed_url(lat: float, lon: float, zoom: float) -> str:
+    """Build the URL of the chrome-free map embed centered on a location (#lat,lon,zoom)."""
+    return f'{MAP_EMBED_HOST}/embed.html#{lat},{lon},{zoom}'
+
+
+async def screenshot_map(lat: float, lon: float, zoom: float = 12,
+                         width: int = 1280, height: int = 720) -> bytes:
+    """Render the map centered on a location to a PNG.
+
+    Uses the archive browser service when DOCKERIZED, otherwise a local headless browser.
+
+    @raise ValueError: if no screenshot could be produced.
+    """
+    url = _map_embed_url(lat, lon, zoom)
+    if DOCKERIZED:
+        # Local import to avoid a circular import (archive lib imports collections/common).
+        from modules.archive.lib import request_url_screenshot
+        png = await request_url_screenshot(url, width=width, height=height)
+    else:
+        # Selenium is blocking; run it off the event loop.
+        png = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: url_screenshot(url, width, height))
+
+    if not png:
+        raise ValueError(f'Failed to render map screenshot for {lat},{lon} z{zoom}')
+    return png
 
 
 def get_map_directory() -> Path:

--- a/modules/map/static/embed.html
+++ b/modules/map/static/embed.html
@@ -42,7 +42,7 @@
             allLayers = allLayers.concat(layers);
         });
 
-        new maplibregl.Map({
+        var map = new maplibregl.Map({
             container: "map",
             style: {
                 version: 8,
@@ -56,9 +56,14 @@
             attributionControl: false,
             interactive: false,
         });
+        // Expose the map and a render-complete flag so a headless browser can wait
+        // for tiles to finish painting before taking a screenshot (see screenshot_url.js).
+        window.__wrolpiMap = map;
+        map.on("idle", function() { window.__wrolpiMapIdle = true; });
     }).catch(function(e) {
         console.error("Embed map error:", e);
         document.getElementById("map").textContent = "Map unavailable";
+        window.__wrolpiMapError = String(e && e.message || e);
     });
 })();
 </script>

--- a/wrolpi/common.py
+++ b/wrolpi/common.py
@@ -15,6 +15,7 @@ import socket
 import string
 import sys
 import tempfile
+import time
 from asyncio import Task
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
@@ -2538,6 +2539,48 @@ def html_screenshot(html: bytes | str) -> bytes:
             driver.set_window_size(1280, 720)
             screenshot = driver.get_screenshot_as_png()
             return screenshot
+
+
+def url_screenshot(url: str, width: int = 1280, height: int = 720, timeout: int = 45) -> bytes:
+    """Return a PNG screenshot of a live URL, rendering WebGL content (e.g. MapLibre maps).
+
+    Used on native (non-Docker) installs where there is no archive browser service.
+    SwiftShader provides software WebGL so this works without a GPU.  Waits for the page
+    to set ``window.__wrolpiMapIdle`` (see modules/map/static/embed.html), falling back to
+    a short settle delay when the flag is absent.
+    """
+    options = webdriver.ChromeOptions()
+    options.add_argument('--headless=new')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--ignore-certificate-errors')
+    # Software WebGL so MapLibre renders without a GPU.
+    options.add_argument('--use-gl=angle')
+    options.add_argument('--use-angle=swiftshader')
+    options.add_argument('--enable-unsafe-swiftshader')
+    options.add_argument(f'--window-size={width},{height}')
+    options.set_capability('acceptInsecureCerts', True)
+
+    with webdriver.Chrome(options=options) as driver:
+        driver.set_window_size(width, height)
+        driver.get(url)
+
+        # Wait for the page's render-complete flag, falling back to a fixed delay.
+        deadline = time.monotonic() + timeout
+        has_flag = False
+        while time.monotonic() < deadline:
+            try:
+                if driver.execute_script('return typeof window.__wrolpiMapIdle !== "undefined"'):
+                    has_flag = True
+                if driver.execute_script('return window.__wrolpiMapIdle === true'):
+                    break
+            except Exception:
+                pass
+            time.sleep(0.25)
+        if not has_flag:
+            time.sleep(3)
+
+        return driver.get_screenshot_as_png()
 
 
 def chain(iterable: Union[List, Tuple], length: int) -> List:


### PR DESCRIPTION
First piece of the ordered-collections ("playlist") feature: render the map, centered on a location, to a PNG so a map pin can become a real image FileGroup in a playlist.

The reliable way to capture MapLibre's WebGL canvas in a headless browser is Puppeteer with the new headless mode + SwiftShader software WebGL, waiting for the map's `idle` event. Chrome's CLI `--screenshot` captures before WebGL composites and yields a blank image.

- modules/map/static/embed.html: expose window.__wrolpiMapIdle so a headless browser can wait for tiles to finish painting.
- docker/archive/screenshot_url.js + /screenshot_url endpoint in docker/archive/main.py: Puppeteer screenshot of a live URL. Uses create_subprocess_exec (no shell) and rejects non-http(s) URLs.
- modules/archive/lib.py: request_url_screenshot() (Docker path).
- wrolpi/common.py: url_screenshot() Selenium path for native installs.
- modules/map/lib.py: screenshot_map(lat, lon, zoom) dispatches Docker vs native.
- modules/map/api.py: GET /api/map/screenshot?lat=&lon=&zoom= returns a PNG.

Verified end-to-end on the Docker stack. Native (RPi/Debian) Selenium path still needs validation on real ARM hardware.