### PR TITLE
Flasher: chip-mismatch guard, WROLPi firmware table, colorblind chip colors

### DIFF
--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -667,6 +667,22 @@ export function FlasherPage() {
     // The nested tab menu isn't inverted automatically; give it the inverted style in dark mode so it matches.
     const tabMenu = theme === darkTheme ? {inverted: true, attached: true} : {attached: true};
 
+    // A connect failure needs a download-mode reminder shown right where the user acted — both in the Connect
+    // segment and next to the "Filter files by detecting device" button so it isn't missed off-screen.
+    const connectErrorMessage = () => (error && bootHint) &&
+        <Message error onDismiss={() => {
+            setError('');
+            setBootHint(false);
+        }} style={{marginTop: '1em'}}>
+            <Message.Header>Could not connect to the device</Message.Header>
+            <p>{error}</p>
+            <p>
+                Many ESP boards must be put into <b>download mode</b> manually before flashing. Hold the
+                {' '}<b>BOOT</b> (or <b>IO0</b>) button, briefly press <b>RESET</b> (<b>EN</b>), then release
+                BOOT and try again. Also check the USB cable is a data cable and no other tab has the port open.
+            </p>
+        </Message>;
+
     // The firmware source is chosen via three tabs (see the ordered array below).
     const computerPane = {
             menuItem: 'Add from computer',
@@ -712,6 +728,8 @@ export function FlasherPage() {
                     <Icon name='usb'/>
                     {deviceChip ? 'Detect a different device' : 'Filter files by detecting device'}
                 </Button>
+                {/* Show a connect failure here too, so the user doesn't have to scroll to the Connect segment. */}
+                {connectErrorMessage()}
                 {deviceChip &&
                     <Message info>
                         {/* Plain (non-inverted) icon: Message backgrounds are light, so a themed white icon
@@ -957,19 +975,7 @@ export function FlasherPage() {
             </Form>
             {/* Rendered outside <Form> so Semantic's ".ui.form .error.message { display:none }" rule doesn't
                 hide it, and here (not at the top) so it is visible right where the user clicked Connect. */}
-            {error && bootHint && <Message error onDismiss={() => {
-                setError('');
-                setBootHint(false);
-            }} style={{marginTop: '1em'}}>
-                <Message.Header>Could not connect to the device</Message.Header>
-                <p>{error}</p>
-                <p>
-                    Many ESP boards must be put into <b>download mode</b> manually before flashing. Hold the
-                    {' '}<b>BOOT</b> (or <b>IO0</b>) button, briefly press <b>RESET</b> (<b>EN</b>), then release
-                    BOOT and try again. Also check the USB cable is a data cable and no other tab has the port
-                    open.
-                </p>
-            </Message>}
+            {connectErrorMessage()}
         </Segment>
 
         <Segment>

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -22,7 +22,7 @@ import {
     TextArea
 } from "./Theme";
 import {ThemeContext} from "../contexts/contexts";
-import {deleteFlasherConfig, filesSearch, flasherSearch, getFlasherConfigs, saveFlasherConfig} from "../api";
+import {deleteFlasherConfig, flasherSearch, getFlasherConfigs, saveFlasherConfig} from "../api";
 
 // The suffix used to find flashable ESP32 firmware in the media directory.
 const FIRMWARE_SUFFIX = '.bin';
@@ -30,6 +30,85 @@ const FIRMWARE_SUFFIX = '.bin';
 // esptool-js reports a chip description like "ESP32-S2 (revision v0.0)"; take the family before " (".
 export function chipFamily(description) {
     return (description || '').split(' (')[0].trim() || null;
+}
+
+// ESP image chip_id -> family name (matches esptool-js IMAGE_CHIP_ID values).
+const ESP_CHIP_ID_NAMES = {
+    0: 'ESP32', 2: 'ESP32-S2', 5: 'ESP32-C3', 9: 'ESP32-S3',
+    12: 'ESP32-C2', 13: 'ESP32-C6', 16: 'ESP32-H2', 18: 'ESP32-C5',
+};
+
+// Known ESP chip names, sorted so each maps to a stable color — colors survive reboots/refreshes and only shift
+// if a new name is added here.  A chip not in this list still gets a deterministic color via hashing below.
+const KNOWN_ESP_CHIPS = [
+    'ESP32', 'ESP32-S2', 'ESP32-S3', 'ESP32-C2', 'ESP32-C3',
+    'ESP32-C5', 'ESP32-C6', 'ESP32-C61', 'ESP32-H2', 'ESP32-P4',
+].sort();
+
+// Paul Tol's "bright" qualitative palette (colorblind-safe) plus black, then four more distinct colors for
+// headroom.  A label's *width* (chip-name length) is itself a discriminator, so two chips only need distinct
+// colors when they render at the same width.  The first eight cover today's largest same-width group (the eight
+// 8-character ESP32-* names); the extras let a same-width group grow past eight before colors would repeat.
+// (Truly colorblind-distinct qualitative colors top out around ten, so beyond that distinctness is best-effort.)
+const CHIP_COLORS = [
+    '#4477aa', '#ee6677', '#228833', '#ccbb44', '#66ccee', '#aa3377', '#bbbbbb', '#000000',
+    '#ee7733', '#332288', '#999933', '#882255',
+];
+
+// Assign each known chip a color *index within its own name-length group*.  Same-width chips therefore always get
+// different (colorblind-distinguishable) colors, while chips of different widths may share one — the width tells
+// them apart.  Built once from the sorted known list.
+const CHIP_COLOR_INDEX = (() => {
+    const perLength = {};
+    const index = {};
+    for (const name of KNOWN_ESP_CHIPS) {
+        const slot = perLength[name.length] || 0;
+        index[name] = slot;
+        perLength[name.length] = slot + 1;
+    }
+    return index;
+})();
+
+// Deterministic background color for a chip label (see CHIP_COLORS/CHIP_COLOR_INDEX).  Unknown chips hash to a
+// stable slot so they still get a consistent color.
+export function chipColor(name) {
+    if (!name) {
+        return CHIP_COLORS[CHIP_COLORS.length - 1];
+    }
+    if (name in CHIP_COLOR_INDEX) {
+        return CHIP_COLORS[CHIP_COLOR_INDEX[name] % CHIP_COLORS.length];
+    }
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+    }
+    return CHIP_COLORS[hash % CHIP_COLORS.length];
+}
+
+// Black or white text for readability on a given hex background (YIQ brightness).
+export function chipTextColor(hex) {
+    const c = (hex || '').replace('#', '');
+    if (c.length < 6) {
+        return '#fff';
+    }
+    const r = parseInt(c.slice(0, 2), 16);
+    const g = parseInt(c.slice(2, 4), 16);
+    const b = parseInt(c.slice(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 > 140 ? '#000' : '#fff';
+}
+
+export function chipIdName(chipId) {
+    return ESP_CHIP_ID_NAMES[chipId] || `chip id ${chipId}`;
+}
+
+// Read the chip_id from an ESP application/bootloader image header: magic byte 0xE9 at offset 0, chip_id as a
+// uint16 LE at offset 0x0C.  Returns null for non-ESP-image files (partition tables start 0xAA, boot_app0 and
+// littlefs are raw, etc.) — those carry no chip_id and must never be flagged as a mismatch.
+export function espImageChipId(header) {
+    if (!header || header.length < 14 || header[0] !== 0xE9) {
+        return null;
+    }
+    return header[12] | (header[13] << 8);
 }
 
 // Flashing happens entirely in the browser using the Web Serial API; nothing is uploaded to WROLPi.  esptool-js is
@@ -68,6 +147,19 @@ async function readEntryBytes(item) {
     }
     const buffer = await resp.arrayBuffer();
     return new Uint8Array(buffer);
+}
+
+// Read just the leading bytes of a firmware entry (enough for the ESP image header) without downloading the
+// whole file.  Local files are sliced; media files use an HTTP Range request (the media server supports Range).
+async function readEntryHeader(item) {
+    if (item.file) {
+        return new Uint8Array(await item.file.slice(0, 24).arrayBuffer());
+    }
+    const resp = await fetch(`/media/${encodeMediaPath(item.mediaPath)}`, {headers: {Range: 'bytes=0-23'}});
+    if (!resp.ok) {
+        return null;
+    }
+    return new Uint8Array(await resp.arrayBuffer()).slice(0, 24);
 }
 
 // A flash offset must be a 0x-prefixed hex string, e.g. "0x0" or "0x10000".
@@ -175,6 +267,11 @@ export function FlasherPage() {
     const [connecting, setConnecting] = useState(false);
     const [flashing, setFlashing] = useState(false);
     const [chip, setChip] = useState('');
+    // The connected device's ESP image chip_id (0=ESP32, 2=S2, 9=S3, …); used to catch wrong-chip firmware.
+    const [deviceChipId, setDeviceChipId] = useState(null);
+    // Per-selected-file chip_id read from each ESP image header, aligned to `files` (null = not an ESP image or
+    // unreadable).  Compared against deviceChipId to warn on the offending table row.
+    const [fileChipIds, setFileChipIds] = useState([]);
     const [progress, setProgress] = useState(null); // {fileIndex, percent}
     const [error, setError] = useState('');
     // Set when a connection attempt fails, so we can remind the user to put the board into download/boot mode.
@@ -274,18 +371,13 @@ export function FlasherPage() {
     };
 
     // Fetch firmware for the picker.  `pathFilter` is a case-insensitive match against the full file path (so
-    // "bffb" lists the firmware inside that directory).  When `chip` is set, only ESP images for that chip are
-    // returned (server inspects each file's header); otherwise all .bin files are listed.
+    // "bffb" lists the firmware inside that directory).  The server inspects each .bin's header and returns its
+    // chip/kind; when `chip` is set, only ESP images for that chip are returned (otherwise every .bin is listed,
+    // including non-ESP parts like partition tables and littlefs).
     const fetchMediaFirmware = React.useCallback(async (pathFilter, chip) => {
         setMediaLoading(true);
         try {
-            let fileGroups;
-            if (chip) {
-                [fileGroups] = await flasherSearch(chip, pathFilter || null);
-            } else {
-                [fileGroups] = await filesSearch(0, 50, null, null, null, null,
-                    false, null, null, null, false, null, FIRMWARE_SUFFIX, pathFilter || null);
-            }
+            const [fileGroups] = await flasherSearch(chip || null, pathFilter || null);
             setMediaResults(fileGroups || []);
         } catch (e) {
             // Surface connectivity errors instead of showing the empty "no firmware found" state, which would
@@ -327,6 +419,37 @@ export function FlasherPage() {
     useEffect(() => {
         fetchSavedConfigs();
     }, [fetchSavedConfigs]);
+
+    // Once connected, read each selected firmware's image chip_id so a wrong-chip file — e.g. an ESP32-S2
+    // bootloader in an ESP32 set — can be flagged on its table row.  Non-ESP-image files (partition tables,
+    // boot_app0, littlefs) carry no chip_id and read as null (never flagged).  Only the small header of each file
+    // is read (Range request for media files).  Keyed on file identity so editing an offset doesn't re-fetch.
+    const fileIdentityKey = files
+        .map(item => item.mediaPath || (item.file ? `${item.file.name}:${item.file.size}` : item.name))
+        .join('|');
+    useEffect(() => {
+        if (!connected || files.length === 0) {
+            setFileChipIds([]);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            const ids = await Promise.all(files.map(async (item) => {
+                try {
+                    return espImageChipId(await readEntryHeader(item));
+                } catch (e) {
+                    return null;  // Unreadable header: just don't flag this file.
+                }
+            }));
+            if (!cancelled) {
+                setFileChipIds(ids);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connected, fileIdentityKey]);
 
     // Media firmware entries that can be persisted (local computer files have no stable path, so are excluded).
     const saveableFiles = files.filter(item => item.mediaPath);
@@ -384,6 +507,9 @@ export function FlasherPage() {
             'Timed out waiting for the device to respond.');
         esploaderRef.current = esploader;
         setChip(chipDescription);
+        // Capture the device's image chip_id so selected firmware can be checked against it (ESP8266 has none).
+        const detected = esploader.chip;
+        setDeviceChipId(detected && typeof detected.IMAGE_CHIP_ID === 'number' ? detected.IMAGE_CHIP_ID : null);
         setConnected(true);
         return chipDescription;
     };
@@ -424,7 +550,11 @@ export function FlasherPage() {
         setConnecting(true);
         try {
             await disconnect();
-            const family = chipFamily(await connectAndDetect());
+            await connectAndDetect();
+            // Filter by esptool's canonical chip name (e.g. "ESP32", not the "ESP32-D0WD-V3" variant from the
+            // description) so it matches the backend's chip_id-derived names — otherwise the search finds nothing.
+            const detected = esploaderRef.current && esploaderRef.current.chip;
+            const family = detected && detected.CHIP_NAME ? detected.CHIP_NAME : null;
             if (family) {
                 applyDeviceChip(family);
             }
@@ -447,8 +577,24 @@ export function FlasherPage() {
         esploaderRef.current = null;
         setConnected(false);
         setChip('');
+        setDeviceChipId(null);
+        setFileChipIds([]);
         setProgress(null);
     };
+
+    // Changing the selected firmware set invalidates the chip check performed at connect time.  Drop the
+    // connection so the user must reconnect and be re-checked — otherwise loading a different (wrong-chip) saved
+    // config while connected would appear valid against the previously-detected device.
+    const prevFileKeyRef = useRef(fileIdentityKey);
+    useEffect(() => {
+        if (prevFileKeyRef.current !== fileIdentityKey) {
+            prevFileKeyRef.current = fileIdentityKey;
+            if (connected) {
+                disconnect();
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fileIdentityKey, connected]);
 
     const handleFlash = async () => {
         if (!esploaderRef.current || files.length === 0) {
@@ -587,7 +733,7 @@ export function FlasherPage() {
                         onChange={(e, {value}) => handleMediaFilterChange(value)}
                     />
                 </Form>
-                <div style={{marginTop: '1em'}}>
+                <div style={{marginTop: '1em', overflowX: 'auto'}}>
                     {mediaLoading
                         ? <Loader active inline='centered'/>
                         : (mediaResults.length === 0
@@ -596,30 +742,50 @@ export function FlasherPage() {
                                 {deviceChip ? ` for ${deviceChip}` : ' in your media directory'}
                                 {mediaFilter ? ' matching that filter.' : '.'}
                             </p>
-                            : <List divided relaxed selection>
-                                {mediaResults.map(result => <List.Item
-                                    key={result.primary_path}
-                                    onClick={busy ? undefined : () => handleAddMediaFile(result)}
-                                    style={busy ? {opacity: 0.5} : {cursor: 'pointer'}}
-                                >
-                                    <List.Icon name='plus' verticalAlign='middle'/>
-                                    <List.Content>
-                                        <List.Header>
-                                            {result.name || result.primary_path}
-                                            {result.esp_kind &&
-                                                <Label size='tiny'
-                                                       color={result.esp_kind === 'factory' ? 'green' : 'grey'}
-                                                       style={{marginLeft: '0.5em'}}>
-                                                    {result.esp_kind}
-                                                </Label>}
-                                        </List.Header>
-                                        <List.Description {...t}>
-                                            {result.primary_path} &mdash; {humanFileSize(result.size)}
-                                            {result.esp_chip && ` — ${result.esp_chip}`}
-                                        </List.Description>
-                                    </List.Content>
-                                </List.Item>)}
-                            </List>)}
+                            : <Table compact selectable unstackable>
+                                <Table.Header>
+                                    <Table.Row>
+                                        <Table.HeaderCell>File</Table.HeaderCell>
+                                        <Table.HeaderCell>Path</Table.HeaderCell>
+                                        <Table.HeaderCell>Size</Table.HeaderCell>
+                                        <Table.HeaderCell>Chip</Table.HeaderCell>
+                                        <Table.HeaderCell>Kind</Table.HeaderCell>
+                                        <Table.HeaderCell width={1}/>
+                                    </Table.Row>
+                                </Table.Header>
+                                <Table.Body>
+                                    {mediaResults.map(result => {
+                                        const name = result.name || (result.primary_path || '').split('/').pop();
+                                        // esp_kind is 'not_esp_image' for parts with no chip (partitions, littlefs).
+                                        const kind = result.esp_kind && result.esp_kind !== 'not_esp_image'
+                                            ? result.esp_kind : null;
+                                        return <Table.Row key={result.primary_path}>
+                                            <Table.Cell>{name}</Table.Cell>
+                                            <Table.Cell {...t} style={{opacity: 0.7, wordBreak: 'break-all'}}>
+                                                {result.primary_path}
+                                            </Table.Cell>
+                                            <Table.Cell>{humanFileSize(result.size)}</Table.Cell>
+                                            <Table.Cell>
+                                                {result.esp_chip
+                                                    ? <Label size='tiny' style={{
+                                                        backgroundColor: chipColor(result.esp_chip),
+                                                        color: chipTextColor(chipColor(result.esp_chip)),
+                                                        borderColor: 'transparent',
+                                                    }}>{result.esp_chip}</Label>
+                                                    : <span style={{opacity: 0.5}}>—</span>}
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                {kind || <span style={{opacity: 0.5}}>—</span>}
+                                            </Table.Cell>
+                                            <Table.Cell textAlign='center'>
+                                                <Button icon='plus' size='mini' primary disabled={busy}
+                                                        title='Add to selected firmware'
+                                                        onClick={() => handleAddMediaFile(result)}/>
+                                            </Table.Cell>
+                                        </Table.Row>;
+                                    })}
+                                </Table.Body>
+                            </Table>)}
                 </div>
             </Tab.Pane>,
     };
@@ -697,10 +863,20 @@ export function FlasherPage() {
                         </Table.Row>
                     </Table.Header>
                     <Table.Body>
-                        {files.map((item, index) => <Table.Row key={`${item.name}-${index}`}>
+                        {files.map((item, index) => {
+                            // Flag (but never block) a file whose image targets a different chip than the device.
+                            const fileChipId = fileChipIds[index];
+                            const chipMismatch = deviceChipId !== null && fileChipId != null
+                                && fileChipId !== deviceChipId;
+                            return <Table.Row key={`${item.name}-${index}`} warning={chipMismatch}>
                             <Table.Cell>
                                 <Icon name={item.mediaPath ? 'database' : 'file'}/>
                                 {item.name} <span style={{opacity: 0.6}}>({humanFileSize(item.size)})</span>
+                                {chipMismatch &&
+                                    <Label color='red' size='tiny' style={{marginLeft: '0.5em'}}>
+                                        <SIcon name='warning sign'/>
+                                        Built for {chipIdName(fileChipId)}, not {chipIdName(deviceChipId)}
+                                    </Label>}
                             </Table.Cell>
                             <Table.Cell>
                                 <Form.Input
@@ -717,7 +893,8 @@ export function FlasherPage() {
                                 <Button icon='trash' size='mini' color='red' disabled={busy}
                                         onClick={() => handleRemoveFile(index)}/>
                             </Table.Cell>
-                        </Table.Row>)}
+                        </Table.Row>;
+                        })}
                     </Table.Body>
                 </Table>
                 {/* Save lives here (not in the Saved Firmwares tab) so the current selection can be saved from

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -35,7 +35,7 @@ export function chipFamily(description) {
 // ESP image chip_id -> family name (matches esptool-js IMAGE_CHIP_ID values).
 const ESP_CHIP_ID_NAMES = {
     0: 'ESP32', 2: 'ESP32-S2', 5: 'ESP32-C3', 9: 'ESP32-S3',
-    12: 'ESP32-C2', 13: 'ESP32-C6', 16: 'ESP32-H2', 18: 'ESP32-C5',
+    12: 'ESP32-C2', 13: 'ESP32-C6', 16: 'ESP32-H2', 17: 'ESP32-C5', 18: 'ESP32-P4',
 };
 
 // Known ESP chip names, sorted so each maps to a stable color — colors survive reboots/refreshes and only shift

--- a/app/src/components/Flasher.test.js
+++ b/app/src/components/Flasher.test.js
@@ -27,14 +27,13 @@ jest.mock('esptool-js', () => ({
 
 // Flasher fetches media firmware on mount; mock the API so tests don't hit the network.
 jest.mock('../api', () => ({
-    filesSearch: jest.fn().mockResolvedValue([[], 0]),
     flasherSearch: jest.fn().mockResolvedValue([[], 0]),
     getFlasherConfigs: jest.fn().mockResolvedValue([]),
     saveFlasherConfig: jest.fn().mockResolvedValue(true),
     deleteFlasherConfig: jest.fn().mockResolvedValue(true),
 }));
 
-import {filesSearch, flasherSearch, getFlasherConfigs} from '../api';
+import {flasherSearch, getFlasherConfigs} from '../api';
 import {
     chipColor,
     chipTextColor,
@@ -167,6 +166,9 @@ describe('chipIdName', () => {
         expect(chipIdName(0)).toBe('ESP32');
         expect(chipIdName(2)).toBe('ESP32-S2');
         expect(chipIdName(9)).toBe('ESP32-S3');
+        // Must match the backend ESP_CHIP_IDS map: 17 -> C5, 18 -> P4 (not the reverse).
+        expect(chipIdName(17)).toBe('ESP32-C5');
+        expect(chipIdName(18)).toBe('ESP32-P4');
     });
 
     it('falls back to a readable string for unknown ids', () => {
@@ -245,8 +247,6 @@ describe('FlasherPage', () => {
     const original = Object.getOwnPropertyDescriptor(global.navigator, 'serial');
 
     beforeEach(() => {
-        filesSearch.mockClear();
-        filesSearch.mockResolvedValue([[], 0]);
         flasherSearch.mockClear();
         flasherSearch.mockResolvedValue([[], 0]);
         getFlasherConfigs.mockClear();

--- a/app/src/components/Flasher.test.js
+++ b/app/src/components/Flasher.test.js
@@ -3,12 +3,17 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 
 // esptool-js ships untranspiled ESM which Jest will not transform; mock it so importing Flasher.js is safe.
 // Real classes (not jest.fn mock impls) so `new ESPLoader()` reliably yields an instance with main()/after().
-// The ESPLoader mock reports an ESP32-S2 so the connect/detect flow can be exercised.
+// The `mock`-prefixed holders let individual tests model different chips (esptool-js sets esploader.chip with a
+// canonical CHIP_NAME plus IMAGE_CHIP_ID during main()); defaults describe an ESP32-S2.
+let mockChipName = 'ESP32-S2';
+let mockChipId = 2;
+let mockDescription = 'ESP32-S2 (revision v0.0)';
 jest.mock('esptool-js', () => ({
     __esModule: true,
     ESPLoader: class {
         async main() {
-            return 'ESP32-S2 (revision v0.0)';
+            this.chip = {CHIP_NAME: mockChipName, IMAGE_CHIP_ID: mockChipId};
+            return mockDescription;
         }
 
         async after() {
@@ -31,7 +36,11 @@ jest.mock('../api', () => ({
 
 import {filesSearch, flasherSearch, getFlasherConfigs} from '../api';
 import {
+    chipColor,
+    chipTextColor,
     chipFamily,
+    chipIdName,
+    espImageChipId,
     estimateFlashSeconds,
     FlasherPage,
     humanDuration,
@@ -90,6 +99,78 @@ describe('chipFamily', () => {
         expect(chipFamily('')).toBeNull();
         expect(chipFamily(null)).toBeNull();
         expect(chipFamily(undefined)).toBeNull();
+    });
+});
+
+describe('espImageChipId', () => {
+    // ESP image header: magic 0xE9 at byte 0, chip_id as uint16 LE at offset 0x0C.
+    const header = (magic, chipId) => {
+        const h = new Uint8Array(24);
+        h[0] = magic;
+        h[12] = chipId & 0xFF;
+        h[13] = (chipId >> 8) & 0xFF;
+        return h;
+    };
+
+    it('reads the chip_id from an ESP image header', () => {
+        expect(espImageChipId(header(0xE9, 0))).toBe(0);   // ESP32
+        expect(espImageChipId(header(0xE9, 2))).toBe(2);   // ESP32-S2
+        expect(espImageChipId(header(0xE9, 9))).toBe(9);   // ESP32-S3
+    });
+
+    it('returns null for non-ESP-image files (no chip_id to compare)', () => {
+        expect(espImageChipId(header(0xAA, 0))).toBeNull(); // partition table magic
+        expect(espImageChipId(new Uint8Array([0x00, 0x01]))).toBeNull(); // too short / raw (boot_app0)
+        expect(espImageChipId(null)).toBeNull();
+    });
+});
+
+describe('chipColor', () => {
+    it('is deterministic — the same chip always gets the same color', () => {
+        expect(chipColor('ESP32')).toBe(chipColor('ESP32'));
+        expect(chipColor('ESP32-S3')).toBe(chipColor('ESP32-S3'));
+    });
+
+    it('gives every same-width chip a distinct color (the colorblind aid)', () => {
+        // All the 8-character ESP32-* names render at the same width, so they must never share a color.
+        const sameWidth = ['ESP32-S2', 'ESP32-S3', 'ESP32-C2', 'ESP32-C3',
+            'ESP32-C5', 'ESP32-C6', 'ESP32-H2', 'ESP32-P4'];
+        const colors = sameWidth.map(chipColor);
+        expect(new Set(colors).size).toBe(sameWidth.length);
+    });
+
+    it('may reuse a color across different widths (width itself disambiguates)', () => {
+        // ESP32 (5 chars) and a same-index 8-char chip can share a color — different widths tell them apart.
+        expect(chipColor('ESP32')).toBe(chipColor('ESP32-C2'));
+    });
+
+    it('returns a valid palette color for known, unknown, and empty names', () => {
+        const hex = /^#[0-9a-f]{6}$/i;
+        expect(chipColor('ESP32')).toMatch(hex);
+        expect(chipColor('ESP32-FUTURE')).toMatch(hex); // unknown -> stable hash
+        expect(chipColor('ESP32-FUTURE')).toBe(chipColor('ESP32-FUTURE'));
+        expect(chipColor(null)).toMatch(hex);
+    });
+});
+
+describe('chipTextColor', () => {
+    it('uses white text on dark backgrounds and black on light ones', () => {
+        expect(chipTextColor('#000000')).toBe('#fff'); // black bg
+        expect(chipTextColor('#4477aa')).toBe('#fff'); // Tol blue (dark)
+        expect(chipTextColor('#ccbb44')).toBe('#000'); // Tol yellow (light)
+        expect(chipTextColor('#bbbbbb')).toBe('#000'); // grey (light)
+    });
+});
+
+describe('chipIdName', () => {
+    it('maps known chip ids to family names', () => {
+        expect(chipIdName(0)).toBe('ESP32');
+        expect(chipIdName(2)).toBe('ESP32-S2');
+        expect(chipIdName(9)).toBe('ESP32-S3');
+    });
+
+    it('falls back to a readable string for unknown ids', () => {
+        expect(chipIdName(99)).toBe('chip id 99');
     });
 });
 
@@ -170,6 +251,10 @@ describe('FlasherPage', () => {
         flasherSearch.mockResolvedValue([[], 0]);
         getFlasherConfigs.mockClear();
         getFlasherConfigs.mockResolvedValue([]);
+        // Default the mocked chip back to ESP32-S2 for each test.
+        mockChipName = 'ESP32-S2';
+        mockChipId = 2;
+        mockDescription = 'ESP32-S2 (revision v0.0)';
     });
 
     afterEach(() => {
@@ -200,21 +285,21 @@ describe('FlasherPage', () => {
         expect(screen.getAllByText('Flash Device')[0].closest('button')).toBeDisabled();
     });
 
-    it('fetches media firmware by suffix on load and lists results', async () => {
+    it('fetches media firmware on load and lists it with chip/kind in a table', async () => {
         Object.defineProperty(global.navigator, 'serial', {value: {}, configurable: true});
-        filesSearch.mockResolvedValue([[
-            {primary_path: 'software/MALVEKE.ino.bin', name: 'MALVEKE.ino.bin', size: 1024},
+        flasherSearch.mockResolvedValue([[
+            {primary_path: 'software/MALVEKE.ino.bin', name: 'MALVEKE.ino.bin', size: 1024,
+                esp_chip: 'ESP32', esp_kind: 'app'},
         ], 1]);
         render(<FlasherPage/>);
-        // Media firmware is fetched on mount filtered to the .bin suffix (the `suffix` positional arg).
-        await waitFor(() => expect(filesSearch).toHaveBeenCalled());
-        const call = filesSearch.mock.calls[0];
-        // filesSearch(offset, limit, searchStr, mimetypes, model, tagNames, headline, months, fromYear, toYear,
-        //             anyTag, order, suffix, path)
-        expect(call[12]).toBe('.bin');
+        // Media firmware is fetched on mount via the flasher search (no chip filter, no path).
+        await waitFor(() => expect(flasherSearch).toHaveBeenCalledWith(null, null));
         // The result is listed for the user to add, under the "Choose from your WROLPi" tab.
         switchTab('Choose from your WROLPi');
         expect((await screen.findAllByText('MALVEKE.ino.bin')).length).toBeGreaterThan(0);
+        // The table surfaces the detected chip and kind.
+        expect(screen.getAllByText('ESP32').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('app').length).toBeGreaterThan(0);
     });
 
     it('offers the detect-device filter button', () => {
@@ -276,6 +361,24 @@ describe('FlasherPage', () => {
         expect((await screen.findAllByText('s2.bin')).length).toBeGreaterThan(0);
     });
 
+    it('filters by the canonical chip name, not the variant from the chip description', async () => {
+        // An ESP32-classic reports description "ESP32-D0WD-V3 (revision 3)" but CHIP_NAME "ESP32".  The backend
+        // stores firmware chips as the canonical name ("ESP32"), so the search must use CHIP_NAME — searching the
+        // variant "ESP32-D0WD-V3" would match nothing even when valid firmware exists.
+        mockChipName = 'ESP32';
+        mockChipId = 0;
+        mockDescription = 'ESP32-D0WD-V3 (revision 3)';
+        Object.defineProperty(global.navigator, 'serial',
+            {value: {requestPort: jest.fn().mockResolvedValue({})}, configurable: true});
+
+        render(<FlasherPage/>);
+        switchTab('Choose from your WROLPi');
+        fireEvent.click(screen.getAllByText('Filter files by detecting device')[0].closest('button'));
+
+        // (flasherSearch also runs on mount with no chip; wait for the detect-driven call specifically.)
+        await waitFor(() => expect(flasherSearch).toHaveBeenCalledWith('ESP32', null));
+    });
+
     it('adds dropped .bin files and switches to the Add-from-computer tab', async () => {
         Object.defineProperty(global.navigator, 'serial', {value: {}, configurable: true});
         render(<FlasherPage/>);
@@ -295,5 +398,23 @@ describe('FlasherPage', () => {
         expect(screen.queryByText('notes.txt')).not.toBeInTheDocument();
         // The drop switches to the "Add from computer" tab, revealing its dropzone.
         expect(screen.getAllByText(/Click here/).length).toBeGreaterThan(0);
+    });
+
+    it('disconnects when the selected firmware set changes, forcing a fresh chip check', async () => {
+        Object.defineProperty(global.navigator, 'serial',
+            {value: {requestPort: jest.fn().mockResolvedValue({})}, configurable: true});
+        render(<FlasherPage/>);
+
+        // Connect to the device.
+        fireEvent.click(screen.getAllByText('Connect Device')[0].closest('button'));
+        await waitFor(() => expect(screen.getAllByText('Disconnect').length).toBeGreaterThan(0));
+
+        // Changing the firmware selection (drop a new file) must drop the connection so it is re-checked.
+        const bin = new File([new Uint8Array([0xe9, 0, 0])], 'swapped.bin');
+        fireEvent.drop(screen.getAllByText('1. Firmware files')[0],
+            {dataTransfer: {files: [bin], types: ['Files']}});
+
+        await waitFor(() => expect(screen.getAllByText('Connect Device').length).toBeGreaterThan(0));
+        expect(screen.queryByText('Disconnect')).not.toBeInTheDocument();
     });
 });

--- a/modules/flasher/lib.py
+++ b/modules/flasher/lib.py
@@ -102,9 +102,13 @@ def _resolve_media_path(primary_path) -> pathlib.Path:
 
 def search_esp_firmware(chip: Optional[str] = None, path: Optional[str] = None,
                         limit: int = 1000) -> Tuple[List[dict], int]:
-    """Search for ``.bin`` firmware and return only ESP images, annotated with their detected chip/kind.
+    """Search for ``.bin`` firmware, annotated with each file's detected chip/kind.
 
-    @param chip: If provided, only return images built for this chip (e.g. "ESP32-S2").
+    Without a ``chip`` filter every ``.bin`` is returned — including non-ESP parts (partition tables, boot_app0,
+    filesystem images) annotated with a null chip — so a full flash set can be assembled.  With a ``chip`` filter
+    only ESP images built for that chip are returned.
+
+    @param chip: If provided, only return ESP images built for this chip (e.g. "ESP32-S2").
     @param path: Case-insensitive partial match against the file path (same as file search).
     @param limit: Maximum number of candidate .bin files to inspect.
     """
@@ -115,11 +119,13 @@ def search_esp_firmware(chip: Optional[str] = None, path: Optional[str] = None,
     results = []
     for file_group in file_groups:
         info = read_esp_image_info(_resolve_media_path(file_group['primary_path']))
-        if not info['is_esp_image']:
-            # Skip non-ESP .bin files (filesystem images, game installers, STM32 firmware, etc.).
-            continue
-        if chip and info['chip'] != chip:
-            continue
+        if chip:
+            # Filtering to a specific chip: only its ESP images.  Non-ESP .bin files (filesystem images, game
+            # installers, STM32 firmware, etc.) have no chip and are excluded from a chip-filtered search.
+            if not info['is_esp_image'] or info['chip'] != chip:
+                continue
+        # Unfiltered: return every .bin, annotating non-ESP parts (partition tables, boot_app0, littlefs) with a
+        # null chip so they remain available to assemble into a flash set.
         results.append({
             **file_group,
             'esp_chip': info['chip'],

--- a/modules/flasher/test/test_flasher.py
+++ b/modules/flasher/test/test_flasher.py
@@ -70,12 +70,16 @@ async def test_search_esp_firmware_filters_by_chip(async_client, test_session, m
     assert total == 1
     assert names(s2) == ['s2-app.bin']
 
-    # No chip: all ESP images, excluding the non-ESP .bin.
-    all_esp, total = search_esp_firmware()
-    assert total == 4
-    assert 'littlefs.bin' not in names(all_esp)
+    # No chip: every .bin, including non-ESP parts (partition tables, littlefs, boot_app0) annotated with a null
+    # chip so a full flash set can still be assembled from the picker.
+    all_bin, total = search_esp_firmware()
+    assert total == 5
+    assert 'littlefs.bin' in names(all_bin)
+    littlefs = next(r for r in all_bin if pathlib.Path(r['primary_path']).name == 'littlefs.bin')
+    assert littlefs['esp_chip'] is None
+    assert littlefs['esp_kind'] == 'not_esp_image'
 
-    # A chip with no matching firmware returns nothing.
+    # Filtering to a specific chip still returns only that chip's ESP images (non-ESP parts are shown unfiltered).
     _, total = search_esp_firmware(chip='ESP32-H2')
     assert total == 0
 


### PR DESCRIPTION
## Summary
Hardens the ESP32 flasher against the wrong-chip flash that bricked a board during testing (an **ESP32-S2 bootloader flashed onto an ESP32**), and reworks the media-firmware picker into a readable, informative table.

### Chip-mismatch guard
- After connecting, each selected file's ESP image header (`chip_id` at offset `0x0C`) is compared to the device's `IMAGE_CHIP_ID`. A mismatched file gets a highlighted row + a red **"Built for ESP32-S2, not ESP32"** label. It's a **warning, not a block** — you can still flash if you mean to.
- Non-ESP `.bin` parts (partition tables, `boot_app0`, littlefs) have no `chip_id` and are never falsely flagged.
- Changing the selected firmware set now **disconnects**, so the check is always re-run against a freshly detected chip (closes a bypass where loading a different config kept a stale detection).

### "Choose from your WROLPi" table
- Now a table: **File · Path · Size · Chip · Kind · +**, served by a single `/flasher/search` call.
- `search_esp_firmware` returns **every `.bin` annotated** when unfiltered (so partition tables / `boot_app0` / littlefs remain pickable for multi-file sets); a chip filter still narrows to that chip's ESP images.

### Fixes
- Detect-device filter now searches by the **canonical chip name** (`CHIP_NAME`, e.g. `ESP32`) instead of the variant description (`ESP32-D0WD-V3`), which matched nothing — the picker said "no firmware" while a saved config was valid.

### Colorblind-safe chip colors
- The Chip column uses deterministic colors that survive reboots. Because a label's **width** is itself a discriminator, **same-width chip names always get distinct** (Paul Tol "bright", colorblind-safe) colors; different-width chips may reuse a color. Auto black/white text for contrast; palette has headroom to grow past today's 8-name group.

## Testing
- Backend: `pytest modules/flasher wrolpi/files` — 106 passed (TDD: red→green for the unfiltered-search change and the canonical-name fix).
- Frontend: full Jest suite — 726 passed.
- Verified live on a real ESP32-D0WD-V3 via Web Serial (valid set clean; S2 config flags the bootloader + firmware rows; detect-filter now lists matching firmware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)