### PR TITLE
Upgrade: silence gpg web-of-trust warnings in verify logs

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -109,6 +109,13 @@ git -C /opt/wrolpi fetch || exit 4
 GNUPGHOME=$(mktemp -d)
 export GNUPGHOME
 gpg --batch --quiet --import /opt/wrolpi/wrolpi/roland@learningselfreliance.com.gpg
+# The throwaway keyring contains only the pinned WROLPi key, so mark it
+# ultimately trusted: possession of the pinned key IS the trust anchor here,
+# and this silences gpg's web-of-trust WARNING noise that makes healthy
+# upgrade logs look scary.  Cosmetic only — verify-commit already ignores
+# ownertrust when judging signature validity.
+gpg --batch --list-keys --with-colons | awk -F: '/^fpr:/ {print $10":6:"; exit}' | \
+  gpg --batch --quiet --import-ownertrust || :
 
 # Verify the fetched commit is signed by the trusted key before checking it out.
 if ! git -C /opt/wrolpi verify-commit origin/"${BRANCH}" 2>&1; then


### PR DESCRIPTION
Every healthy upgrade printed gpg's `WARNING: This key is not certified with a trusted signature!` during commit verification, which reads like the upgrade continued past a failure (observed live on 10.0.0.9 today).

The warning is web-of-trust noise: the throwaway keyring holds only the pinned WROLPi key, and possession of that key is the trust anchor. `git verify-commit` ignores ownertrust when judging validity, so this is purely cosmetic — mark the sole key ultimately trusted after import and the warning disappears from upgrade logs.

Validated locally against the shipped key: import → ownertrust pipeline → key listed as `ultimate`. Non-fatal (`|| :`) so a hiccup here can never block an upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)