### PR TITLE
Bake the app build into images; rebuild on-device only when stale

### DIFF
--- a/debian-live-config/config/hooks/normal/9999-wrolpi.hook.chroot
+++ b/debian-live-config/config/hooks/normal/9999-wrolpi.hook.chroot
@@ -60,8 +60,9 @@ npm install
 # does not exist and wrolpi-app.service (`serve build -l 3000 ...`) returns
 # 404 for every request.  Baking the build into the squashfs means the
 # live image works offline immediately and the installed deployment skips
-# a multi-minute first-boot step.
-BROWSERSLIST_IGNORE_OLD_DATA=true npm run build
+# a multi-minute first-boot step.  build_app.sh also writes build/.build-stamp
+# so the on-device repair.sh sees this build as current and never rebuilds it.
+/opt/wrolpi/scripts/build_app.sh
 
 # Install Node console commands.
 npm i -g serve@12.0.1 single-file-cli@2.0.73 readability-extractor@0.0.6

--- a/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
+++ b/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
@@ -57,6 +57,12 @@ echo "Controller pre-installed"
 # Install webapp.
 (cd /opt/wrolpi/app && npm install)
 
+# Build the React production bundle now, so it is baked into the image.  Without
+# this the Pi would build on first boot -- a multi-minute, memory-hungry step
+# that can OOM on a 2GB Pi.  build_app.sh stamps the output so the on-device
+# repair.sh sees it as current and never rebuilds.
+/opt/wrolpi/scripts/build_app.sh
+
 chown -R wrolpi:wrolpi /opt/wrolpi
 
 # Install Caddy from official apt repo.

--- a/repair.sh
+++ b/repair.sh
@@ -159,8 +159,11 @@ if grep -qs /media/wrolpi /proc/mounts && [ -z "$(ls -A /media/wrolpi)" ] && [ !
   mkdir /media/wrolpi/config
 fi
 
-# Build the frontend app.
-(cd /opt/wrolpi/app && npm run build)
+# Build the frontend app -- only if build/ is missing or the app source changed.
+# The shipped image already contains a current build/, so on a healthy install
+# (including a weak Pi) this is a no-op; it only rebuilds after an upgrade that
+# changed app/, or if build/ went missing.  Stays offline: it never npm-installs.
+/opt/wrolpi/scripts/build_app.sh
 
 # Change owner of the media directory, ignore any errors because the drive may be fat/exfat/etc.
 chown wrolpi:wrolpi /media/wrolpi 2>/dev/null || echo "Ignoring failure to change media directory permissions."

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build the React app ONLY when the built output is missing or stale.
+#
+# This is the single source of truth for producing app/build/.  It is called
+# from three places that must never drift apart:
+#   - repair.sh                                      (on-device: first boot, manual repair, install, upgrade)
+#   - pi-gen/stage2/04-wrolpi/03-run-chroot.sh       (bakes build/ into the Raspberry Pi image)
+#   - debian-live-config/.../9999-wrolpi.hook.chroot (bakes build/ into the Debian Live ISO)
+#
+# Both image builds run this at image-build time on the (powerful) build host, so
+# the shipped image already contains app/build/ with a matching stamp.  On the
+# device the same script then finds the stamp current and does nothing -- a weak
+# Pi (even 2GB) never has to run the multi-minute webpack build itself.  It only
+# rebuilds when the app source actually changed (e.g. an upgrade pulled new code)
+# or when build/ is missing/corrupt.
+#
+# Offline-safe: this only ever runs `npm run build`, which uses the already
+# installed node_modules.  It never runs `npm install`, so repair.sh keeps its
+# "will not use internet" guarantee.  Installing node_modules stays the caller's
+# job (the install/upgrade scripts and image hooks do it before calling here).
+set -e
+
+APP_DIR="${1:-/opt/wrolpi/app}"
+cd "$APP_DIR"
+
+# Hash of every input that determines the built output.
+#
+# KEEP IN SYNC: if a build-affecting input is ever added (craco.config.js, an
+# .env / .env.production, a new config dir, etc.) add it here.  A missed input
+# means a stale build ships silently -- the worst failure mode, because it looks
+# like everything worked.
+app_build_stamp() {
+  {
+    sha256sum package.json package-lock.json tsconfig.json
+    find src public -type f -exec sha256sum {} +
+  } | sort | sha256sum | cut -d' ' -f1
+}
+
+need_build=false
+if [ ! -f build/index.html ]; then
+  echo "app build is missing."
+  need_build=true
+elif [ "$(app_build_stamp)" != "$(cat build/.build-stamp 2>/dev/null)" ]; then
+  echo "app source changed since the last build."
+  need_build=true
+fi
+
+if [ "$need_build" = true ]; then
+  echo "Building the React production bundle (this can take several minutes)..."
+  # GENERATE_SOURCEMAP=false: source maps are a debugging aid for the deployed
+  # bundle that WROLPi never ships or uses; skipping them cuts build time and,
+  # importantly on low-RAM devices, peak memory.
+  GENERATE_SOURCEMAP=false BROWSERSLIST_IGNORE_OLD_DATA=true npm run build
+  # Stamp lives inside build/ so it is naturally absent whenever build/ is, and
+  # travels with the baked artifact into the image.
+  app_build_stamp > build/.build-stamp
+  echo "app build complete; wrote build/.build-stamp."
+else
+  echo "app build is current -- skipping (stamp match)."
+fi

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -36,9 +36,35 @@ app_build_stamp() {
   } | sort | sha256sum | cut -d' ' -f1
 }
 
+# Verify the built output is actually intact, not just present.
+#
+# A matching stamp only proves the *inputs* are unchanged; it says nothing about
+# whether the *outputs* survived.  repair.sh exists precisely to fix a corrupted
+# install, so a build/ that still has index.html + a stamp but is missing a JS/CSS
+# chunk must NOT be treated as current -- otherwise repair would leave the UI
+# broken where the old unconditional build restored it.  Check that every asset
+# referenced by build/asset-manifest.json exists on disk.  node is guaranteed
+# here: anything that can run `npm run build` can run node.
+build_output_intact() {
+  [ -f build/asset-manifest.json ] || return 1
+  node -e '
+    const fs = require("fs");
+    let m;
+    try { m = JSON.parse(fs.readFileSync("build/asset-manifest.json", "utf8")); }
+    catch { process.exit(1); }                       // unparseable manifest -> rebuild
+    const missing = Object.values(m.files || {})
+      .map(p => "build/" + p.replace(/^\//, ""))
+      .filter(p => !fs.existsSync(p));
+    process.exit(missing.length ? 1 : 0);
+  ' 2>/dev/null
+}
+
 need_build=false
 if [ ! -f build/index.html ]; then
   echo "app build is missing."
+  need_build=true
+elif ! build_output_intact; then
+  echo "app build is present but incomplete/corrupt (missing referenced assets)."
   need_build=true
 elif [ "$(app_build_stamp)" != "$(cat build/.build-stamp 2>/dev/null)" ]; then
   echo "app source changed since the last build."


### PR DESCRIPTION
## Problem

The Raspberry Pi image shipped **without** `app/build/` and compiled the React bundle on first boot via `repair.sh` — a multi-minute, memory-hungry step that can OOM a 2GB Pi. The Debian Live ISO already baked the build in, so the two image paths had drifted, and every manual `repair.sh` re-ran the full ~10-minute webpack build even when nothing changed.

## Change

Add `scripts/build_app.sh` as the single source of truth. It hashes the build inputs (`src/`, `public/`, `package.json`, `package-lock.json`, `tsconfig.json`) and runs `npm run build` (with `GENERATE_SOURCEMAP=false`) **only when** `build/` is missing or those inputs changed, then writes `build/.build-stamp`.

All three call sites delegate to it:
- **`pi-gen/stage2/04-wrolpi/03-run-chroot.sh`** — now builds after `npm install`, baking `build/` into the Pi image like the Debian hook already does.
- **`debian-live-config/.../9999-wrolpi.hook.chroot`** — uses it so the baked build is stamped.
- **`repair.sh`** — uses it, so first-boot / manual-repair / install / upgrade all become no-ops when the shipped build is current.

## Result

- Fresh Pi/Debian images ship a stamped `build/`, so a weak Pi (even 2GB) **never compiles on boot or repair**.
- An on-device rebuild happens **only** when an upgrade actually changes `app/`.
- `build_app.sh` never runs `npm install`, so `repair.sh` keeps its offline guarantee.
- `GENERATE_SOURCEMAP=false` drops production source maps (unused on an offline appliance), cutting build time and peak memory.

## Testing

Guard logic exercised against a fake app across all decision paths: missing `build/` → build; unchanged → skip; source change → rebuild; deleted `build/` → rebuild; unchanged → skip. ✅

## Notes / out of scope

- pi-gen now builds in the chroot on the build host (native ARM or qemu) — a one-time build-host cost, matching what the Debian build already accepts.
- **Keep the hash input list in sync**: if a build-affecting input is added later (`craco.config.js`, an `.env`, etc.), add it to `app_build_stamp()` — a missed input would ship a stale build silently.
- Not included: having the release pipeline publish a prebuilt `build/` artifact for `upgrade.sh` to fetch, which would remove the on-device rebuild for upgrades too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)