### PR TITLE
Videos: a Channel's directory beats source_id when assigning a Video

### DIFF
--- a/modules/videos/channel/lib.py
+++ b/modules/videos/channel/lib.py
@@ -56,7 +56,9 @@ COD = Union[dict, Channel]
 def get_channel(session: Session, *, channel_id: int = None, source_id: str = None, url: str = None,
                 directory: str = None, name: str = None, return_dict: bool = True) -> COD:
     """
-    Attempt to find a Channel using the provided params.  The params are in order of reliability.
+    Attempt to find a Channel using the provided params.  The params are in order of reliability, except that
+    directory beats source_id/url: a Video's files must live in their Channel's directory, so the directory a file
+    is in reflects the user's intent and beats yt-dlp metadata.
 
     Raises UnknownChannel if no channel is found.
     """
@@ -65,18 +67,6 @@ def get_channel(session: Session, *, channel_id: int = None, source_id: str = No
     # Always eagerly load Collection to ensure name/directory/tag_id are available
     if channel_id:
         channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(id=channel_id).one_or_none()
-    if not channel and source_id:
-        channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(
-            source_id=source_id).one_or_none()
-    if not channel and url:
-        channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(url=url).one_or_none()
-    if not channel and url:
-        # Try to extract YouTube channel ID from the URL and match by source_id.
-        from modules.videos.common import get_youtube_channel_id
-        yt_channel_id = get_youtube_channel_id(url)
-        if yt_channel_id:
-            channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(
-                source_id=yt_channel_id).one_or_none()
     if not channel and directory:
         directory = Path(directory)
         if not directory.is_absolute():
@@ -93,6 +83,18 @@ def get_channel(session: Session, *, channel_id: int = None, source_id: str = No
             if channel:
                 break
             current = current.parent
+    if not channel and source_id:
+        channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(
+            source_id=source_id).one_or_none()
+    if not channel and url:
+        channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(url=url).one_or_none()
+    if not channel and url:
+        # Try to extract YouTube channel ID from the URL and match by source_id.
+        from modules.videos.common import get_youtube_channel_id
+        yt_channel_id = get_youtube_channel_id(url)
+        if yt_channel_id:
+            channel = session.query(Channel).options(joinedload(Channel.collection)).filter_by(
+                source_id=yt_channel_id).one_or_none()
     if not channel and name:
         channel = session.query(Channel).join(Collection).filter(Collection.name == name).one_or_none()
 

--- a/modules/videos/channel/test/test_lib.py
+++ b/modules/videos/channel/test/test_lib.py
@@ -65,6 +65,43 @@ def test_get_channel(test_session, test_directory, channel_factory):
         assert lib.get_channel(test_session, **p)
 
 
+def test_get_channel_directory_beats_source_id(test_session, test_directory, channel_factory):
+    """A Channel owning the directory wins over a Channel matching source_id/url.
+
+    A Video's files must live in their Channel's directory, so the directory a file is in reflects the user's
+    intent and beats yt-dlp metadata."""
+    source_id_channel = channel_factory(source_id='the source id', url='https://example.com/source-channel')
+    directory_channel = channel_factory(directory=test_directory / 'directory channel')
+
+    # Both source_id and directory match different Channels; the directory's Channel wins.
+    channel = lib.get_channel(
+        test_session,
+        source_id='the source id',
+        url='https://example.com/source-channel',
+        directory=str(test_directory / 'directory channel'),
+        return_dict=False,
+    )
+    assert channel == directory_channel
+
+    # A subdirectory of the Channel's directory also wins.
+    channel = lib.get_channel(
+        test_session,
+        source_id='the source id',
+        directory=str(test_directory / 'directory channel/2024'),
+        return_dict=False,
+    )
+    assert channel == directory_channel
+
+    # source_id still matches when the directory does not belong to any Channel.
+    channel = lib.get_channel(
+        test_session,
+        source_id='the source id',
+        directory=str(test_directory / 'not a channel directory'),
+        return_dict=False,
+    )
+    assert channel == source_id_channel
+
+
 @pytest.mark.asyncio
 async def test_channels_no_url(async_client, test_session, test_directory, test_channels_config):
     """Test that a Channel's URL is coerced to None if it is empty."""

--- a/modules/videos/test/test_lib.py
+++ b/modules/videos/test/test_lib.py
@@ -126,6 +126,33 @@ def test_validate_video(test_session, test_directory, video_factory, image_bytes
     assert {i.suffix for i in vid2.file_group.my_paths()} == {'.jpg', '.png', '.mp4'}
 
 
+def test_validate_video_directory_beats_info_json_channel(test_session, test_directory, channel_factory,
+                                                          video_factory):
+    """A Video in a Channel's directory belongs to that Channel, even when its info json names another
+    existing Channel.
+
+    Replicates a user report: videos placed in Channel B's directory did not appear on Channel B's page
+    because their info json named Channel A (which exists in the library), and the source_id match
+    was preferred over the directory."""
+    channel_a = channel_factory(source_id='channel_a_id', url='https://example.com/channel_a')
+    channel_b = channel_factory(directory=test_directory / 'videos/ChannelB')
+
+    video = video_factory(
+        with_video_file=channel_b.directory / 'The Title.mp4',
+        with_info_json={
+            'channel_id': 'channel_a_id',
+            'channel_url': 'https://example.com/channel_a',
+            'duration': 5,
+            'epoch': 12345678,
+            'title': 'The Title',
+        },
+    )
+    test_session.commit()
+
+    assert video.channel_id == channel_b.id, \
+        f'Video in ChannelB directory should belong to ChannelB, got channel_id={video.channel_id}'
+
+
 @pytest.mark.asyncio
 async def test_get_statistics(test_session, video_factory, channel_factory):
     # Can get statistics in empty DB.


### PR DESCRIPTION
## Summary

A user reported that videos sitting inside a Channel's directory did not show on that Channel's page. Their info json named a *different* existing Channel (a real `channel_id`/source_id), and `get_channel` preferred the source_id match over the directory match, so the videos were assigned to the other Channel. The Channel page filters strictly by `video.channel_id`, so they never appeared.

## Fix

Reorder `get_channel` (`modules/videos/channel/lib.py`) so the directory match — including its parent-directory walk for subdirectories — runs before the source_id/url matches:

- `channel_id` still beats everything.
- A file inside a Channel's directory is now assigned to that Channel, regardless of yt-dlp metadata.
- source_id/url still apply when the file is not inside any Channel's directory (e.g. singles downloaded to a generic directory) — unchanged behavior there.

This also aligns validation with `VideoDownloader._get_channel`, which already prefers the destination directory ("files must live in their channel's directory") — previously `validate_video` could clobber that decision on the next validation.

## Tests

- `test_get_channel_directory_beats_source_id` — unit test of the new priority, including subdirectory walk and the source_id fallback for non-channel directories.
- `test_validate_video_directory_beats_info_json_channel` — end-to-end replication of the user report: video file in Channel B's directory with an info json naming Channel A; the Video must belong to Channel B.

Both failed before the fix (video was assigned to Channel A) and pass after.

- Full backend suite: 1555 passed, 5 skipped
- Videos module: 271 passed
- Frontend Jest: 746 passed

## Notes

Existing misassigned videos will not self-heal automatically: `validate_video` only runs on (re)indexing, so affected files need a re-index to be reassigned. Reassignment also exposes the known stale `video_count` trigger bug (fires only on INSERT/DELETE, not UPDATE of channel_id), which is a separate open issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)