### PR TITLE
File preview: Open in Slicer button for STL/3MF files

### DIFF
--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -72,7 +72,13 @@ function OpenInSlicerButton({previewFile}) {
                 {SLICERS.map(s =>
                     <Dropdown.Item key={s.key} text={`Open in ${s.text}`}
                                    as='a' href={getSlicerURL(previewFile, s.scheme)}
-                                   onClick={() => setSlicerKey(s.key)}/>)}
+                                   onClick={(e) => {
+                                       // Navigate programmatically so keyboard activation (which may not
+                                       // follow the href) still launches the slicer.
+                                       if (e) e.preventDefault();
+                                       setSlicerKey(s.key);
+                                       window.location.assign(getSlicerURL(previewFile, s.scheme));
+                                   }}/>)}
             </Dropdown.Menu>
         </Dropdown>
     </SButton.Group>

--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -1,8 +1,8 @@
 import React from "react";
 import _ from "lodash";
-import {Header as SHeader, Icon, Image,} from "semantic-ui-react";
+import {Button as SButton, Dropdown, Header as SHeader, Icon, Image,} from "semantic-ui-react";
 import {TagsSelector} from "../Tags";
-import {encodeMediaPath, isSupportedArchive} from "./Common";
+import {encodeMediaPath, isSupportedArchive, useLocalStorage} from "./Common";
 import {getFile, tagFileGroup, untagFileGroup} from "../api";
 import {ArchivePreviewContent} from "./ArchivePreview";
 import {CbzViewer} from "./CbzViewer";
@@ -41,6 +41,41 @@ function getDownloadPathURL(previewFile) {
     } else {
         return `/download/${encodeMediaPath(previewFile['path'])}`;
     }
+}
+
+// PrusaSlicer is omitted because it only downloads from domains whitelisted by Prusa
+// (printables.com, thingiverse.com, cults3d.com), so it cannot fetch from a WROLPi.
+// Bambu Studio asks the user to confirm because a WROLPi is not one of its trusted sites.
+export const SLICERS = [
+    {key: 'orcaslicer', text: 'Orca Slicer', scheme: 'orcaslicer'},
+    {key: 'bambustudio', text: 'Bambu Studio', scheme: 'bambustudio'},
+    {key: 'cura', text: 'Cura', scheme: 'cura'},
+];
+
+export function getSlicerURL(previewFile, scheme) {
+    // Slicers register their own URL scheme and download the file themselves, so the
+    // file parameter must be an absolute URL reachable from the user's computer.
+    const absoluteURL = new URL(getMediaPathURL(previewFile), window.location.origin).href;
+    return `${scheme}://open?file=${encodeURIComponent(absoluteURL)}`;
+}
+
+function OpenInSlicerButton({previewFile}) {
+    // Browsers cannot report which slicers are installed, so remember the last one used.
+    const [slicerKey, setSlicerKey] = useLocalStorage('preferredSlicer', SLICERS[0].key);
+    const slicer = SLICERS.find(s => s.key === slicerKey) || SLICERS[0];
+    return <SButton.Group color='violet' size='small'>
+        <Button color='violet' as='a' href={getSlicerURL(previewFile, slicer.scheme)} icon labelPosition='left'>
+            <Icon name='cube'/>Open in {slicer.text}
+        </Button>
+        <Dropdown className='button icon' floating trigger={<></>}>
+            <Dropdown.Menu>
+                {SLICERS.map(s =>
+                    <Dropdown.Item key={s.key} text={`Open in ${s.text}`}
+                                   as='a' href={getSlicerURL(previewFile, s.scheme)}
+                                   onClick={() => setSlicerKey(s.key)}/>)}
+            </Dropdown.Menu>
+        </Dropdown>
+    </SButton.Group>
 }
 
 function getEpubViewerURL(previewFile) {
@@ -457,7 +492,7 @@ export function FilePreviewProvider({children}) {
         await localFetchFile();
     }
 
-    function setModalContent(content, url, downloadURL, path, taggable = true) {
+    function setModalContent(content, url, downloadURL, path, taggable = true, extraButtons = null) {
         // All action buttons share `size='small'` and `icon` for consistent height across viewports.
         // Close is handled by the Modal's `closeIcon` (X in the top-right corner) — no dedicated button.
         const openButton = url
@@ -497,6 +532,7 @@ export function FilePreviewProvider({children}) {
                         {downloadButton}
                         {directoryButton}
                         <ShareButton/>
+                        {extraButtons}
                         {previewFile && previewFile['id'] &&
                             <AddToPlaylistButton fileGroupId={previewFile['id']} content={null} size='small'
                                                  title='Add to Playlist'/>}
@@ -549,16 +585,20 @@ export function FilePreviewProvider({children}) {
             } else if (mimetype.startsWith('image/')) {
                 setModalContent(getImagePreviewModal(previewFile), url, null, path, taggable);
             } else if (mimetype.startsWith('model/stl')) {
-                setModalContent(<STLPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable);
+                setModalContent(<STLPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable,
+                    <OpenInSlicerButton previewFile={previewFile}/>);
             } else if (mimetype.startsWith('model/3mf')) {
-                setModalContent(<ThreeMFPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable);
+                setModalContent(<ThreeMFPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable,
+                    <OpenInSlicerButton previewFile={previewFile}/>);
             } else if (mimetype.startsWith('application/octet-stream') && lowerPath.endsWith('.mp3')) {
                 setModalContent(getAudioPreviewModal(previewFile), url, downloadURL, path, taggable);
             } else if (mimetype.startsWith('application/octet-stream') && lowerPath.endsWith('.stl')) {
-                setModalContent(<STLPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable);
+                setModalContent(<STLPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable,
+                    <OpenInSlicerButton previewFile={previewFile}/>);
             } else if ((mimetype.startsWith('application/octet-stream') || mimetype === 'application/zip')
                 && lowerPath.endsWith('.3mf')) {
-                setModalContent(<ThreeMFPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable);
+                setModalContent(<ThreeMFPreviewModal previewFile={previewFile}/>, null, downloadURL, path, taggable,
+                    <OpenInSlicerButton previewFile={previewFile}/>);
             } else if (mimetype.includes('cbz') || mimetype.includes('cbr') || mimetype.includes('comicbook+zip') || mimetype.includes('comicbook-rar')
                 || lowerPath.endsWith('.cbz') || lowerPath.endsWith('.cbr') || lowerPath.endsWith('.cbt') || lowerPath.endsWith('.cb7')) {
                 setModalContent(<Modal.Content><CbzViewer path={path}/></Modal.Content>, null, downloadURL, path, taggable);

--- a/app/src/components/FilePreview.test.js
+++ b/app/src/components/FilePreview.test.js
@@ -1,0 +1,24 @@
+import {getSlicerURL, SLICERS} from "./FilePreview";
+
+describe('getSlicerURL', () => {
+    test('builds a slicer link with the absolute media URL encoded once', () => {
+        const previewFile = {path: '3d printing/benchy.stl'};
+        const url = getSlicerURL(previewFile, 'orcaslicer');
+        expect(url).toEqual(
+            `orcaslicer://open?file=${encodeURIComponent('http://localhost/media/3d%20printing/benchy.stl')}`);
+    });
+
+    test('prefers primary_path and encodes special characters', () => {
+        const previewFile = {
+            primary_path: 'models/Buckle #2 (v2)/buckle.3mf',
+            path: 'models/Buckle #2 (v2)/buckle.stl',
+        };
+        const url = getSlicerURL(previewFile, 'bambustudio');
+        expect(url).toEqual(
+            `bambustudio://open?file=${encodeURIComponent('http://localhost/media/models/Buckle%20%232%20(v2)/buckle.3mf')}`);
+    });
+
+    test('PrusaSlicer is not offered because it only downloads from whitelisted domains', () => {
+        expect(SLICERS.map(s => s.scheme)).not.toContain('prusaslicer');
+    });
+});


### PR DESCRIPTION
## Summary

Adds an **Open in Slicer** split button to the STL and 3MF file preview toolbars (next to the Share button). Clicking it launches the model directly in a desktop slicer via its registered URL scheme (`scheme://open?file=<absolute media URL>`); the slicer then downloads the file itself over the network.

- Offers **Orca Slicer**, **Bambu Studio**, and **Cura** via the dropdown half of the split button.
- Browsers cannot detect which protocol handlers are installed, so the last-used slicer is remembered in `localStorage` and becomes the split button's default (Orca Slicer initially).
- The button is passed into the generic preview toolbar via a new optional `extraButtons` parameter on `setModalContent`, so other file types are unaffected.

## Why no PrusaSlicer?

PrusaSlicer's `prusaslicer://` handler only downloads from domains centrally whitelisted by Prusa (printables.com, thingiverse.com, cults3d.com) with no user-configurable override ([prusa3d/PrusaSlicer#13752](https://github.com/prusa3d/PrusaSlicer/issues/13752), closed as not planned), so it can never fetch from a WROLPi. Verified from source:

- Orca Slicer accepts any URL and its HTTP client skips TLS verification, so WROLPi's self-signed cert works.
- Bambu Studio works but shows a one-time "not from a trusted site" confirmation.
- Cura accepts any URL; it may require the WROLPi CA (`/ca.crt`) to be installed since Qt verifies TLS.

## Testing

- New `FilePreview.test.js` covering slicer URL construction, `primary_path` preference, special-character encoding, and the PrusaSlicer exclusion.
- Full Jest suite passes (47 suites, 746 tests); Cypress E2E passes (6 specs, 43 tests).
- Verified live in the docker dev app with an STL and a 3MF file, at desktop and 400px mobile widths: correct hrefs, dropdown fully visible, toolbar wraps cleanly, and slicer preference persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)