### PR TITLE
Module pages: always show the deep-search reminder during fast searches

### DIFF
--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -898,18 +898,19 @@ export function SearchControlBar(
     </div>
 }
 
-// Offers deep search when a fast search found nothing.  Used by the module pages (Videos/Archives/Docs),
-// which have no deep estimate; FilesSearchView has a count-aware variant.
+// Reminds the user that the fast search only matches titles/authors/descriptions.  Used by the module
+// pages (Videos/Archives/Docs), which have no deep estimate, so it shows whenever a fast search is
+// active; FilesSearchView has a count-aware variant.
 export function DeepSearchHint({searchStr, files}) {
     const {deep} = useSearchDeep();
     const {updateQuery} = useContext(QueryContext);
 
-    if (!searchStr || deep || !files || files.length > 0) {
+    if (!searchStr || deep || !Array.isArray(files)) {
         return null;
     }
 
     return <Segment>
-        Not finding what you need?
+        {files.length === 0 ? 'Not finding what you need?' : 'More results may be available in deep search.'}
         <Button primary
                 onClick={() => updateQuery({deep: 'true', o: 0})}
                 style={{marginLeft: '1em'}}


### PR DESCRIPTION
Follow-up to #520. The `DeepSearchHint` on the Videos/Archives/Docs pages only appeared on zero results, so a fast search **with** matches gave no indication that captions/page contents/document text were not searched.

Module searches have no deep estimate (unlike the global search's count-aware hint), so the reminder now shows whenever a fast search is active:

- With results: *"More results may be available in deep search. [Try deep search]"*
- Zero results: *"Not finding what you need? [Try deep search]"* (unchanged)
- Hidden when deep mode is on or no search string is entered.

The button still applies `{deep: 'true', o: 0}` in one update so the user lands on page 1 of deep results.

Verified against the docker stack: videos `?q=filament` shows 4 fast results + the reminder; clicking it lands on `deep=true&o=0` with 19 results and no reminder; archives `?q=yawn` (zero results) keeps the original wording. Jest: 729 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)