### PR TITLE
Restore the censored-video search filter

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -187,7 +187,7 @@ export async function tagChannelInfo(channelId, tagName) {
     });
 }
 
-export async function searchVideos(offset, limit, channelId, searchStr, order_by, tagNames, headline) {
+export async function searchVideos(offset, limit, channelId, searchStr, order_by, tagNames, headline, censored) {
     // Build a search query to retrieve a list of videos from the API
     offset = parseInt(offset || 0);
     limit = parseInt(limit || DEFAULT_LIMIT);
@@ -204,6 +204,9 @@ export async function searchVideos(offset, limit, channelId, searchStr, order_by
     }
     if (headline) {
         body['headline'] = true;
+    }
+    if (censored) {
+        body['censored'] = true;
     }
 
     console.debug('searching videos', body);

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -31,6 +31,7 @@ import {
     PreviewLink,
     SearchInput,
     TagIcon,
+    Toggle,
     textEllipsis,
     useTitle
 } from "./Common";
@@ -38,6 +39,7 @@ import {
     usePages,
     useSearchDate,
     useSearchFiles,
+    useSearchCensored,
     useSearchFilter,
     useSearchOrder,
     useSearchView,
@@ -541,6 +543,7 @@ export function SearchFilterModal(
         showDates = false,
         showTags = true,
         showLimit = true,
+        showCensored = false,
         limitOptions = [12, 24, 48, 96],
     },
 ) {
@@ -549,6 +552,7 @@ export function SearchFilterModal(
     const {sort} = useSearchOrder();
     const {dateRange, months} = useSearchDate();
     const {activeTags, anyTag} = useSearch();
+    const {censored} = useSearchCensored();
     const {limit} = usePages(DEFAULT_SEARCH_LIMIT);
     const {updateQuery} = useContext(QueryContext);
 
@@ -565,6 +569,7 @@ export function SearchFilterModal(
     const [draftLimit, setDraftLimit] = useState(null);
     const [draftMonths, setDraftMonths] = useState([]);
     const [draftRange, setDraftRange] = useState(emptyRange);
+    const [draftCensored, setDraftCensored] = useState(false);
 
     // Seed the drafts from the URL each time the modal is opened.
     React.useEffect(() => {
@@ -576,6 +581,7 @@ export function SearchFilterModal(
             setDraftLimit(limit);
             setDraftMonths(seededMonths);
             setDraftRange(seededRange);
+            setDraftCensored(censored || false);
         }
     }, [open]);
 
@@ -613,6 +619,9 @@ export function SearchFilterModal(
             params.toDate = newToDate;
             params.month = draftMonths;
         }
+        if (showCensored && draftCensored !== censored) {
+            params.censored = draftCensored ? 'true' : null;
+        }
         if (Object.keys(params).length > 0) {
             params.o = 0;
             updateQuery(params);
@@ -631,6 +640,7 @@ export function SearchFilterModal(
         setDraftLimit(DEFAULT_SEARCH_LIMIT);
         setDraftMonths([]);
         setDraftRange(emptyRange);
+        setDraftCensored(false);
     }
 
     // Sort section (operates on the draft).
@@ -701,6 +711,18 @@ export function SearchFilterModal(
                         </Grid.Column>
                     </Grid.Row>}
 
+                {showCensored &&
+                    <Grid.Row>
+                        <Grid.Column>
+                            <SearchFilterSection header='Availability'>
+                                <Toggle label='Only censored (no longer available to download)'
+                                        checked={draftCensored}
+                                        onChange={setDraftCensored}
+                                />
+                            </SearchFilterSection>
+                        </Grid.Column>
+                    </Grid.Row>}
+
                 {(showTags || showLimit) &&
                     <Grid.Row columns={2}>
                         {showTags &&
@@ -760,6 +782,7 @@ export function SearchFilterButton(
         showDates = false,
         showTags = true,
         showLimit = true,
+        showCensored = false,
         limitOptions = [12, 24, 48, 96],
         size = 'medium',
         content = 'Filter',
@@ -770,6 +793,7 @@ export function SearchFilterButton(
     const {sort} = useSearchOrder();
     const {dateRange, months} = useSearchDate();
     const {activeTags, anyTag} = useSearch();
+    const {censored} = useSearchCensored();
 
     let count = 0;
     if (fileFilterOptions && filter) {
@@ -782,6 +806,9 @@ export function SearchFilterButton(
         count += 1;
     }
     if (showDates && ((months && months.length > 0) || !dateRangeIsEmpty(dateRange))) {
+        count += 1;
+    }
+    if (showCensored && censored) {
         count += 1;
     }
     const active = count > 0;
@@ -801,6 +828,7 @@ export function SearchFilterButton(
             showDates={showDates}
             showTags={showTags}
             showLimit={showLimit}
+            showCensored={showCensored}
             limitOptions={limitOptions}
         />
     </>
@@ -820,6 +848,7 @@ export function SearchControlBar(
         sorts = null,
         fileFilterOptions = null,
         showDates = false,
+        showCensored = false,
     },
 ) {
     const [localSearchStr, setLocalSearchStr] = useState(searchStr || '');
@@ -836,7 +865,8 @@ export function SearchControlBar(
     return <div style={{display: 'flex', alignItems: 'center', gap: '0.5em', marginBottom: '1em'}}>
         {viewButton}
         <div style={{flexGrow: 1, minWidth: 0}}>{searchInput}</div>
-        <SearchFilterButton sorts={sorts} fileFilterOptions={fileFilterOptions} showDates={showDates}/>
+        <SearchFilterButton sorts={sorts} fileFilterOptions={fileFilterOptions} showDates={showDates}
+                            showCensored={showCensored}/>
     </div>
 }
 

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -711,18 +711,6 @@ export function SearchFilterModal(
                         </Grid.Column>
                     </Grid.Row>}
 
-                {showCensored &&
-                    <Grid.Row>
-                        <Grid.Column>
-                            <SearchFilterSection header='Availability'>
-                                <Toggle label='Only censored (no longer available to download)'
-                                        checked={draftCensored}
-                                        onChange={setDraftCensored}
-                                />
-                            </SearchFilterSection>
-                        </Grid.Column>
-                    </Grid.Row>}
-
                 {(showTags || showLimit) &&
                     <Grid.Row columns={2}>
                         {showTags &&
@@ -752,6 +740,18 @@ export function SearchFilterModal(
                                     <div>{limitButtons}</div>
                                 </SearchFilterSection>
                             </Grid.Column>}
+                    </Grid.Row>}
+
+                {showCensored &&
+                    <Grid.Row>
+                        <Grid.Column>
+                            <SearchFilterSection header='Availability'>
+                                <Toggle label='Only censored (no longer available to download)'
+                                        checked={draftCensored}
+                                        onChange={setDraftCensored}
+                                />
+                            </SearchFilterSection>
+                        </Grid.Column>
                     </Grid.Row>}
 
                 {showDates &&

--- a/app/src/components/SearchFilterModal.test.js
+++ b/app/src/components/SearchFilterModal.test.js
@@ -116,6 +116,36 @@ describe('SearchFilterButton', () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
+    it('counts the censored filter and applies it on close when showCensored is set', () => {
+        const spy = jest.fn();
+        renderButton({sorts: videoOrders, showCensored: true}, {}, spy);
+
+        // No censored badge initially.
+        expect(screen.queryByText('1')).toBeNull();
+
+        fireEvent.click(screen.getByText('Filter'));
+        // The Availability section/toggle is shown.
+        expect(screen.getByText('Availability')).toBeInTheDocument();
+        fireEvent.mouseUp(screen.getByTestId('toggle'));
+        // Draft only — nothing applied yet.
+        expect(spy).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByText('Done'));
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][0]).toMatchObject({censored: 'true'});
+    });
+
+    it('does not show the Availability section unless showCensored is set', () => {
+        renderButton({sorts: videoOrders});
+        fireEvent.click(screen.getByText('Filter'));
+        expect(screen.queryByText('Availability')).toBeNull();
+    });
+
+    it('shows a count badge when the censored filter is active in the URL', () => {
+        renderButton({sorts: videoOrders, showCensored: true}, {censored: 'true'});
+        expect(screen.getByText('1')).toBeInTheDocument();
+    });
+
     it('shows the File Type section when fileFilterOptions are provided', () => {
         renderButton({
             sorts: videoOrders,

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -240,6 +240,7 @@ export function VideosPage() {
             inputRef={searchInputRef}
             viewButton={viewButton}
             sorts={videoOrders}
+            showCensored={true}
         />
         {body}
         {paginator}

--- a/app/src/hooks/customHooks.js
+++ b/app/src/hooks/customHooks.js
@@ -616,6 +616,7 @@ export const useSearchVideos = (defaultLimit, channelId, order_by) => {
     const {view} = useSearchView();
     const headline = view === 'headline';
     const anyTag = searchParams.get('anyTag') === 'true';
+    const censored = searchParams.get('censored') === 'true';
 
     const [videos, setVideos] = useState(null);
     const [totalPages, setTotalPages] = useState(0);
@@ -626,7 +627,7 @@ export const useSearchVideos = (defaultLimit, channelId, order_by) => {
         setLoading(true);
         setTotalPages(0);
         try {
-            let [videos_, total] = await searchVideos(offset, limit, channelId, searchStr, order, activeTags, headline, anyTag);
+            let [videos_, total] = await searchVideos(offset, limit, channelId, searchStr, order, activeTags, headline, censored);
             setVideos(videos_);
             setTotalPages(calculateTotalPages(total, limit));
         } catch (e) {
@@ -639,7 +640,7 @@ export const useSearchVideos = (defaultLimit, channelId, order_by) => {
 
     useEffect(() => {
         localSearchVideos();
-    }, [searchStr, limit, channelId, offset, order_by, JSON.stringify(activeTags), headline]);
+    }, [searchStr, limit, channelId, offset, order_by, JSON.stringify(activeTags), headline, censored]);
 
     const setSearchStr = (value) => {
         updateQuery({q: value, o: 0, order: undefined});
@@ -1622,6 +1623,14 @@ export const useSearchView = () => {
 export const useSearchOrder = () => {
     const [sort, setSort] = useOneQuery('order');
     return {sort, setSort}
+}
+
+export const useSearchCensored = () => {
+    // Filters Videos to only those which are no longer available for download (?censored=true).
+    const [value, setValue] = useOneQuery('censored');
+    const censored = value === 'true';
+    const setCensored = (newValue) => setValue(newValue ? 'true' : undefined);
+    return {censored, setCensored}
 }
 
 export const useSearchDate = () => {

--- a/modules/videos/conftest.py
+++ b/modules/videos/conftest.py
@@ -335,6 +335,7 @@ def assert_video_search(async_client):
             limit: int = None,
             order_by: str = None,
             channel_id: int = None,
+            censored: bool = None,
     ):
         content = dict()
         if search_str is not None:
@@ -349,6 +350,8 @@ def assert_video_search(async_client):
             content['order_by'] = order_by
         if channel_id is not None:
             content['channel_id'] = channel_id
+        if censored is not None:
+            content['censored'] = censored
 
         request, response = await async_client.post('/api/videos/search', content=json.dumps(content))
 

--- a/modules/videos/schema.py
+++ b/modules/videos/schema.py
@@ -177,6 +177,7 @@ class VideoSearchRequest:
     channel_id: Optional[int] = None
     tag_names: List[str] = field(default_factory=list)
     headline: bool = False
+    censored: bool = False
 
 
 @dataclass

--- a/modules/videos/test/test_api.py
+++ b/modules/videos/test/test_api.py
@@ -265,6 +265,27 @@ async def test_search_videos(test_session, video_factory, assert_video_search, s
 
 
 @pytest.mark.asyncio
+async def test_search_videos_censored(test_session, video_factory, assert_video_search):
+    """The censored filter returns only Videos which are no longer available for download."""
+    vid1: Video = video_factory(upload_date='2022-09-16', with_video_file=True, title='vid1')
+    vid2: Video = video_factory(upload_date='2022-09-17', with_video_file=True, title='vid2')
+    vid3: Video = video_factory(upload_date='2022-09-18', with_video_file=True, title='vid3')
+
+    # vid2 is no longer available.
+    vid2.file_group.censored = True
+    test_session.commit()
+
+    # Without the filter, all Videos are returned.
+    await assert_video_search(assert_total=3, assert_ids=[vid1.id, vid2.id, vid3.id],
+                              order_by='published_datetime')
+    await assert_video_search(assert_total=3, assert_ids=[vid1.id, vid2.id, vid3.id],
+                              order_by='published_datetime', censored=False)
+
+    # With the filter, only the censored Video is returned.
+    await assert_video_search(assert_total=1, assert_ids=[vid2.id], order_by='published_datetime', censored=True)
+
+
+@pytest.mark.asyncio
 async def test_search_audio_only(test_session, audio_factory, assert_video_search):
     """Audio-only files should be searchable alongside videos."""
     audio1 = audio_factory(title='podcast episode one', upload_date='2025-01-01', with_info_json=True)

--- a/modules/videos/video/api.py
+++ b/modules/videos/video/api.py
@@ -65,6 +65,7 @@ async def search_videos(_: Request, body: schema.VideoSearchRequest):
         body.order_by,
         body.tag_names,
         body.headline,
+        body.censored,
     )
 
     ret = {'file_groups': list(file_groups), 'totals': {'file_groups': videos_total}}

--- a/modules/videos/video/lib.py
+++ b/modules/videos/video/lib.py
@@ -92,10 +92,14 @@ def search_videos(
         order: str = None,
         tag_names: List[str] = None,
         headline: bool = False,
+        censored: bool = False,
 ) -> Tuple[List[dict], int]:
     tag_names = tag_names or []
     # Search videos and audio-only files.
     wheres = ["(fg.mimetype LIKE 'video/%%' OR fg.mimetype LIKE 'audio/%%')"]
+    if censored:
+        # Only return videos which are no longer available for download.
+        wheres.append('fg.censored = TRUE')
     joins = list()
     join_video = False
 


### PR DESCRIPTION
## Summary

Censored videos (no longer publicly available) are already flagged on `FileGroup.censored` — set when a channel refresh drops a video from the channel list (`common.update_view_counts_and_censored`), or when comment downloads fail with *video unavailable / private / removed* (`video/lib.add_video_to_skip_list(..., censored=True)`). A past search rework dropped the UI filter to find them, so this restores it inside the reworked search-filter modal.

- A **Censored** toggle now appears in the filter modal, shown only on the Videos page (`showCensored`).
- When enabled, the video search returns only videos with `FileGroup.censored = TRUE`, tracked via a `?censored=true` query param (`useSearchCensored`).
- Uses the theme-aware `Toggle` component so it renders correctly in dark mode.

## Changes

**Backend**
- `schema.py`: `censored: bool = False` on `VideoSearchRequest`
- `video/lib.py`: `search_videos` adds `fg.censored = TRUE` when `censored` is set
- `video/api.py`: forwards `body.censored`
- New `test_search_videos_censored` + `censored` param in the `assert_video_search` fixture

**Frontend**
- `customHooks.js`: new `useSearchCensored` hook; `useSearchVideos` reads/forwards it
- `api.js`: `searchVideos` sends `censored`
- `Files.js`: `showCensored` threaded through `SearchControlBar → SearchFilterButton → SearchFilterModal`; new **Availability** section (drafted-then-committed, counted in the filter badge)
- `Videos.js`: `showCensored={true}`
- 3 new modal tests

## Testing

- Backend `modules/videos` suite: **265 passed**
- Frontend touched-area + modal suites: **45 passed**
- Build compiles (only pre-existing warnings)
- Verified live: flagged two videos censored in the dev DB → toggle filtered to exactly those two; URL `?censored=true&o=0`; badge showed `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)