### PR TITLE
Restore "Most Views" download order

### DIFF
--- a/app/src/components/Vars.js
+++ b/app/src/components/Vars.js
@@ -101,7 +101,7 @@ export const validUrlRegex = /^(http|https):\/\/[^ "]+$/;
 export const downloadOrderOptions = [
     {key: 'newest', text: 'Newest', value: 'newest'},
     {key: 'oldest', text: 'Oldest', value: 'oldest'},
-    // 'views'/'Most Views' was removed: YouTube no longer provides view counts in channel/playlist listings.
+    {key: 'views', text: 'Most Views', value: 'views'},
 ];
 
 export const downloadResolutionOptions = [

--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -720,12 +720,15 @@ class ChannelDownloader(Downloader, ABC):
             logger.debug(f'Downloading oldest videos from {download.url}')
             downloads = downloads.reverse()
         elif sort_key == 'views':
-            # YouTube no longer exposes `view_count` in flat channel/playlist listings, so we can no longer
-            # sort by views without fetching every video individually.  This may become possible again if we
-            # integrate the YouTube Data API.
-            raise UnrecoverableDownloadError(
-                'Downloading by "Most Views" is no longer supported because YouTube no longer provides view '
-                'counts in channel/playlist listings.  Please change this download to "Newest" or "Oldest".')
+            # Listing view counts are approximate ("3K" -> 3000); good enough for ordering.
+            logger.debug(f'Downloading most viewed videos from {download.url}')
+            if not any(i.get('view_count') is not None for i in downloads):
+                # Old yt-dlp (< 2026.07) does not extract view_count from YouTube's lockupViewModel
+                # listings.  Fail cleanly rather than downloading in arbitrary order.
+                raise UnrecoverableDownloadError(
+                    'yt-dlp did not report view counts for this channel/playlist.  Update yt-dlp '
+                    '(or change this download to "Newest"/"Oldest").')
+            downloads = sorted(downloads, key=lambda i: i.get('view_count') or 0, reverse=True)
 
         # Limit the videos that will be downloads (this allows the user to download the "top 100" videos of a Channel)
         if video_count_limit := settings.get('video_count_limit'):

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -708,12 +708,34 @@ async def test_download_playlist(test_session, test_directory, mock_video_extrac
     }
 
 
-def test_get_missing_videos_views_order_deprecated(test_session):
-    """The 'views' download order was deprecated.  YouTube no longer provides `view_count` in flat
-    channel/playlist listings, so a download configured for 'views' raises an unrecoverable error rather
-    than crashing with a KeyError or silently downloading in the wrong order."""
+def test_get_missing_videos_views_order(test_session):
+    """The 'views' download order sorts videos most-viewed-first.  Entries missing a `view_count`
+    (some listings omit it) sort last rather than raising a KeyError."""
     from modules.videos.downloader import channel_downloader
-    # Flat entries no longer contain a `view_count` key (matches current yt-dlp behavior).
+    download = Download(
+        url='https://www.youtube.com/@example/videos',
+        settings={'download_order': 'views'},
+        info_json={'entries': [
+            {'_type': 'url', 'id': 'a', 'title': 'a', 'url': 'https://youtube.com/watch?v=a', 'view_count': 918},
+            {'_type': 'url', 'id': 'b', 'title': 'b', 'url': 'https://youtube.com/watch?v=b'},  # No view_count.
+            {'_type': 'url', 'id': 'c', 'title': 'c', 'url': 'https://youtube.com/watch?v=c', 'view_count': 3000},
+        ]},
+    )
+    test_session.add(download)
+    test_session.commit()
+
+    missing_videos = channel_downloader.get_missing_videos(test_session, download)
+    assert missing_videos == [
+        'https://youtube.com/watch?v=c',
+        'https://youtube.com/watch?v=a',
+        'https://youtube.com/watch?v=b',
+    ]
+
+
+def test_get_missing_videos_views_order_no_view_counts(test_session):
+    """When no entry has a `view_count` (old yt-dlp does not extract it from YouTube's lockupViewModel
+    listings), the 'views' download order fails cleanly rather than downloading in arbitrary order."""
+    from modules.videos.downloader import channel_downloader
     download = Download(
         url='https://www.youtube.com/@example/videos',
         settings={'download_order': 'views'},

--- a/wrolpi/schema.py
+++ b/wrolpi/schema.py
@@ -301,9 +301,8 @@ class DownloadSettings:
         if not self.download_metadata_only:
             del self.download_metadata_only
 
-        # 'views' was deprecated: YouTube no longer provides view counts in channel/playlist listings.
-        if self.download_order not in (None, 'newest', 'oldest'):
-            raise ValidationError(f'Download order must be one of newest, oldest, or null.')
+        if self.download_order not in (None, 'newest', 'oldest', 'views'):
+            raise ValidationError(f'Download order must be one of newest, oldest, views, or null.')
 
         if self.video_format not in (None, 'mp4', 'mkv', 'ogg', 'webm'):
             raise ValidationError(f'Video format must be one of mp4, mkv, ogg, webm, or null.')

--- a/wrolpi/test/test_downloader.py
+++ b/wrolpi/test/test_downloader.py
@@ -914,18 +914,10 @@ def test_download_settings_coerces_numeric_strings():
     assert 'max_pages' not in req.settings
 
 
-@pytest.mark.parametrize('order', ['newest', 'oldest', None])
+@pytest.mark.parametrize('order', ['newest', 'oldest', 'views', None])
 def test_download_settings_accepts_valid_download_order(order):
     from wrolpi.schema import DownloadSettings
     DownloadSettings(download_order=order)
-
-
-def test_download_settings_rejects_deprecated_views_order():
-    """'views' download order was deprecated; YouTube no longer provides view counts in listings."""
-    from wrolpi.schema import DownloadSettings
-    from wrolpi.errors import ValidationError
-    with pytest.raises(ValidationError):
-        DownloadSettings(download_order='views')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Restores the "Most Views" channel/playlist download order that was deprecated in fcb64fed. The deprecation assumed YouTube removed view counts from listings, but YouTube only changed its listing markup to `lockupViewModel` — yt-dlp stable **2026.7.4** (via upstream [PR #16965](https://github.com/yt-dlp/yt-dlp/pull/16965)) now extracts `view_count` from it again. Verified live against a real channel `/videos` tab with our exact extraction path (`extract_info(..., process=False)`): flat entries return view counts.

Unlike the pre-deprecation implementation (which raised `KeyError` and retried forever), the restored sort degrades gracefully:

- Entries missing `view_count` sort last instead of crashing.
- If **no** entry has a `view_count` (device running yt-dlp older than ~2026.07), the download fails cleanly with `UnrecoverableDownloadError` telling the user to update yt-dlp or switch to Newest/Oldest.

Listing counts are approximate ("3K" → 3000) — fine for ordering. No `requirements.txt` change needed: the existing `>=2026.03.17` range picks up 2026.7.4 on new installs/upgrades.

## Changes

- `modules/videos/downloader.py`: `'views'` branch sorts by `view_count` descending with graceful degradation.
- `wrolpi/schema.py`: `'views'` accepted again as a valid `download_order`.
- `app/src/components/Vars.js`: "Most Views" back in the download-order dropdown.
- Tests: deprecation tests replaced with sort-order + no-counts-error tests (written TDD-first).

## Test plan

- [x] Full backend suite: 1553 passed, 5 skipped (`pytest -nauto`)
- [x] Frontend Jest suite: 746 passed (`CI=true npm test -- --watchAll=false`)
- [x] Live extraction check with yt-dlp 2026.7.4 against a real channel
- [ ] On-device check: create a channel download ordered by "Most Views", confirm children queue most-viewed-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)