### PR TITLE
Calculators: 4-Wire Kelvin segment, aluminum wire, copper table fixes

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -258,6 +258,17 @@ textarea.otp {
     background-color: transparent !important;
 }
 
+/* Semantic UI paints a definition table's empty corner cell white (background on the inverted
+   variant, white box-shadows on the celled/plain variants) to fake a "cut-out" corner on a white
+   page.  Our dark theme has a dark page, so the corner must be transparent with no shadow. */
+.ui.inverted.definition.table thead:not(.full-width) th:first-child,
+.ui.inverted.definition.table tfoot:not(.full-width) th:first-child,
+.ui.inverted.celled.definition.table thead:not(.full-width) th:first-child,
+.ui.inverted.celled.definition.table tfoot:not(.full-width) th:first-child {
+    background: transparent !important;
+    box-shadow: none !important;
+}
+
 /* Mobile-responsive Confirm modal */
 .ui.modal.themed-confirm {
     max-width: 95vw;

--- a/app/src/components/calculators/ElectricalCalculators.js
+++ b/app/src/components/calculators/ElectricalCalculators.js
@@ -175,14 +175,14 @@ export function OhmsLawCalculator({setVolts}) {
 }
 
 // Dropdown options for wire types
-const resistancesPerKFeet = {
+export const resistancesPerKFeet = {
     solid: {
         '0000 AWG': 0.049,
         '00 AWG': 0.0779,
         '0 AWG': 0.0982,
         '2 AWG': 0.1563,
         '4 AWG': 0.2485,
-        '6 AWG': 0.3134,
+        '6 AWG': 0.3951,
         '8 AWG': 0.628,
         '10 AWG': 0.9987,
         '12 AWG': 1.588,
@@ -194,9 +194,9 @@ const resistancesPerKFeet = {
     stranded: {
         '0000 AWG': 0.0608,
         '00 AWG': 0.0967,
-        '0 AWG': 0.022,
-        '2 AWG': 0.019,
-        '4 AWG': 0.038,
+        '0 AWG': 0.122,
+        '2 AWG': 0.194,
+        '4 AWG': 0.308,
         '6 AWG': 0.491,
         '8 AWG': 0.778,
         '10 AWG': 1.24,
@@ -205,8 +205,37 @@ const resistancesPerKFeet = {
         '16 AWG': 4.99,
         '18 AWG': 7.95,
     },
+    solid_aluminum: {
+        '0000 AWG': 0.0804,
+        '00 AWG': 0.128,
+        '0 AWG': 0.161,
+        '2 AWG': 0.256,
+        '4 AWG': 0.408,
+        '6 AWG': 0.648,
+        '8 AWG': 1.03,
+        '10 AWG': 1.64,
+        '12 AWG': 2.61,
+        '14 AWG': 4.14,
+        '16 AWG': 6.59,
+        '20 AWG': 16.7,
+        '24 AWG': 42.1,
+    },
+    stranded_aluminum: {
+        '0000 AWG': 0.082,
+        '00 AWG': 0.130,
+        '0 AWG': 0.164,
+        '2 AWG': 0.261,
+        '4 AWG': 0.416,
+        '6 AWG': 0.661,
+        '8 AWG': 1.05,
+        '10 AWG': 1.67,
+        '12 AWG': 2.66,
+        '14 AWG': 4.22,
+        '16 AWG': 6.72,
+        '18 AWG': 10.7,
+    },
 };
-const resistancesPerKm = {
+export const resistancesPerKm = {
     solid: {
         ['120 mm²']: 0.153,
         ['70 mm²']: 0.272,
@@ -236,6 +265,36 @@ const resistancesPerKm = {
         ['1 mm²']: 18.1,
         ['0.75 mm²']: 24.5,
         ['0.5 mm²']: 36.0
+    },
+    solid_aluminum: {
+        ['120 mm²']: 0.235,
+        ['70 mm²']: 0.403,
+        ['50 mm²']: 0.564,
+        ['25 mm²']: 1.13,
+        ['16 mm²']: 1.76,
+        ['10 mm²']: 2.82,
+        ['6 mm²']: 4.70,
+        ['4 mm²']: 7.05,
+        ['2.5 mm²']: 11.3,
+        ['1.5 mm²']: 18.8,
+        ['1 mm²']: 28.2,
+        ['0.75 mm²']: 37.6,
+        ['0.5 mm²']: 56.4
+    },
+    stranded_aluminum: {
+        ['120 mm²']: 0.240,
+        ['70 mm²']: 0.411,
+        ['50 mm²']: 0.575,
+        ['25 mm²']: 1.15,
+        ['16 mm²']: 1.80,
+        ['10 mm²']: 2.88,
+        ['6 mm²']: 4.79,
+        ['4 mm²']: 7.19,
+        ['2.5 mm²']: 11.5,
+        ['1.5 mm²']: 19.2,
+        ['1 mm²']: 28.8,
+        ['0.75 mm²']: 38.4,
+        ['0.5 mm²']: 57.5
     }
 };
 
@@ -244,6 +303,8 @@ const resistancesPerKm = {
 const wireTypeOptions = [
     {key: 'solid', text: 'Solid Copper', value: 'solid'},
     {key: 'stranded', text: 'Stranded Copper', value: 'stranded'},
+    {key: 'solid_aluminum', text: 'Solid Aluminum', value: 'solid_aluminum'},
+    {key: 'stranded_aluminum', text: 'Stranded Aluminum', value: 'stranded_aluminum'},
 ];
 
 // Helper function to calculate power loss
@@ -261,10 +322,7 @@ export const calcPowerLossPercent = (isSAE, volts, amps, resistancePerKiloLength
     return (voltageDrop / volts) * 100; // Return as a percentage
 };
 
-const PowerLossCalculator = ({volts, setVolts}) => {
-    const [wireType, setWireType] = useLocalStorage('calculators.power_loss.wire_type', 'solid');
-    const [isSAE, setIsSAE] = useLocalStorage('calculators.power_loss.is_sae', true);
-    const [length, setLength] = useLocalStorageInt('calculators.power_loss.length', 100);
+const PowerLossCalculator = ({volts, setVolts, wireType, setWireType, isSAE, setIsSAE, length, setLength}) => {
     const [ampsRange] = useState([1, 5, 10, 20, 40, 100]);
 
     const {inverted} = React.useContext(ThemeContext);
@@ -375,10 +433,104 @@ const PowerLossCalculator = ({volts, setVolts}) => {
     </Form>
 };
 
+// Resistance changes with temperature; the resistance tables are referenced at 20°C.
+export const COPPER_TEMP_COEFFICIENT = 0.00393; // per °C
+export const ALUMINUM_TEMP_COEFFICIENT = 0.00403; // per °C
+const REFERENCE_TEMPERATURE_C = 20;
+
+const tempCoefficientForWireType = (wireType) =>
+    wireType.includes('aluminum') ? ALUMINUM_TEMP_COEFFICIENT : COPPER_TEMP_COEFFICIENT;
+
+// Helper function to calculate the expected millivolt drop across a single wire (4-wire Kelvin measurement).
+export const calcKelvinMilliVoltDrop = (amps, resistancePerKiloLength, length,
+                                        temperatureC = REFERENCE_TEMPERATURE_C,
+                                        tempCoefficient = COPPER_TEMP_COEFFICIENT) => {
+    const temperatureFactor = 1 + tempCoefficient * (temperatureC - REFERENCE_TEMPERATURE_C);
+    const resistancePerLength = (resistancePerKiloLength * temperatureFactor) / 1000;
+    // Sense leads measure across the single conductor, so the length is NOT doubled.
+    const resistance = length * resistancePerLength;
+    return amps * resistance * 1000; // Volts to millivolts.
+};
+
+const FourWireKelvinCalculator = ({wireType, isSAE, length}) => {
+    const [ampsRange] = useState([1, 5, 10]);
+    // Stored in Celsius; displayed in Fahrenheit when SAE.  Default is room temperature.
+    const [temperatureC, setTemperatureC] = useLocalStorage(
+        'calculators.kelvin.temperature_c', REFERENCE_TEMPERATURE_C, parseFloat, (num) => num.toString());
+
+    const resistances = isSAE ? resistancesPerKFeet[wireType]
+        : resistancesPerKm[wireType];
+
+    const displayTemperature = isSAE ? roundDigits(temperatureC * 9 / 5 + 32, 1) : roundDigits(temperatureC, 1);
+    const handleTemperatureChange = (value) => {
+        const temperature = parseFloat(value);
+        setTemperatureC(isSAE ? (temperature - 32) * 5 / 9 : temperature);
+    };
+
+    return <Form>
+        <Header as='h1'>4-Wire Kelvin</Header>
+        <p>
+            Expected millivolt drop across {length} {isSAE ? 'feet' : 'meters'} of wire when driving a known
+            current through it.  Measure with separate sense leads at each end of the wire.
+            <InfoPopup
+                content='Uses the length and wire type from the Power Loss calculator above.  The length is NOT doubled because the sense leads measure across a single conductor.'/>
+        </p>
+
+        <Grid columns={2}>
+            <Grid.Row>
+                <Grid.Column mobile={12} tablet={12}>
+                    <Input fluid
+                           label={isSAE ? '°F' : '°C'}
+                           labelPosition='right'
+                           type='number'
+                           value={displayTemperature}
+                           onChange={(e, {value}) => handleTemperatureChange(value)}
+                           autoComplete="off"
+                    />
+                </Grid.Column>
+                <Grid.Column mobile={4} tablet={2}>
+                    <InfoPopup
+                        content='Wire temperature.  Resistances are referenced at 20°C (68°F) and corrected using the temperature coefficient of the wire material (copper 0.393% per °C, aluminum 0.403% per °C).'/>
+                </Grid.Column>
+            </Grid.Row>
+        </Grid>
+
+        <Table unstackable compact celled definition>
+            <TableHeader>
+                <TableRow>
+                    <TableHeaderCell/>
+                    {ampsRange.map(amp => <TableHeaderCell key={amp}>{amp}A</TableHeaderCell>)}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {Object.entries(resistances).map(([size, resistance]) => (
+                    <TableRow key={size}>
+                        <TableCell>{size}</TableCell>
+                        {ampsRange.map(amp => {
+                            const milliVolts = calcKelvinMilliVoltDrop(
+                                amp, resistance, length, temperatureC, tempCoefficientForWireType(wireType));
+                            return <TableCell key={`${size}-${amp}`}>
+                                {roundDigits(milliVolts, 1)} mV
+                            </TableCell>
+                        })}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    </Form>
+};
+
 export const ElectricalCalculators = () => {
     const [volts, setVolts] = useLocalStorageInt('calculators.electrical.volts', 120);
+    const [wireType, setWireType] = useLocalStorage('calculators.power_loss.wire_type', 'solid');
+    const [isSAE, setIsSAE] = useLocalStorage('calculators.power_loss.is_sae', true);
+    const [length, setLength] = useLocalStorageInt('calculators.power_loss.length', 100);
     return <Container>
         <Segment><OhmsLawCalculator setVolts={setVolts}/></Segment>
-        <Segment><PowerLossCalculator volts={volts} setVolts={setVolts}/></Segment>
+        <Segment><PowerLossCalculator volts={volts} setVolts={setVolts}
+                                      wireType={wireType} setWireType={setWireType}
+                                      isSAE={isSAE} setIsSAE={setIsSAE}
+                                      length={length} setLength={setLength}/></Segment>
+        <Segment><FourWireKelvinCalculator wireType={wireType} isSAE={isSAE} length={length}/></Segment>
     </Container>
 }

--- a/app/src/components/calculators/ElectricalCalculators.js
+++ b/app/src/components/calculators/ElectricalCalculators.js
@@ -455,15 +455,27 @@ export const calcKelvinMilliVoltDrop = (amps, resistancePerKiloLength, length,
 const FourWireKelvinCalculator = ({wireType, isSAE, length}) => {
     const [ampsRange] = useState([1, 5, 10]);
     // Stored in Celsius; displayed in Fahrenheit when SAE.  Default is room temperature.
+    const decodeTemperature = (value) => {
+        const temperature = parseFloat(value);
+        return Number.isFinite(temperature) ? temperature : REFERENCE_TEMPERATURE_C;
+    };
     const [temperatureC, setTemperatureC] = useLocalStorage(
-        'calculators.kelvin.temperature_c', REFERENCE_TEMPERATURE_C, parseFloat, (num) => num.toString());
+        'calculators.kelvin.temperature_c', REFERENCE_TEMPERATURE_C, decodeTemperature, (num) => num.toString());
 
     const resistances = isSAE ? resistancesPerKFeet[wireType]
         : resistancesPerKm[wireType];
 
     const displayTemperature = isSAE ? roundDigits(temperatureC * 9 / 5 + 32, 1) : roundDigits(temperatureC, 1);
     const handleTemperatureChange = (value) => {
+        if (value === '') {
+            // Never store NaN; fall back to room temperature when the input is cleared.
+            setTemperatureC(REFERENCE_TEMPERATURE_C);
+            return;
+        }
         const temperature = parseFloat(value);
+        if (!Number.isFinite(temperature)) {
+            return;
+        }
         setTemperatureC(isSAE ? (temperature - 32) * 5 / 9 : temperature);
     };
 

--- a/app/src/components/calculators/ElectricalCalculators.test.js
+++ b/app/src/components/calculators/ElectricalCalculators.test.js
@@ -1,9 +1,76 @@
-import {calcPowerLossPercent} from "./ElectricalCalculators";
+import {
+    ALUMINUM_TEMP_COEFFICIENT,
+    calcKelvinMilliVoltDrop,
+    calcPowerLossPercent,
+    resistancesPerKFeet,
+    resistancesPerKm,
+} from "./ElectricalCalculators";
 
 describe('calcPowerLossPercent Function Tests', () => {
     test('should correctly calculate power loss percentage', () => {
         // Parameters: isSAE, volts, amps, resistancePerKm, length
         const percent = calcPowerLossPercent(true, 120, 8.33, 2.58, 200);
         expect(percent).toBeCloseTo(7.16, 2); // Use expected correct value and precision
+    });
+});
+
+describe('calcKelvinMilliVoltDrop Function Tests', () => {
+    test('should correctly calculate millivolt drop', () => {
+        // Parameters: amps, resistancePerKiloLength, length
+        // 100 feet of 10 AWG solid copper (0.9987 Ω/kft) at 1A: 0.09987 Ω * 1A = 99.87 mV
+        expect(calcKelvinMilliVoltDrop(1, 0.9987, 100)).toBeCloseTo(99.87, 2);
+        // Same wire at 10A: 998.7 mV
+        expect(calcKelvinMilliVoltDrop(10, 0.9987, 100)).toBeCloseTo(998.7, 1);
+        // Length is not doubled: 50 feet at 5A is a quarter of 100 feet at 10A.
+        expect(calcKelvinMilliVoltDrop(5, 0.9987, 50)).toBeCloseTo(calcKelvinMilliVoltDrop(10, 0.9987, 100) / 4, 5);
+    });
+
+    test('should return zero for zero length or amps', () => {
+        expect(calcKelvinMilliVoltDrop(0, 0.9987, 100)).toBe(0);
+        expect(calcKelvinMilliVoltDrop(1, 0.9987, 0)).toBe(0);
+    });
+
+    test('should correct resistance for temperature', () => {
+        // At the 20°C reference temperature, no correction is applied.
+        expect(calcKelvinMilliVoltDrop(1, 0.9987, 100, 20)).toBeCloseTo(99.87, 2);
+        // Warmer wire has more resistance: 30°C is a 3.93% increase.
+        expect(calcKelvinMilliVoltDrop(1, 0.9987, 100, 30)).toBeCloseTo(99.87 * 1.0393, 2);
+        // Colder wire has less resistance: 0°C is a 7.86% decrease.
+        expect(calcKelvinMilliVoltDrop(1, 0.9987, 100, 0)).toBeCloseTo(99.87 * 0.9214, 2);
+    });
+
+    test('should use the given temperature coefficient', () => {
+        // 100 feet of 10 AWG solid aluminum (1.64 Ω/kft) at 1A and 30°C: 164 mV plus aluminum's 4.03% increase.
+        expect(calcKelvinMilliVoltDrop(1, 1.64, 100, 30, ALUMINUM_TEMP_COEFFICIENT))
+            .toBeCloseTo(164 * 1.0403, 2);
+    });
+});
+
+describe('Resistance Table Sanity Tests', () => {
+    // The tables list wire sizes from largest to smallest, so resistance must strictly increase.
+    test.each([
+        ...Object.entries(resistancesPerKFeet),
+        ...Object.entries(resistancesPerKm),
+    ])('%s resistances increase as the wire gets smaller', (wireType, resistances) => {
+        const values = Object.values(resistances);
+        for (let i = 1; i < values.length; i++) {
+            expect(values[i]).toBeGreaterThan(values[i - 1]);
+        }
+    });
+
+    test('solid copper matches published values', () => {
+        // Published solid copper resistance at 20°C is 0.3951 Ω/kft for 6 AWG.
+        expect(resistancesPerKFeet.solid['6 AWG']).toBeCloseTo(0.3951, 2);
+    });
+
+    test('stranded copper is a consistent ratio of solid copper', () => {
+        // The stranded copper table was built as solid × 1.24; every entry must match that ratio.
+        for (const [size, resistance] of Object.entries(resistancesPerKFeet.stranded)) {
+            const solid = resistancesPerKFeet.solid[size];
+            if (solid === undefined) {
+                continue; // Stranded has 18 AWG which solid does not.
+            }
+            expect(resistance / solid).toBeCloseTo(1.24, 1);
+        }
     });
 });


### PR DESCRIPTION
## Summary

Adds a **4-Wire Kelvin** segment to the Electrical Calculator: a table of expected millivolt drop across a single wire at 1A, 5A, and 10A, so a wire run can be verified by driving a known current and measuring with separate sense leads.

* Shares length, SAE/IEC units, and wire type with the Power Loss calculator (state lifted to the parent; localStorage keys unchanged). Length is **not** doubled — the sense leads measure across one conductor.
* Wire temperature input (defaults to room temperature; °F/°C follows the SAE toggle, stored canonically in Celsius) corrects resistance via the material's temperature coefficient (Cu 0.393%/°C, Al 0.403%/°C, referenced at 20°C).
* New **Solid Aluminum** and **Stranded Aluminum** wire types with published resistance tables for both unit systems, used by Power Loss and Kelvin tables.

## Bug fixes

* **Copper resistance data:** solid 6 AWG was 0.3134 instead of the published 0.3951 Ω/kft, and stranded 0/2/4 AWG were decimal typos (0.022/0.019/0.038 → 0.122/0.194/0.308; the stranded table is solid × 1.24 throughout, which back-confirms both fixes). The old values understated voltage drop — stranded 0/2/4 by ~6–8× — making undersized wire look safe.
* **Dark mode:** Semantic UI hardcodes a white background on a definition table's empty corner cell (it assumes an inverted table sits on a white page), which rendered as a white square on our dark theme. Overridden to transparent for inverted tables only; affects every definition table in the app.

## Testing

* New unit tests: Kelvin mV math (incl. no-doubling scaling), temperature correction at/above/below reference, aluminum coefficient, table monotonicity across all 8 tables, solid-copper published value spot check, stranded/solid ratio consistency. The data tests fail against the old copper values.
* Full frontend suite passes: 760 tests, 47 suites.
* Verified in the browser (light + dark): shared inputs update both tables live, aluminum values correct (10 AWG Al = 164 mV @ 1A/100ft), 104°F shows the expected +7.86% on copper, corner cell blends in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)