### PR TITLE
Fix swapped arguments in download_info_json Video.get_by_url call

### DIFF
--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -1187,7 +1187,7 @@ class VideoDownloader(Downloader, ABC):
 
         with get_db_session() as session:
             # Find the existing video, replace its info json.
-            video = Video.get_by_url(url, session)
+            video = Video.get_by_url(session, url)
 
             location = video.location
 
@@ -1202,7 +1202,7 @@ class VideoDownloader(Downloader, ABC):
 
         with get_db_session(commit=True) as session:
             # Find the existing video, replace its info json.
-            video = Video.get_by_url(url, session)
+            video = Video.get_by_url(session, url)
             video.replace_info_json(info_json)
 
             if parent_download_url := settings.get('parent_download_url'):

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -539,6 +539,29 @@ async def test_video_download(test_session, test_directory, mock_video_extract_i
 
 
 @pytest.mark.asyncio
+async def test_download_info_json_finds_existing_video(test_session, test_directory, video_factory):
+    """`download_info_json` looks up the existing Video by its URL.
+
+    Regression: `Video.get_by_url` was called with its arguments swapped — `(url, session)` instead of
+    `(session, url)` — which raised `AttributeError: 'str' object has no attribute 'query'`."""
+    source_id = 'video-source-id'
+    url = 'https://example.com/the-video'
+    video = video_factory(with_info_json={'id': source_id}, source_id=source_id)
+    video.file_group.url = url
+    test_session.commit()
+
+    download = Download(url=url, info_json={'id': source_id}, settings={})
+
+    # The info_json download itself fails here, but the buggy existing-video lookup runs first.
+    with mock.patch('modules.videos.downloader.download_video_info_json') as mock_download:
+        mock_download.side_effect = Exception('no network')
+        result = await VideoDownloader.download_info_json(download, video.video_path)
+
+    assert result.success is False, 'Download should fail gracefully once the info json download fails'
+    mock_download.assert_called_once_with(url)
+
+
+@pytest.mark.asyncio
 async def test_download_result(test_session, test_directory, video_download_manager, mock_video_process_runner,
                                mock_video_extract_info, image_file, await_switches):
     """VideoDownloader returns a DownloadResult when complete."""


### PR DESCRIPTION
## Problem

Refreshing a Video's metadata crashed with:

```
File "/opt/wrolpi/modules/videos/downloader.py", line 1190, in download_info_json
    video = Video.get_by_url(url, session)
File "/opt/wrolpi/modules/videos/models.py", line 366, in get_by_url
    video = session.query(Video) \
AttributeError: 'str' object has no attribute 'query'
```

`Video.get_by_url` has the signature `get_by_url(session, url)`, but `download_info_json` called it as `get_by_url(url, session)` at two sites — passing the URL string where the session was expected.

## Fix

Swap the arguments at both call sites in `download_info_json` so they match the `(session, url)` signature (consistent with the other `Video.get_by_url` call sites at lines 456 and 821).

## Test

Added `test_download_info_json_finds_existing_video`, which reproduces the exact `AttributeError` before the fix and passes after. Full `test_downloader.py` suite (54 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)