### PR TITLE
Consolidate map-tool install into a shared script

### DIFF
--- a/debian-live-config/config/hooks/normal/9999-wrolpi.hook.chroot
+++ b/debian-live-config/config/hooks/normal/9999-wrolpi.hook.chroot
@@ -119,33 +119,12 @@ mkdir /media/wrolpi
 [[ -f /opt/wrolpi-blobs/map-overview.pmtiles && -s /opt/wrolpi-blobs/map-overview.pmtiles ]] || \
   (echo "ERROR: map-overview.pmtiles missing from /opt/wrolpi-blobs!" && exit 1)
 
-# Bake in pmtiles CLI so first boot does not need internet.
-# Mirrors scripts/install_protomaps.sh; duplicated here because that script's
-# migration logic relies on a running systemd, which is not present in chroot.
-# Hash pinned to detect tampering of the upstream release artifact.
-PMTILES_VERSION="v1.30.1"
-PMTILES_SHA256="23a2a2222f658320b539ccd06ac3b9b3b803ecbdd39a6cb5249d2ce2e16e38ae"
-curl -fsSL "https://github.com/protomaps/go-pmtiles/releases/download/${PMTILES_VERSION}/go-pmtiles_${PMTILES_VERSION#v}_Linux_x86_64.tar.gz" \
-  -o /tmp/pmtiles.tar.gz
-echo "${PMTILES_SHA256}  /tmp/pmtiles.tar.gz" | sha256sum -c -
-tar -xz -C /usr/local/bin/ -f /tmp/pmtiles.tar.gz pmtiles
-rm /tmp/pmtiles.tar.gz
-chmod +x /usr/local/bin/pmtiles
-pmtiles version
-
-# Build and bake in tippecanoe (used to build map search indexes).
-# Hash pinned to detect tampering of the upstream release tarball.
-TIPPECANOE_VERSION="2.79.0"
-TIPPECANOE_SHA256="b0fd9df49b6efc988288ea48774822c6de19eb48428017f27ee0b3b01d44f05d"
-TIPPECANOE_BUILD_DIR=$(mktemp -d)
-curl -fsSL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz" \
-  -o /tmp/tippecanoe.tar.gz
-echo "${TIPPECANOE_SHA256}  /tmp/tippecanoe.tar.gz" | sha256sum -c -
-tar -xz -C "${TIPPECANOE_BUILD_DIR}" --strip-components=1 -f /tmp/tippecanoe.tar.gz
-rm /tmp/tippecanoe.tar.gz
-(cd "${TIPPECANOE_BUILD_DIR}" && make -j"$(nproc)" && make install)
-rm -rf "${TIPPECANOE_BUILD_DIR}"
-tippecanoe --version
+# Bake in the map toolchain (pmtiles CLI + tippecanoe) so first boot does not
+# need internet.  Shared with pi-gen and on-device upgrades via a single script
+# so versions/pins live in one place.  It is safe in the chroot: unlike
+# install_protomaps.sh it contains no migration logic that needs a running
+# systemd.
+/opt/wrolpi/wrolpi/scripts/install_map_tools.sh
 
 # Install WROLPi Help.
 /opt/wrolpi/scripts/install_help_service.sh

--- a/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
+++ b/pi-gen/stage2/04-wrolpi/03-run-chroot.sh
@@ -32,30 +32,18 @@ chmod +x /usr/local/bin/deno
 rm /tmp/deno.zip
 deno --version
 
-# Build and bake in tippecanoe (used to build map search indexes).  Without this
-# the Pi compiles it on first boot/upgrade via scripts/install_protomaps.sh -- a
-# multi-minute, CPU-heavy C++ build on weak hardware.  The Debian Live image
-# already bakes it in; this brings the Pi image to parity.  Build deps
-# (build-essential, libsqlite3-dev, zlib1g-dev) come from 01-packages-nr.  Hash
-# pinned to the source tarball (arch-independent) to detect upstream tampering.
-TIPPECANOE_VERSION="2.79.0"
-TIPPECANOE_SHA256="b0fd9df49b6efc988288ea48774822c6de19eb48428017f27ee0b3b01d44f05d"
-TIPPECANOE_BUILD_DIR=$(mktemp -d)
-curl -fsSL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz" \
-  -o /tmp/tippecanoe.tar.gz
-echo "${TIPPECANOE_SHA256}  /tmp/tippecanoe.tar.gz" | sha256sum -c -
-tar -xz -C "${TIPPECANOE_BUILD_DIR}" --strip-components=1 -f /tmp/tippecanoe.tar.gz
-rm /tmp/tippecanoe.tar.gz
-(cd "${TIPPECANOE_BUILD_DIR}" && make -j"$(nproc)" && make install)
-rm -rf "${TIPPECANOE_BUILD_DIR}"
-tippecanoe --version
-
 # Put the latest WROLPi in /opt/wrolpi.
 git clone -b "${WROLPI_BRANCH:-release}" https://github.com/lrnselfreliance/wrolpi.git /opt/wrolpi
 # `git config --global` needs HOME, which is empty when the build runs under
 # systemd (the release poller service has no HOME); set it to root's home.
 export HOME=/root
 git config --global --add safe.directory /opt/wrolpi
+
+# Install the map toolchain (pmtiles CLI + tippecanoe).  Shared with the Debian
+# Live build and on-device upgrades so versions/pins live in one place.  Baking
+# it in keeps a fresh Pi from compiling tippecanoe on first boot -- a slow,
+# CPU-heavy step on weak hardware.
+/opt/wrolpi/wrolpi/scripts/install_map_tools.sh
 
 # Install Python requirements.  Try multiple times because pypi may stop responding.
 python3 -m venv /opt/wrolpi/venv

--- a/scripts/install_protomaps.sh
+++ b/scripts/install_protomaps.sh
@@ -6,64 +6,11 @@
 set -e
 set -x
 
-# --- Install/upgrade pmtiles CLI ---
-
-install_pmtiles() {
-    PMTILES_VERSION="v1.30.1"
-    ARCH=$(uname -m)
-    if [ "$ARCH" = "aarch64" ]; then
-        PMTILES_ARCH="arm64"
-    elif [ "$ARCH" = "x86_64" ]; then
-        PMTILES_ARCH="amd64"
-    else
-        echo "Unsupported architecture for pmtiles: $ARCH"
-        return 1
-    fi
-
-    # Check if already installed at correct version.
-    if command -v pmtiles &>/dev/null; then
-        CURRENT=$(pmtiles version 2>&1 | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
-        if [ "$CURRENT" = "$PMTILES_VERSION" ]; then
-            echo "pmtiles ${PMTILES_VERSION} already installed"
-            return 0
-        fi
-    fi
-
-    echo "Installing pmtiles ${PMTILES_VERSION} for ${ARCH}..."
-    curl -fsSL "https://github.com/protomaps/go-pmtiles/releases/download/${PMTILES_VERSION}/go-pmtiles_${PMTILES_VERSION#v}_Linux_${PMTILES_ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin/ pmtiles
-    chmod +x /usr/local/bin/pmtiles
-    pmtiles version
-}
-
-install_pmtiles || echo "pmtiles CLI installation failed, continuing..."
-
-# --- Install/upgrade tippecanoe (for map search index building) ---
-
-install_tippecanoe() {
-    TIPPECANOE_VERSION="2.79.0"
-
-    # Check if already installed at correct version.
-    if command -v tippecanoe-decode &>/dev/null; then
-        CURRENT=$(tippecanoe --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
-        if [ "$CURRENT" = "$TIPPECANOE_VERSION" ]; then
-            echo "tippecanoe ${TIPPECANOE_VERSION} already installed"
-            return 0
-        fi
-    fi
-
-    echo "Building tippecanoe ${TIPPECANOE_VERSION}..."
-    apt-get install -y build-essential libsqlite3-dev zlib1g-dev
-
-    TIPPECANOE_BUILD_DIR=$(mktemp -d)
-    curl -fsSL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz" \
-      | tar -xz -C "${TIPPECANOE_BUILD_DIR}" --strip-components=1
-    cd "${TIPPECANOE_BUILD_DIR}" && make -j$(nproc) && make install
-    rm -rf "${TIPPECANOE_BUILD_DIR}"
-    tippecanoe --version
-}
-
-install_tippecanoe || echo "tippecanoe installation failed, continuing..."
+# --- Install/upgrade the map toolchain (pmtiles CLI + tippecanoe) ---
+# Shared with the pi-gen and Debian Live image builds so the versions and hash
+# pins live in one place.  Version-guarded, so this is a no-op when the running
+# image already baked in the current versions.
+/opt/wrolpi/wrolpi/scripts/install_map_tools.sh || echo "Map tool installation failed, continuing..."
 
 # --- Migrate from old map stack (runs once) ---
 

--- a/wrolpi/scripts/install_map_tools.sh
+++ b/wrolpi/scripts/install_map_tools.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Install WROLPi's map toolchain: the pmtiles CLI (a prebuilt Go binary) and
+# tippecanoe (compiled from source, used to build map search indexes).
+#
+# This is the single source of truth, called by every place that provisions a
+# WROLPi so a version bump only has to be made here:
+#   - scripts/install_protomaps.sh                        (on-device upgrade)
+#   - pi-gen/stage2/04-wrolpi/03-run-chroot.sh            (Raspberry Pi image build)
+#   - debian-live-config/config/hooks/normal/9999-wrolpi.hook.chroot  (Debian Live ISO build)
+#
+# Baking the tools into an image and running this again on-device stay
+# consistent because each installer is version-guarded: a tool already at the
+# pinned version is left untouched, so on-device runs are no-ops until the
+# pinned version actually changes.  Upstream artifacts are SHA-pinned to detect
+# tampering.  Run as root: installs into /usr/local/bin and apt-installs build
+# dependencies.
+set -e
+
+PMTILES_VERSION="v1.30.1"
+# Per-arch SHA256 of the Linux release tarballs (go-pmtiles ships prebuilt binaries).
+PMTILES_SHA256_amd64="23a2a2222f658320b539ccd06ac3b9b3b803ecbdd39a6cb5249d2ce2e16e38ae"
+PMTILES_SHA256_arm64="a1f9f42d8317ab1fadc25dd050e208547f32a3f99a4b90e7cb8fd6030f143d8e"
+
+TIPPECANOE_VERSION="2.79.0"
+# SHA256 of the *source* tarball -- arch-independent, so one value covers every build.
+TIPPECANOE_SHA256="b0fd9df49b6efc988288ea48774822c6de19eb48428017f27ee0b3b01d44f05d"
+
+install_pmtiles() {
+  local arch sha
+  case "$(uname -m)" in
+    aarch64) arch="arm64"; sha="${PMTILES_SHA256_arm64}" ;;
+    x86_64) arch="amd64"; sha="${PMTILES_SHA256_amd64}" ;;
+    *) echo "Unsupported architecture for pmtiles: $(uname -m)"; return 1 ;;
+  esac
+
+  if command -v pmtiles &>/dev/null; then
+    local current
+    current=$(pmtiles version 2>&1 | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+    if [ "${current}" = "${PMTILES_VERSION}" ]; then
+      echo "pmtiles ${PMTILES_VERSION} already installed"
+      return 0
+    fi
+  fi
+
+  echo "Installing pmtiles ${PMTILES_VERSION} (${arch})..."
+  curl -fsSL "https://github.com/protomaps/go-pmtiles/releases/download/${PMTILES_VERSION}/go-pmtiles_${PMTILES_VERSION#v}_Linux_${arch}.tar.gz" \
+    -o /tmp/pmtiles.tar.gz
+  echo "${sha}  /tmp/pmtiles.tar.gz" | sha256sum -c -
+  tar -xz -C /usr/local/bin/ -f /tmp/pmtiles.tar.gz pmtiles
+  rm -f /tmp/pmtiles.tar.gz
+  chmod +x /usr/local/bin/pmtiles
+  pmtiles version
+}
+
+install_tippecanoe() {
+  if command -v tippecanoe-decode &>/dev/null; then
+    local current
+    current=$(tippecanoe --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+    if [ "${current}" = "${TIPPECANOE_VERSION}" ]; then
+      echo "tippecanoe ${TIPPECANOE_VERSION} already installed"
+      return 0
+    fi
+  fi
+
+  echo "Building tippecanoe ${TIPPECANOE_VERSION}..."
+  apt-get install -y build-essential libsqlite3-dev zlib1g-dev
+
+  local build_dir
+  build_dir=$(mktemp -d)
+  curl -fsSL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz" \
+    -o /tmp/tippecanoe.tar.gz
+  echo "${TIPPECANOE_SHA256}  /tmp/tippecanoe.tar.gz" | sha256sum -c -
+  tar -xz -C "${build_dir}" --strip-components=1 -f /tmp/tippecanoe.tar.gz
+  rm -f /tmp/tippecanoe.tar.gz
+  (cd "${build_dir}" && make -j"$(nproc)" && make install)
+  rm -rf "${build_dir}"
+  tippecanoe --version
+}
+
+install_pmtiles
+install_tippecanoe


### PR DESCRIPTION
## Motivation

Installing the map toolchain (**pmtiles CLI** + **tippecanoe**) was duplicated across three places:
- `scripts/install_protomaps.sh` (on-device upgrade)
- `debian-live-config/.../9999-wrolpi.hook.chroot` (Debian Live ISO)
- `pi-gen/stage2/04-wrolpi/03-run-chroot.sh` (Pi image, added in #537)

A version bump or logic change meant editing all three in lockstep — easy to get out of sync.

## Change

Introduce **`wrolpi/scripts/install_map_tools.sh`** as the single source of truth, and have all three callers invoke it.

The shared script:
- Installs **pmtiles** (per-arch prebuilt binary, SHA-pinned for **both** `amd64` and `arm64`) and builds **tippecanoe** (source tarball, arch-independent SHA).
- Is **version-guarded**: a tool already at the pinned version is left alone, so baking it into an image makes the on-device run a no-op until a version actually bumps.
- apt-installs its own build deps, so callers don't have to know them.

Net effect: `-103 / +98`, with the logic living in one file instead of three.

## Notes

- Adds SHA pinning to the **on-device pmtiles** path, which was previously an unpinned `curl | tar`.
- The arm64 pmtiles hash was computed from the upstream v1.30.1 release tarball; the amd64 hash matches the pin already in the Debian hook.
- Rebased on `master` after #537 merged, so the diff is purely the consolidation (the pi-gen dep additions from #537 are already upstream).

## Testing

- `bash -n` on all four scripts passes.
- Exercised the shared script's guard logic locally with mocked tools + `uname`: matching versions → both installers skip with no network; a stale version → resolves the correct arch and download URL (`..._Linux_amd64.tar.gz`).
- Full image builds not run here (compile tippecanoe in-chroot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)