### PR TITLE
Fix dark-theme Accordion background mismatch outside modals

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -247,11 +247,15 @@ textarea.otp {
     color: #DDDDDD !important;
 }
 
-/* Direct children only, so nested components that use the `content`/`title` class names (e.g. a Message's
-   Message.Content) are not given the accordion's dark background. */
+/* The accordion has no background of its own; it inherits whatever container it sits in (Modal
+   content #171616, Segment #1B1C1D, the page body, etc.).  This matches how the light theme already
+   renders accordions (transparent), and avoids a darker band when the parent isn't #171616.
+   Direct children only, so nested components that use the `content`/`title` class names (e.g. a
+   Message's Message.Content) are not affected. */
+.ui.inverted.accordion,
 .ui.inverted.accordion > .title,
 .ui.inverted.accordion > .content {
-    background-color: #171616 !important;
+    background-color: transparent !important;
 }
 
 /* Mobile-responsive Confirm modal */


### PR DESCRIPTION
## Problem

In the dark theme, an `Accordion` did not match its parent's background in some contexts. It matched well inside a `Modal` (e.g. Dashboard → Download → Videos → **Advanced Settings**), but on the **/admin/status** page the Accordion rendered as a noticeably darker band than its surrounding `Segment`.

## Root cause

The dark-theme rule in `app/src/App.css` hardcoded the inverted Accordion's title/content background to `#171616` — the Modal content color:

```css
.ui.inverted.accordion > .title,
.ui.inverted.accordion > .content {
    background-color: #171616 !important;
}
```

The app has two dark shades, and the Accordion lives in different containers:

| Context | Container bg | Accordion title bg | Result |
|---|---|---|---|
| Download modal | `.modal .content.inverted` → `#171616` | `#171616` | ✅ matches |
| `/admin/status` | `Segment` → `#1B1C1D` | `#171616` | ❌ darker band |

(Verified via computed styles: segment `rgb(27,28,29)` vs. accordion title `rgb(23,22,22)`.)

## Fix

Make the inverted Accordion (and its title/content) `transparent` so it inherits whatever container it sits in — Modal content, Segment, page body, etc. This is a one-rule CSS change.

This also brings dark theme in line with the **light theme**, where accordions are already transparent (`rgba(0,0,0,0)`) and inherit their container by default — so light theme is unchanged.

## Verification

- Injected the rule live via DevTools: the "Status Details" title bar now blends seamlessly into the "Developer" segment, and the Modal accordion is visually unchanged.
- Confirmed light theme is unaffected (rule is scoped to `.ui.inverted.accordion`; light-theme accordions carry no `inverted` class and are already transparent).
- Frontend test suite: **688 passed, 43 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)