### PR TITLE
PWA: installable app, offline calculators, read-only Inventory

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -33,7 +33,12 @@
         "semantic-ui-offline": "^2.5.0",
         "semantic-ui-react": "^2.1.5",
         "three": "^0.184",
-        "web-vitals": "^5.3.0"
+        "web-vitals": "^5.3.0",
+        "workbox-cacheable-response": "^6.5.4",
+        "workbox-core": "^6.5.4",
+        "workbox-precaching": "^6.5.4",
+        "workbox-routing": "^6.5.4",
+        "workbox-strategies": "^6.5.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -106,6 +111,7 @@
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -902,6 +908,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -1463,6 +1470,7 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz",
       "integrity": "sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -3377,6 +3385,7 @@
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4164,6 +4173,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4174,6 +4184,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4297,6 +4308,7 @@
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.50.0.tgz",
       "integrity": "sha512-vwksQWSFZiUhgq3Kv7o1Jcj0DUNylwnIlGvKvLLYsq8pAWha6/WCnXUeaSoNNha/K7QSf2+jvmkxggC1u3pIwQ==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.50.0",
         "@typescript-eslint/type-utils": "5.50.0",
@@ -4348,6 +4360,7 @@
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.50.0.tgz",
       "integrity": "sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.50.0",
         "@typescript-eslint/types": "5.50.0",
@@ -4678,6 +4691,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4800,6 +4814,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5657,6 +5672,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6454,6 +6470,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6740,6 +6757,7 @@
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.15.2.tgz",
       "integrity": "sha512-ARbnUorjcCM3XiPwgHKuqsyr5W9Qn+pIIBPaoilnoBkLdSC2oLQjV1BUpnmc7KR+b7Avah3Ly2RMFnfxr96E/A==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
@@ -7506,6 +7524,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -7785,6 +7804,7 @@
       "version": "8.33.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
       "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -8198,6 +8218,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10689,6 +10710,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -13383,6 +13405,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14223,6 +14246,7 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -15281,6 +15305,7 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
       "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15470,6 +15495,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15677,6 +15703,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15830,6 +15857,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -15931,6 +15959,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16445,6 +16474,7 @@
       "version": "2.80.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -16720,6 +16750,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.5.tgz",
       "integrity": "sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@fluentui/react-component-event-listener": "~0.63.0",
@@ -17807,6 +17838,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17878,7 +17910,8 @@
     "node_modules/three": {
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
-      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "peer": true
     },
     "node_modules/three-stdlib": {
       "version": "2.17.2",
@@ -18126,6 +18159,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18179,6 +18213,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18489,6 +18524,7 @@
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -18558,6 +18594,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18607,6 +18644,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
       "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -18661,6 +18699,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18773,6 +18812,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19055,6 +19095,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19123,6 +19164,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.5.4.tgz",
       "integrity": "sha512-DCR9uD0Fqj8oB2TSWQEm1hbFs/85hXXoayVwFKLVuIuxwJaihBsLsp4y7J9bvZbqtPJ1KlCkmYVGQKrBU4KAug==",
+      "license": "MIT",
       "dependencies": {
         "workbox-core": "6.5.4"
       }
@@ -19130,7 +19172,8 @@
     "node_modules/workbox-core": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.5.4.tgz",
-      "integrity": "sha512-OXYb+m9wZm8GrORlV2vBbE5EC1FKu71GGp0H4rjmxmF4/HLbMCoTFws87M3dFwgpmg0v00K++PImpNQ6J5NQ6Q=="
+      "integrity": "sha512-OXYb+m9wZm8GrORlV2vBbE5EC1FKu71GGp0H4rjmxmF4/HLbMCoTFws87M3dFwgpmg0v00K++PImpNQ6J5NQ6Q==",
+      "license": "MIT"
     },
     "node_modules/workbox-expiration": {
       "version": "6.5.4",
@@ -19164,6 +19207,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.5.4.tgz",
       "integrity": "sha512-hSMezMsW6btKnxHB4bFy2Qfwey/8SYdGWvVIKFaUm8vJ4E53JAY+U2JwLTRD8wbLWoP6OVUdFlXsTdKu9yoLTg==",
+      "license": "MIT",
       "dependencies": {
         "workbox-core": "6.5.4",
         "workbox-routing": "6.5.4",
@@ -19195,6 +19239,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.5.4.tgz",
       "integrity": "sha512-apQswLsbrrOsBUWtr9Lf80F+P1sHnQdYodRo32SjiByYi36IDyL2r7BH1lJtFX8fwNHDa1QOVY74WKLLS6o5Pg==",
+      "license": "MIT",
       "dependencies": {
         "workbox-core": "6.5.4"
       }
@@ -19203,6 +19248,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.5.4.tgz",
       "integrity": "sha512-DEtsxhx0LIYWkJBTQolRxG4EI0setTJkqR4m7r4YpBdxtWJH1Mbg01Cj8ZjNOO8etqfA3IZaOPHUxCs8cBsKLw==",
+      "license": "MIT",
       "dependencies": {
         "workbox-core": "6.5.4"
       }
@@ -19499,6 +19545,7 @@
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -20041,6 +20088,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
+      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -20386,6 +20434,7 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.20.13.tgz",
       "integrity": "sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==",
+      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -21733,7 +21782,8 @@
     "@popperjs/core": {
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "peer": true
     },
     "@react-three/fiber": {
       "version": "8.16.5",
@@ -22311,6 +22361,7 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -22320,6 +22371,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "peer": true,
       "requires": {}
     },
     "@types/react-reconciler": {
@@ -22440,6 +22492,7 @@
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.50.0.tgz",
       "integrity": "sha512-vwksQWSFZiUhgq3Kv7o1Jcj0DUNylwnIlGvKvLLYsq8pAWha6/WCnXUeaSoNNha/K7QSf2+jvmkxggC1u3pIwQ==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.50.0",
         "@typescript-eslint/type-utils": "5.50.0",
@@ -22465,6 +22518,7 @@
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.50.0.tgz",
       "integrity": "sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.50.0",
         "@typescript-eslint/types": "5.50.0",
@@ -22714,7 +22768,8 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -22801,6 +22856,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -23418,6 +23474,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -23959,6 +24016,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -24167,6 +24225,7 @@
       "version": "13.15.2",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.15.2.tgz",
       "integrity": "sha512-ARbnUorjcCM3XiPwgHKuqsyr5W9Qn+pIIBPaoilnoBkLdSC2oLQjV1BUpnmc7KR+b7Avah3Ly2RMFnfxr96E/A==",
+      "peer": true,
       "requires": {
         "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
@@ -24730,6 +24789,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "peer": true,
       "requires": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -24948,6 +25008,7 @@
       "version": "8.33.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
       "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
+      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -25323,6 +25384,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -26993,6 +27055,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "requires": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -28964,6 +29027,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -29556,6 +29620,7 @@
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
       "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -30139,6 +30204,7 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
       "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -30278,6 +30344,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -30435,6 +30502,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -30548,6 +30616,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -30624,7 +30693,8 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true
     },
     "react-router": {
       "version": "7.16.0",
@@ -30993,6 +31063,7 @@
       "version": "2.80.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -31178,6 +31249,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.5.tgz",
       "integrity": "sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.10.5",
         "@fluentui/react-component-event-listener": "~0.63.0",
@@ -32007,6 +32079,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -32058,7 +32131,8 @@
     "three": {
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
-      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "peer": true
     },
     "three-stdlib": {
       "version": "2.17.2",
@@ -32260,7 +32334,8 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -32297,7 +32372,8 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -32524,6 +32600,7 @@
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -32556,6 +32633,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -32619,6 +32697,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -32656,6 +32735,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
       "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
+      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -32692,6 +32772,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -32938,6 +33019,7 @@
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,12 @@
     "semantic-ui-offline": "^2.5.0",
     "semantic-ui-react": "^2.1.5",
     "three": "^0.184",
-    "web-vitals": "^5.3.0"
+    "web-vitals": "^5.3.0",
+    "workbox-cacheable-response": "^6.5.4",
+    "workbox-core": "^6.5.4",
+    "workbox-precaching": "^6.5.4",
+    "workbox-routing": "^6.5.4",
+    "workbox-strategies": "^6.5.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
     <meta name="theme-color" content="#000000"/>
+    <!-- iOS: allow standalone "Add to Home Screen" launch so the PWA shell + cached inventory work offline. -->
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+    <meta name="apple-mobile-web-app-title" content="WROLPi"/>
     <meta
             name="description"
             content="The WROLPI webapp"

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -12,6 +12,7 @@ import {ArchiveRoute} from "./components/Archive";
 import {FilesRoute} from "./components/Files";
 import {QueryProvider, StatusProvider} from "./hooks/customHooks";
 import {FileWorkerStatusProvider} from "./contexts/FileWorkerStatusContext";
+import {PwaProvider} from "./contexts/PwaContext";
 import {ChannelEditPage, ChannelNewPage, ChannelsPage} from "./components/Channels";
 import {MapRoute} from "./components/Map";
 import {MediaContextProvider, mediaStyles, StatusContext, ThemeContext} from "./contexts/contexts";
@@ -113,14 +114,16 @@ export default function App() {
     useEventsInterval();
 
     return <StatusProvider>
-        <FileWorkerStatusProvider>
-            {/* Context and style to handle switching between mobile/computer. */}
-            <style>{mediaStyles}</style>
-            {/* Toasts can be on any page. */}
-            <SemanticToastContainer position='top-right'/>
-            <MediaContextProvider>
-                <RouterProvider router={router}/>
-            </MediaContextProvider>
-        </FileWorkerStatusProvider>
+        <PwaProvider>
+            <FileWorkerStatusProvider>
+                {/* Context and style to handle switching between mobile/computer. */}
+                <style>{mediaStyles}</style>
+                {/* Toasts can be on any page. */}
+                <SemanticToastContainer position='top-right'/>
+                <MediaContextProvider>
+                    <RouterProvider router={router}/>
+                </MediaContextProvider>
+            </FileWorkerStatusProvider>
+        </PwaProvider>
     </StatusProvider>
 }

--- a/app/src/Events.js
+++ b/app/src/Events.js
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {useRecurringTimeout} from "./hooks/customHooks";
 import {ApiDownError, getEvents} from "./api";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "./toast";
 
 const apiEventName = 'apiEvent';
 

--- a/app/src/api.js
+++ b/app/src/api.js
@@ -1,5 +1,5 @@
 import {emptyToNull} from "./components/Common";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "./toast";
 import _ from "lodash";
 import {
     API_URI,
@@ -72,6 +72,16 @@ async function apiCall(url, method, body, ms = 60_000) {
         if (e instanceof ApiDownError) {
             // Throw ApiDownError immediately without logging.
             throw e;
+        }
+        // A truly offline PWA (or an unreachable API) does not return HTTP 502; instead `fetch` rejects with a
+        // TypeError ("Failed to fetch"/"Load failed"), or our timeoutPromise rejects, or the browser reports it is
+        // offline.  Map all of these to ApiDownError so useStatus lights the apiDown indicator (Nav.js) instead of
+        // surfacing a raw network error.
+        const isNetworkFailure = e instanceof TypeError
+            || (e instanceof Error && e.message === 'promise timeout')
+            || navigator.onLine === false;
+        if (isNetworkFailure) {
+            throw apiDownError;
         }
         // Ignore SyntaxError because they happen when the API is down.
         if (!(e instanceof SyntaxError)) {

--- a/app/src/components/AddToPlaylist.js
+++ b/app/src/components/AddToPlaylist.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Input, Message} from "semantic-ui-react";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 
 import {Button, Form, List, Loader, Modal} from "./Theme";
 import {addPlaylistItem, createPlaylist, fetchPlaylists} from "../api";

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -86,7 +86,7 @@ import {Button, Card, darkTheme, Header, Loader, Placeholder, Popup, Segment, St
 import {BulkTagModal} from "./BulkTagModal";
 import {taggedImageLabel, TagsSelector} from "../Tags";
 import {AddToPlaylistButton} from "./AddToPlaylist";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import {API_ARCHIVE_UPLOAD_URI, Downloaders} from "./Vars";
 import {CollectionTable} from "./collections/CollectionTable";
 import {CollectionEditForm} from "./collections/CollectionEditForm";

--- a/app/src/components/Channels.js
+++ b/app/src/components/Channels.js
@@ -22,7 +22,7 @@ import Message from "semantic-ui-react/dist/commonjs/collections/Message";
 import {useChannel, useChannels, useOneQuery} from "../hooks/customHooks";
 import _ from "lodash";
 import {Button, Form, Header, Loader, Modal, Segment, Statistic} from "./Theme";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import {RecurringDownloadsTable} from "./admin/Downloads";
 import {InputForm, ToggleForm} from "../hooks/useForm";
 import {ChannelDownloadForm, DestinationForm, DownloadTagsSelector} from "./Download";

--- a/app/src/components/Docs.js
+++ b/app/src/components/Docs.js
@@ -25,7 +25,7 @@ import {TaggedDeleteConfirmModal} from "./TaggedDeleteConfirmModal";
 import {DocSearchFilterButton, FilesView} from "./Files";
 import {useAuthors, useDoc, useOneQuery, useSearchDocs, useSubjects} from "../hooks/customHooks";
 import {TagsSelector} from "../Tags";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import {CollectionTable} from "./collections/CollectionTable";
 import {AddToPlaylistButton} from "./AddToPlaylist";
 import {CbzViewer} from "./CbzViewer";

--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -8,7 +8,7 @@ import {ArchivePreviewContent} from "./ArchivePreview";
 import {CbzViewer} from "./CbzViewer";
 import {StlViewer} from "react-stl-viewer";
 import {Button, Modal} from "./Theme";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import {useOneQuery} from "../hooks/customHooks";
 import {ShareButton} from "./Share";
 import {AddToPlaylistButton} from "./AddToPlaylist";

--- a/app/src/components/Playlists.js
+++ b/app/src/components/Playlists.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Link, Route, Routes, useNavigate, useParams} from "react-router";
 import {Grid, Image, Input, Message} from "semantic-ui-react";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 
 import {Button, Form, Header, Icon, Loader, Modal, Segment, Table} from "./Theme";
 import {

--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -63,7 +63,7 @@ import {TagsQuerySelector} from "./Files";
 import {ThemeContext} from "../contexts/contexts";
 import {Link, Route, Routes} from "react-router";
 import {SortableTable} from "./SortableTable";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import _ from "lodash";
 import {ZIM_VIEWER_URI} from "./Vars";
 

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -24,7 +24,7 @@ import {
     stopService,
     unmountDisk,
 } from "../../api/controller";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../../toast";
 import {RestartButton, ShutdownButton} from "./Settings";
 import Message from "semantic-ui-react/dist/commonjs/collections/Message";
 import {CONTROLLER_URI} from "../Vars";

--- a/app/src/components/admin/Settings.js
+++ b/app/src/components/admin/Settings.js
@@ -26,7 +26,7 @@ import {
 } from "../Common";
 import QRCode from "react-qr-code";
 import {useConfigs, useDockerized} from "../../hooks/customHooks";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../../toast";
 import Grid from "semantic-ui-react/dist/commonjs/collections/Grid";
 import {ConfigsTable} from "./Configs";
 import {semanticUIColorMap} from "../Vars";

--- a/app/src/components/inventory/InventoryImportModal.js
+++ b/app/src/components/inventory/InventoryImportModal.js
@@ -1,5 +1,5 @@
 import React, {useContext, useEffect, useState} from "react";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../../toast";
 import {TableBody, TableCell, TableHeader, TableHeaderCell, TableRow} from "semantic-ui-react";
 import {Button, Divider, Header, Icon, Loader, Modal, Table} from "../Theme";
 import {

--- a/app/src/components/inventory/InventoryRoute.js
+++ b/app/src/components/inventory/InventoryRoute.js
@@ -1,5 +1,5 @@
 import React, {useMemo, useState} from "react";
-import {Dropdown, Input, Select} from "semantic-ui-react";
+import {Dropdown, Input, Message, Select} from "semantic-ui-react";
 import {Button, Confirm, Header, Icon, Loader, Menu, Modal, Segment} from "../Theme";
 import {PageContainer, useTitle} from "../Common";
 import {collectLocations, useCatalog, useInventories} from "../../hooks/customHooks";
@@ -14,6 +14,7 @@ import {FieldSchemaEditor} from "./FieldSchemaEditor";
 import {CatalogEditor} from "./CatalogEditor";
 import {InventoryImportModal} from "./InventoryImportModal";
 import {Media, ThemeContext} from "../../contexts/contexts";
+import {usePwa} from "../../contexts/PwaContext";
 
 const INVENTORY_TYPES = [
     {key: 'food', value: 'food', text: 'Food Storage'},
@@ -60,6 +61,10 @@ export function InventoryRoute() {
     const {inventories, fetchInventories, persistInventory, addInventory, removeInventory} = useInventories();
     const {catalog, persistCatalog} = useCatalog();
     const [slug, setSlug] = useState(null);
+
+    // When offline, inventory reads come from the service-worker cache, but writes can't reach the config-only
+    // backend, so the editing UI is disabled and a read-only banner is shown.
+    const {offline} = usePwa();
 
     const [tab, setTab] = useState('items');
     const [newOpen, setNewOpen] = useState(false);
@@ -142,6 +147,15 @@ export function InventoryRoute() {
     return <PageContainer>
         <Header as='h1'>Inventory</Header>
 
+        {offline &&
+            <Message icon warning>
+                <Icon name='wifi'/>
+                <Message.Content>
+                    <Message.Header>Offline — read only</Message.Header>
+                    You're viewing the last synced copy of your inventory. Changes can't be saved until you reconnect.
+                </Message.Content>
+            </Message>}
+
         <Segment>
             <div style={{display: 'flex', gap: '0.5em', alignItems: 'center', flexWrap: 'wrap'}}>
                 <Dropdown
@@ -152,24 +166,24 @@ export function InventoryRoute() {
                     onChange={(e, data) => setSlug(data.value)}
                     style={{minWidth: '14em'}}
                 />
-                <Button primary icon onClick={() => setNewOpen(true)} aria-label='New inventory'>
+                <Button primary icon disabled={offline} onClick={() => setNewOpen(true)} aria-label='New inventory'>
                     <Icon name='plus'/>
                 </Button>
-                <Button icon onClick={() => setCatalogOpen(true)} aria-label='Food catalog'>
+                <Button icon disabled={offline} onClick={() => setCatalogOpen(true)} aria-label='Food catalog'>
                     <Icon name='book'/> Catalog
                 </Button>
                 {current && <>
-                    <Button icon onClick={() => {
+                    <Button icon disabled={offline} onClick={() => {
                         setRenameValue(current.name);
                         setRenaming(true);
                     }} aria-label='Rename inventory'><Icon name='edit'/></Button>
-                    <Button icon onClick={() => setEditFieldsOpen(true)} aria-label='Customize fields'>
+                    <Button icon disabled={offline} onClick={() => setEditFieldsOpen(true)} aria-label='Customize fields'>
                         <Icon name='columns'/> Fields
                     </Button>
-                    <Button icon onClick={() => setImportOpen(true)} aria-label='Import or restore inventory'>
+                    <Button icon disabled={offline} onClick={() => setImportOpen(true)} aria-label='Import or restore inventory'>
                         <Icon name='history'/> Restore
                     </Button>
-                    <Button color='red' icon onClick={() => setConfirmDelete(true)} aria-label='Delete inventory'>
+                    <Button color='red' icon disabled={offline} onClick={() => setConfirmDelete(true)} aria-label='Delete inventory'>
                         <Icon name='trash'/>
                     </Button>
                 </>}

--- a/app/src/components/inventory/InventoryTable.js
+++ b/app/src/components/inventory/InventoryTable.js
@@ -4,6 +4,7 @@ import {Button, Icon, Table} from "../Theme";
 import {FieldCell} from "./FieldCell";
 import {applyComputedCounts, computedCountConfigs} from "./computeFields";
 import {NUMERIC_TYPES} from "./units";
+import {usePwa} from "../../contexts/PwaContext";
 
 const LOCATION_LIST_ID = 'inventory-location-suggestions';
 const CATALOG_LIST_ID = 'inventory-catalog-names';
@@ -50,6 +51,8 @@ function compareByField(a, b, field) {
  * bottom: Tab moves between fields and Enter submits the item then refocuses the first field.
  */
 export function InventoryTable({slug, fields, items, locations, catalog, search, onChange}) {
+    // Offline (PWA cache) is read-only: writes can't reach the config-only backend, so editing affordances are hidden.
+    const {offline: readOnly} = usePwa();
     const [draft, setDraft] = useState(() => emptyItem(fields));
     const [edits, setEdits] = useState({});       // itemId -> edited copy
     const [selected, setSelected] = useState(new Set());
@@ -212,7 +215,7 @@ export function InventoryTable({slug, fields, items, locations, catalog, search,
             <datalist id={CATALOG_LIST_ID}>
                 {catalog.map(e => <option key={e.id ?? e.name} value={e.name}/>)}
             </datalist>}
-        {selected.size > 0 &&
+        {!readOnly && selected.size > 0 &&
             <Button color='red' onClick={removeSelected} style={{marginBottom: '0.5em'}}>
                 Delete {selected.size} selected
             </Button>}
@@ -235,7 +238,8 @@ export function InventoryTable({slug, fields, items, locations, catalog, search,
                     const expired = isExpired(item);
                     return <TableRow key={item.id} negative={expired}>
                         <TableCell collapsing>
-                            <Checkbox checked={selected.has(item.id)} onChange={() => toggleSelected(item.id)}/>
+                            {!readOnly &&
+                                <Checkbox checked={selected.has(item.id)} onChange={() => toggleSelected(item.id)}/>}
                             {expired && <Icon name='warning sign' color='red' title='Expired'
                                               style={{marginLeft: '0.4em'}}/>}
                         </TableCell>
@@ -251,7 +255,8 @@ export function InventoryTable({slug, fields, items, locations, catalog, search,
                                     listId={listIdFor(f)}
                                     autoFocus={focusCell && focusCell.id === item.id && focusCell.key === f.key}
                                 />
-                                : <span onClick={() => startEdit(item, f.key)} style={{cursor: 'pointer'}}>
+                                : <span onClick={readOnly ? undefined : () => startEdit(item, f.key)}
+                                        style={{cursor: readOnly ? 'default' : 'pointer'}}>
                                     {formatValue(item, f)}
                                 </span>}
                         </TableCell>)}
@@ -264,26 +269,27 @@ export function InventoryTable({slug, fields, items, locations, catalog, search,
                         </TableCell>
                     </TableRow>}
             </TableBody>
-            <TableFooter>
-                {/* The persistent new-item entry row. */}
-                <TableRow>
-                    <TableCell collapsing>
-                        <Button primary size='mini' onClick={submitDraft} aria-label='Add item'>+</Button>
-                    </TableCell>
-                    {sortedFields.map((f, index) => <TableCell key={f.key}>
-                        <FieldCell
-                            field={f}
-                            value={draft[f.key]}
-                            unitValue={draft[`${f.key}_unit`]}
-                            onChange={v => setDraftValue(f.key, v)}
-                            onUnitChange={v => setDraftValue(`${f.key}_unit`, v)}
-                            onEnter={submitDraft}
-                            inputRef={index === 0 ? firstInputRef : undefined}
-                            listId={listIdFor(f)}
-                        />
-                    </TableCell>)}
-                </TableRow>
-            </TableFooter>
+            {!readOnly &&
+                <TableFooter>
+                    {/* The persistent new-item entry row. */}
+                    <TableRow>
+                        <TableCell collapsing>
+                            <Button primary size='mini' onClick={submitDraft} aria-label='Add item'>+</Button>
+                        </TableCell>
+                        {sortedFields.map((f, index) => <TableCell key={f.key}>
+                            <FieldCell
+                                field={f}
+                                value={draft[f.key]}
+                                unitValue={draft[`${f.key}_unit`]}
+                                onChange={v => setDraftValue(f.key, v)}
+                                onUnitChange={v => setDraftValue(`${f.key}_unit`, v)}
+                                onEnter={submitDraft}
+                                inputRef={index === 0 ? firstInputRef : undefined}
+                                listId={listIdFor(f)}
+                            />
+                        </TableCell>)}
+                    </TableRow>
+                </TableFooter>}
         </Table>
     </>;
 }

--- a/app/src/components/inventory/InventoryTable.test.js
+++ b/app/src/components/inventory/InventoryTable.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import {fireEvent, render, screen, within} from "@testing-library/react";
 import {filterItems, InventoryTable} from "./InventoryTable";
+import {PwaContext} from "../../contexts/PwaContext";
 
 const FIELDS = [
     {key: 'name', label: 'Name', type: 'text', order: 0},
@@ -348,5 +349,38 @@ describe('InventoryTable search', () => {
         render(<InventoryTable slug='s' fields={FIELDS} items={items} locations={[]} search='xyzzy'
                                onChange={jest.fn()}/>);
         expect(screen.getByText(/no items match/i)).toBeTruthy();
+    });
+});
+
+describe('InventoryTable offline (read-only)', () => {
+    // The PWA serves cached inventory reads offline, but writes can't reach the config-only backend, so the table
+    // becomes read-only: item values are visible for reference but every editing affordance is gone.
+    const items = [{id: 1, name: 'Wood Screw #8', count: '200'}];
+
+    const renderOffline = (extra = {}) =>
+        render(
+            <PwaContext.Provider value={{offline: true, isStandalone: false}}>
+                <InventoryTable slug='fasteners' fields={FIELDS} items={items} locations={[]}
+                                onChange={jest.fn()} {...extra}/>
+            </PwaContext.Provider>
+        );
+
+    test('item values are shown but there is no new-item row or editable input', () => {
+        renderOffline();
+        // The fastener is visible for reference at the store.
+        expect(screen.getByText('Wood Screw #8')).toBeInTheDocument();
+        // No persistent new-item entry row.
+        expect(screen.queryByLabelText('Add item')).not.toBeInTheDocument();
+        // No editable inputs at all (draft row gone, cells render as static text).
+        expect(screen.queryAllByLabelText('Name')).toHaveLength(0);
+    });
+
+    test('clicking a cell does not enter edit mode and never persists', () => {
+        const onChange = jest.fn();
+        renderOffline({onChange});
+        fireEvent.click(screen.getByText('200'));
+        // Cell stays static — no input appears and nothing is saved.
+        expect(screen.queryAllByLabelText('Count')).toHaveLength(0);
+        expect(onChange).not.toHaveBeenCalled();
     });
 });

--- a/app/src/contexts/PwaContext.js
+++ b/app/src/contexts/PwaContext.js
@@ -1,0 +1,58 @@
+import React, {useContext, useEffect, useMemo, useState} from "react";
+import {StatusContext} from "./contexts";
+
+// Cross-cutting PWA state, consumed anywhere via usePwa() instead of prop-drilling.
+//
+//   offline      - true when the browser is offline or the API is unreachable.  Inventory (and other) reads are
+//                  served from the service-worker cache, but writes can't reach the backend, so editing UI is
+//                  disabled while this is true.
+//   isStandalone - true when launched as an installed PWA (Add to Home Screen / standalone display mode).
+//
+// The default value (offline: false) means components rendered outside a PwaProvider — e.g. in unit tests — behave
+// as if online, so they need no provider wrapper.
+export const PwaContext = React.createContext({
+    offline: false,
+    isStandalone: false,
+});
+
+const computeOffline = () =>
+    (typeof navigator !== 'undefined' && navigator.onLine === false) || window.apiDown === true;
+
+const computeStandalone = () =>
+    (typeof window !== 'undefined') && (
+        (typeof window.matchMedia === 'function' && window.matchMedia('(display-mode: standalone)').matches) ||
+        window.navigator.standalone === true
+    );
+
+export function PwaProvider({children}) {
+    // Consuming StatusContext makes this provider re-render on every status poll, so window.apiDown (set imperatively
+    // by useStatus) is picked up without a dedicated interval.
+    const {status} = useContext(StatusContext);
+
+    const [offline, setOffline] = useState(computeOffline);
+    const [isStandalone] = useState(computeStandalone);
+
+    // Instant updates when connectivity flips (the store-aisle case: network drops).
+    useEffect(() => {
+        const update = () => setOffline(computeOffline());
+        window.addEventListener('online', update);
+        window.addEventListener('offline', update);
+        return () => {
+            window.removeEventListener('online', update);
+            window.removeEventListener('offline', update);
+        };
+    }, []);
+
+    // Re-sync on each status poll to catch the network-up / API-down case.
+    useEffect(() => {
+        setOffline(computeOffline());
+    }, [status]);
+
+    const value = useMemo(() => ({offline, isStandalone}), [offline, isStandalone]);
+
+    return <PwaContext.Provider value={value}>{children}</PwaContext.Provider>;
+}
+
+export function usePwa() {
+    return useContext(PwaContext);
+}

--- a/app/src/hooks/customHooks.js
+++ b/app/src/hooks/customHooks.js
@@ -54,7 +54,7 @@ import {
 import {createSearchParams, useLocation, useSearchParams} from "react-router";
 import {enumerate, filterToMimetypes, humanFileSize, secondsToFullDuration} from "../components/Common";
 import {QueryContext, SettingsContext, StatusContext} from "../contexts/contexts";
-import {toast} from "react-semantic-toasts-2";
+import {toast} from "../toast";
 import {useSearch} from "../components/Search";
 import _ from "lodash";
 import {TagsSelector} from "../Tags";

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -2,6 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App/>);
+
+// Register the service worker so the app installs as a PWA and works offline (production build only).
+serviceWorkerRegistration.register();

--- a/app/src/service-worker.js
+++ b/app/src/service-worker.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-restricted-globals */
+
+// WROLPi service worker (Workbox InjectManifest).  Production build only - `npm start` does not emit this,
+// so local development is unaffected.  Scope is `/` (the build is served from the host root).
+//
+// v1 offline surface:
+//   - The precached app shell makes all Calculators (incl. the One Time Pad, which is pure client-side
+//     crypto - see otp.js) work fully offline.
+//   - GET /api/inventory[/catalog] is cached NetworkFirst so inventories can be referenced offline.
+//   - /api/status is NetworkOnly so the apiDown indicator always reflects reality.
+
+import {clientsClaim} from 'workbox-core';
+import {precacheAndRoute, createHandlerBoundToURL} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {NetworkFirst, NetworkOnly} from 'workbox-strategies';
+import {CacheableResponsePlugin} from 'workbox-cacheable-response';
+
+clientsClaim();
+
+// Precache the shell/JS/CSS emitted by the webpack build.  This is what lets the Calculators work offline.
+precacheAndRoute(self.__WB_MANIFEST);
+
+// react-router deep links (e.g. /inventory, /more/calculators) must resolve to the precached index.html when
+// offline.  Serve index.html for navigation requests, but never for API, media, or file-asset requests.
+const fileExtensionRegexp = new RegExp('/[^/?]+\\.[^/]+$');
+registerRoute(
+    ({request, url}) => {
+        if (request.mode !== 'navigate') return false;
+        if (url.pathname.startsWith('/api/')) return false;
+        if (url.pathname.startsWith('/media/')) return false;
+        if (url.pathname.match(fileExtensionRegexp)) return false;
+        return true;
+    },
+    createHandlerBoundToURL(process.env.PUBLIC_URL + '/index.html')
+);
+
+// Status must always reflect reality - never serve a cached "up" status.
+registerRoute(
+    ({url}) => url.pathname === '/api/status',
+    new NetworkOnly()
+);
+
+// Inventory is config-only and arrives in a single GET (see modules/inventory/api.py).  Cache it NetworkFirst
+// so it stays fresh online and renders (read-only) offline.  GET only - PUT/POST writes won't match.
+registerRoute(
+    ({url, request}) => request.method === 'GET' && (
+        url.pathname === '/api/inventory' ||
+        url.pathname === '/api/inventory/' ||
+        url.pathname === '/api/inventory/catalog'
+    ),
+    new NetworkFirst({
+        cacheName: 'wrolpi-inventory',
+        plugins: [new CacheableResponsePlugin({statuses: [200]})],
+    })
+);
+
+// Allow the page to tell a waiting SW to activate immediately (used by the update flow).
+self.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+});

--- a/app/src/service-worker.js
+++ b/app/src/service-worker.js
@@ -54,6 +54,21 @@ registerRoute(
     })
 );
 
+// Proactively cache the inventory (and food catalog) the moment the worker activates, while the device is still
+// online.  Relying on the page's first fetch is unreliable - especially on a fresh iOS "Add to Home Screen"
+// install, where the just-installed worker is often not yet controlling the page when React fetches the
+// inventory, so the NetworkFirst route never stores it and the offline page spins forever.  Caching at activate
+// (with cache:'reload' to bypass the HTTP cache) guarantees an offline copy after the first online launch.
+self.addEventListener('activate', (event) => {
+    event.waitUntil((async () => {
+        const cache = await caches.open('wrolpi-inventory');
+        await Promise.allSettled([
+            cache.add(new Request('/api/inventory', {cache: 'reload'})),
+            cache.add(new Request('/api/inventory/catalog', {cache: 'reload'})),
+        ]);
+    })());
+});
+
 // Allow the page to tell a waiting SW to activate immediately (used by the update flow).
 self.addEventListener('message', (event) => {
     if (event.data && event.data.type === 'SKIP_WAITING') {

--- a/app/src/service-worker.js
+++ b/app/src/service-worker.js
@@ -15,6 +15,9 @@ import {registerRoute} from 'workbox-routing';
 import {NetworkFirst, NetworkOnly} from 'workbox-strategies';
 import {CacheableResponsePlugin} from 'workbox-cacheable-response';
 
+// Activate a new worker immediately so fixes/updates reach installed PWAs (incl. iOS home-screen apps) without a
+// reinstall, then take control of open clients.
+self.skipWaiting();
 clientsClaim();
 
 // Precache the shell/JS/CSS emitted by the webpack build.  This is what lets the Calculators work offline.
@@ -50,6 +53,10 @@ registerRoute(
     ),
     new NetworkFirst({
         cacheName: 'wrolpi-inventory',
+        // iOS does not fail offline fetches fast - they hang.  Without a timeout, NetworkFirst would wait forever
+        // on the (hung) network attempt and never fall back to the cache, leaving the page spinning offline.  Give
+        // the network a few seconds, then serve the cached copy.
+        networkTimeoutSeconds: 3,
         plugins: [new CacheableResponsePlugin({statuses: [200]})],
     })
 );

--- a/app/src/serviceWorkerRegistration.js
+++ b/app/src/serviceWorkerRegistration.js
@@ -1,0 +1,113 @@
+// Registration helper for the WROLPi service worker (adapted from the cra-template-pwa default).
+//
+// This lets the app load faster on subsequent visits and work offline.  Registration only takes effect in a
+// production build served over HTTPS (or localhost).  Note: on iOS Safari the WROLPi Root CA must be trusted
+// on the device or the SW will fail to register.
+
+const isLocalhost = Boolean(
+    window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4.
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+);
+
+export function register(config) {
+    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+        // The URL constructor is available in all browsers that support SW.
+        const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+        if (publicUrl.origin !== window.location.origin) {
+            // Our service worker won't work if PUBLIC_URL is on a different origin.
+            return;
+        }
+
+        window.addEventListener('load', () => {
+            const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+            if (isLocalhost) {
+                // This is running on localhost. Check if a service worker still exists or not.
+                checkValidServiceWorker(swUrl, config);
+                navigator.serviceWorker.ready.then(() => {
+                    // Logging for localhost developers.
+                    // eslint-disable-next-line no-console
+                    console.log('This web app is being served cache-first by a service worker.');
+                });
+            } else {
+                // Is not localhost. Just register service worker
+                registerValidSW(swUrl, config);
+            }
+        });
+    }
+}
+
+function registerValidSW(swUrl, config) {
+    navigator.serviceWorker
+        .register(swUrl)
+        .then((registration) => {
+            registration.onupdatefound = () => {
+                const installingWorker = registration.installing;
+                if (installingWorker == null) {
+                    return;
+                }
+                installingWorker.onstatechange = () => {
+                    if (installingWorker.state === 'installed') {
+                        if (navigator.serviceWorker.controller) {
+                            // New content is available; it will be used after all tabs are closed.
+                            if (config && config.onUpdate) {
+                                config.onUpdate(registration);
+                            }
+                        } else {
+                            // Content is cached for offline use.
+                            if (config && config.onSuccess) {
+                                config.onSuccess(registration);
+                            }
+                        }
+                    }
+                };
+            };
+        })
+        .catch((error) => {
+            // eslint-disable-next-line no-console
+            console.error('Error during service worker registration:', error);
+        });
+}
+
+function checkValidServiceWorker(swUrl, config) {
+    // Check if the service worker can be found. If it can't reload the page.
+    fetch(swUrl, {headers: {'Service-Worker': 'script'}})
+        .then((response) => {
+            // Ensure service worker exists, and that we really are getting a JS file.
+            const contentType = response.headers.get('content-type');
+            if (
+                response.status === 404 ||
+                (contentType != null && contentType.indexOf('javascript') === -1)
+            ) {
+                // No service worker found. Probably a different app. Reload the page.
+                navigator.serviceWorker.ready.then((registration) => {
+                    registration.unregister().then(() => {
+                        window.location.reload();
+                    });
+                });
+            } else {
+                // Service worker found. Proceed as normal.
+                registerValidSW(swUrl, config);
+            }
+        })
+        .catch(() => {
+            // eslint-disable-next-line no-console
+            console.log('No internet connection found. App is running in offline mode.');
+        });
+}
+
+export function unregister() {
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+            .then((registration) => {
+                registration.unregister();
+            })
+            .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error(error.message);
+            });
+    }
+}

--- a/app/src/toast.js
+++ b/app/src/toast.js
@@ -1,0 +1,15 @@
+import {toast as baseToast} from "react-semantic-toasts-2";
+
+// Central wrapper around react-semantic-toasts-2's toast.  While the API is unreachable (offline PWA, or the
+// backend is down) we swallow `error` toasts so the user gets a single calm apiDown indicator in the nav instead
+// of a wall of red error toasts.  Success/info/warning toasts still show.
+//
+// `window.apiDown` lags the ~3s status poll, so we also check `navigator.onLine === false` to suppress instantly
+// when the browser already knows it is offline.
+export function toast(opts) {
+    const offline = window.apiDown === true || navigator.onLine === false;
+    if (offline && opts && opts.type === 'error') {
+        return;
+    }
+    return baseToast(opts);
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+# Local development override for the React app.
+#
+# The base docker-compose.yml serves the production build (so the PWA service worker ships).  This override runs
+# the Create React App dev server instead, restoring hot reload.  The dev server does not emit a service worker —
+# that is expected; offline/PWA support is a production concern and is verified against a production build.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# (Production / end users just run `docker compose up`, which serves the built PWA.)
+services:
+  app:
+    command: 'npm run start'
+    stdin_open: true
+    volumes:
+      - './app/public:/app/public'
+      - './app/src:/app/src'
+      - './app/package.json:/app/package.json'
+      - '.env:/app/.env'
+    environment:
+      # Force React to use the Caddy port for its dev-server websocket.
+      - WDS_SOCKET_PORT=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,20 +92,13 @@ services:
     build:
       context: .
       dockerfile: docker/app/Dockerfile
-    volumes:
-      - './app/public:/app/public'
-      - './app/src:/app/src'
-      - './app/package.json:/app/package.json'
-      - '.env:/app/.env'
-    command: 'npm run start'
-    stdin_open: true
+    # The image builds the production bundle and serves it (see docker/app/Dockerfile), so the PWA service worker
+    # ships.  Rebuild the image (`docker compose build app`) to pick up code changes.  For local development with
+    # hot reload, layer on docker-compose.dev.yml (runs the CRA dev server instead).
     healthcheck:
       test: [ 'CMD-SHELL', 'curl http://127.0.0.1:3000' ]
       interval: 1m
     user: '${UID-1000}:${GID-1000}'
-    environment:
-      # Force React to use Caddy port to connect to it's websocket.
-      - WDS_SOCKET_PORT=0
 
   web: # Caddy reverse proxy - handles HTTPS for all services.
     depends_on:

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,10 +13,24 @@ docker volume create --name=openstreetmap-data
 docker volume create --name=openstreetmap-rendered-tiles
 docker-compose up -d db
 docker-compose run --rm api db upgrade
-docker-compose up
+# Development (React dev server, hot reload):
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 Browse to https://localhost:8443
+
+### Production vs. development
+
+The base `docker-compose.yml` serves the **production** React build, which is what ships the installable PWA
+and its offline service worker — this is what end users run:
+
+```bash
+docker compose up          # serves the built PWA (no hot reload; rebuild the app image to update)
+```
+
+For day-to-day frontend work, layer on `docker-compose.dev.yml` (as in the Quick Start above) to run the CRA
+dev server with hot reload instead. The dev server does not emit a service worker, which is expected — verify
+PWA/offline behavior against the production build.
 
 ## Services
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN npm install -g serve
 COPY app/public /app/public
 COPY app/src /app/src
-COPY app/package.json app/package-lock.json app/tsconfig.json /app/
+COPY app/package.json app/package-lock.json app/tsconfig.json app/serve.json /app/
 # "node" user will run the app after build.
 RUN chown -R node:node /app
 
@@ -17,5 +17,9 @@ RUN chown -R node:node /app
 USER node
 RUN npm install
 
-# Run the production build
-CMD ["npm", "run", "start"]
+# Build the production bundle (emits the PWA service worker; the dev server does not).
+RUN npm run build
+
+# Serve the production build, matching the native wrolpi-app.service.  serve.json keeps the SPA fallback while
+# serving real files (service-worker.js, epub.html) directly.
+CMD ["serve", "build", "-l", "3000", "-c", "/app/serve.json"]


### PR DESCRIPTION
## Summary

Makes the React app an **installable PWA** whose app shell, **calculators** (including the One Time Pad), and **Inventory** work fully **offline**. Driving use case: reference an inventory (e.g. Fasteners) from an iPhone in a store aisle with no connection.

No backend changes. The service worker only emits in a production build, so `npm start` dev is unaffected.

## What's included

**Phase 1 — Service worker** (Workbox InjectManifest, production build only)
- `service-worker.js`: precache the shell (calculators work offline), `NavigationRoute` for react-router deep links, **NetworkFirst** cache of `GET /api/inventory` + `/api/inventory/catalog` (`wrolpi-inventory`), **NetworkOnly** `/api/status` (so the apiDown indicator stays truthful).
- `serviceWorkerRegistration.js` + registration in `index.js`.
- `workbox-*` runtime deps pinned to **6.5.4** to match CRA's bundled plugin.

**Phase 2 — Offline hardening + read-only Inventory**
- `api.js` maps offline `fetch` failures (TypeError / timeout / `!navigator.onLine`) → `ApiDownError`, so the existing nav apiDown icon lights up.
- `toast.js` wrapper swallows **error** toasts while offline; the `toast` import is repointed in the **13** files that raise them (the `App.js` container is left on the original package).
- `PwaContext` (`usePwa()` → `{offline, isStandalone}`), provider mounted in `App.js` inside `StatusProvider`. Default `offline: false` so components render without the provider in unit tests.
- Inventory goes **read-only offline**: `InventoryRoute` disables the edit buttons and shows a banner; `InventoryTable` hides the new-item row, checkboxes and delete, and disables click-to-edit. Item values stay visible for reference. Writes are simply never issued (no API write-guards needed).

**Phase 3 — iOS** Add-to-Home-Screen meta tags in `public/index.html`.

## Testing

- **676 Jest tests pass**, including 2 new `InventoryTable` offline tests.
- **Verified end-to-end against the real API** (production build served via Caddy at `:8443`): the SW caches the real Fasteners inventory, then with the origin stopped the cached inventory still renders **read-only** — both reactively (no reload) and on a cold offline reload.

## Deferred (not in this PR)

Media "Save for offline" (Cache Storage + IndexedDB, iOS Range/206, quota), a Downloads list, and offline inventory **edits**/sync.

## Remaining manual verification

Definitive on-device test: Add to Home Screen on an iPhone against `10.0.0.5` — requires the WROLPi Root CA trusted on the device or the SW won't register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)