### PR TITLE
Hotspot: ship dnsmasq-base; NetworkManager requires it for hotspot DHCP

### DIFF
--- a/debian-live-config/config/package-lists/wrolpi.list.chroot
+++ b/debian-live-config/config/package-lists/wrolpi.list.chroot
@@ -13,6 +13,7 @@ chromium
 chromium-driver
 cpufrequtils
 curl
+dnsmasq-base
 dosfstools
 ethtool
 exfat-fuse
@@ -36,6 +37,7 @@ hostapd
 htop
 iotop
 iperf3
+iw
 kiwix
 kiwix-tools
 libboost-all-dev
@@ -76,6 +78,7 @@ python3-doc
 python3-full
 python3-pip
 python3-venv
+rfkill
 rsync
 samba
 smartmontools

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -163,6 +163,16 @@ if ! command -v gnome-disks &>/dev/null; then
     -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold gnome-disk-utility
 fi
 
+# Install dnsmasq-base if not already installed (NetworkManager needs it for the hotspot's
+# DHCP; it is only a Recommends of network-manager, so ISOs built with --apt-recommends
+# false shipped without it).  iw and rfkill are WiFi diagnostic tools.
+if ! command -v dnsmasq &>/dev/null; then
+  echo "Installing dnsmasq-base, iw, rfkill..."
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold dnsmasq-base iw rfkill
+fi
+
 # Clean up stale landing page (Controller now serves port 80 directly).
 rm -f /var/www/landing.html
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -166,7 +166,7 @@ fi
 # Install dnsmasq-base if not already installed (NetworkManager needs it for the hotspot's
 # DHCP; it is only a Recommends of network-manager, so ISOs built with --apt-recommends
 # false shipped without it).  iw and rfkill are WiFi diagnostic tools.
-if ! command -v dnsmasq &>/dev/null; then
+if ! command -v dnsmasq &>/dev/null || ! command -v iw &>/dev/null || ! command -v rfkill &>/dev/null; then
   echo "Installing dnsmasq-base, iw, rfkill..."
   apt-get update
   DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
## Summary

The WiFi hotspot fails to activate on every install made from the amd64 ISO. The ISO is built with `--apt-recommends false` (`debian-live-config/build.sh`), so `network-manager`'s Recommends were never installed — including `dnsmasq-base`, which NetworkManager's shared/hotspot IPv4 mode spawns for DHCP. We explicitly listed `wpasupplicant` in the package list but missed `dnsmasq-base`. (Ubuntu ships it with NetworkManager by default, which is why users report the hotspot "worked fine on Ubuntu".)

Found while debugging a user's fresh v0.27.0 install on a mini PC; confirmed by extracting the package manifest from the released ISO — `dnsmasq-base` is absent from the squashfs and from the offline pool.

## Changes

- `debian-live-config/config/package-lists/wrolpi.list.chroot`: add `dnsmasq-base`, plus `iw` and `rfkill` (the standard WiFi diagnostic tools, also dropped by no-recommends). This list is also installed by `scripts/install_debian_12.sh`, so fresh stock-Debian installs are covered too.
- `scripts/upgrade.sh`: idempotent install block (matching the existing Caddy/Samba/gnome-disk-utility pattern, non-interactive per the tty-less `wrolpi-upgrade.service` requirements) so all existing installs get the fix on their next upgrade. No-op on systems that already have dnsmasq-base (Ubuntu-style installs, RPi OS).

NetworkManager's NAT for the hotspot autodetects a firewall backend and `nftables` is already on the image, so no iptables change is needed.

## Test plan

- [x] `bash -n scripts/upgrade.sh`
- [x] Manually verified on the affected user's box: installing `dnsmasq-base` was sufficient for `nmcli device wifi hotspot` to activate (their remaining WiFi issue was an unrelated missing kernel driver for RTL8851BE)
- [ ] Next ISO build: confirm `dnsmasq-base` in `live/filesystem.packages` and hotspot toggle works on first boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)