### PR TITLE
Bake tippecanoe into the Raspberry Pi image

### DIFF
--- a/pi-gen/stage2/04-wrolpi/01-packages-nr
+++ b/pi-gen/stage2/04-wrolpi/01-packages-nr
@@ -42,6 +42,7 @@ libgeos++-dev
 libgeos-dev
 libicu-dev
 libproj-dev
+libsqlite3-dev
 libssl-dev
 libtiff-dev
 libtool
@@ -73,3 +74,4 @@ vim
 vlc
 wget
 zim-tools
+zlib1g-dev

--- a/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
+++ b/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
@@ -32,6 +32,24 @@ chmod +x /usr/local/bin/deno
 rm /tmp/deno.zip
 deno --version
 
+# Build and bake in tippecanoe (used to build map search indexes).  Without this
+# the Pi compiles it on first boot/upgrade via scripts/install_protomaps.sh -- a
+# multi-minute, CPU-heavy C++ build on weak hardware.  The Debian Live image
+# already bakes it in; this brings the Pi image to parity.  Build deps
+# (build-essential, libsqlite3-dev, zlib1g-dev) come from 01-packages-nr.  Hash
+# pinned to the source tarball (arch-independent) to detect upstream tampering.
+TIPPECANOE_VERSION="2.79.0"
+TIPPECANOE_SHA256="b0fd9df49b6efc988288ea48774822c6de19eb48428017f27ee0b3b01d44f05d"
+TIPPECANOE_BUILD_DIR=$(mktemp -d)
+curl -fsSL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz" \
+  -o /tmp/tippecanoe.tar.gz
+echo "${TIPPECANOE_SHA256}  /tmp/tippecanoe.tar.gz" | sha256sum -c -
+tar -xz -C "${TIPPECANOE_BUILD_DIR}" --strip-components=1 -f /tmp/tippecanoe.tar.gz
+rm /tmp/tippecanoe.tar.gz
+(cd "${TIPPECANOE_BUILD_DIR}" && make -j"$(nproc)" && make install)
+rm -rf "${TIPPECANOE_BUILD_DIR}"
+tippecanoe --version
+
 # Put the latest WROLPi in /opt/wrolpi.
 git clone -b "${WROLPI_BRANCH:-release}" https://github.com/lrnselfreliance/wrolpi.git /opt/wrolpi
 # `git config --global` needs HOME, which is empty when the build runs under


### PR DESCRIPTION
## Problem

The Debian Live image builds **tippecanoe** at image-build time (`9999-wrolpi.hook.chroot`), but **pi-gen never did**. So a fresh Raspberry Pi compiled tippecanoe from source on its first boot/upgrade via `scripts/install_protomaps.sh` — a multi-minute, CPU-heavy C++ build on the weakest hardware WROLPi targets. This is the same "Debian bakes it, pi-gen doesn't" asymmetry recently fixed for the React app build (#536).

## Change

- Build `tippecanoe 2.79.0` in the stage2 chroot (`03-run-chroot.sh`), mirroring the Debian hook: SHA-pinned tarball, `make -j$(nproc) && make install`. The pin is the **source** tarball, so the same hash is valid on arm64.
- Add the two missing build deps to `01-packages-nr`: `libsqlite3-dev` and `zlib1g-dev` (`build-essential` was already present). Debian carries these same three in its package list.

## Why this is safe on upgrades

`install_protomaps.sh`'s `install_tippecanoe()` is guarded: if `tippecanoe --version` already equals `2.79.0`, it skips the build. `make install` puts `tippecanoe`/`tippecanoe-decode` on `PATH`, so a baked image satisfies the guard → **no on-device compile on first boot or subsequent upgrades**. The build only recurs when the pinned version actually bumps (a legitimate one-time rebuild).

## Scope

- Baking the **pmtiles CLI** into pi-gen is intentionally left out: it's a quick prebuilt-binary download (not a compile), and pinning it needs the arm64 release checksum. It continues to install on first boot via `install_protomaps.sh`. Easy follow-up if desired.

## Testing

- `bash -n` on the chroot script passes.
- Logic verified against `install_protomaps.sh`'s guard: baked `tippecanoe-decode` + matching version → guard returns early.
- Full validation requires a pi-gen image build (compiles tippecanoe in the aarch64 chroot); not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)