### PR TITLE
videos: center YouTube auto-captions at download time

### DIFF
--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from yt_dlp import YoutubeDL, DownloadError
 from yt_dlp.extractor import YoutubeTabIE  # noqa
 
+from wrolpi.captions import strip_youtube_caption_positioning
 from wrolpi.cmd import YT_DLP_BIN
 from wrolpi.common import logger, get_media_directory, escape_file_name, resolve_generators, background_task, \
     trim_file_name, cached_multiprocessing_result, get_absolute_media_path, aiohttp_post, normalize_domain
@@ -1036,6 +1037,16 @@ class VideoDownloader(Downloader, ABC):
             video_paths = glob_shared_stem(video_path)
             video_paths = self._delete_part_files(video_path, video_paths)
             video_paths = self.normalize_video_file_names(video_path, video_paths)
+
+            if url and ('youtube.com' in url or 'youtu.be' in url):
+                # YouTube auto-captions pin the text to the bottom-left; center them at the source.  Runs
+                # before the FileGroup is created, so the first index reads the corrected file.
+                for path in video_paths:
+                    if path.name.endswith('.vtt'):
+                        try:
+                            strip_youtube_caption_positioning(path)
+                        except Exception:
+                            logger.warning(f'Failed to center YouTube captions in {path}', exc_info=True)
 
             return ExecutedVideo(
                 url=url,

--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -186,6 +186,19 @@ def get_youtube_video_id(url: str) -> Optional[str]:
     return None
 
 
+YOUTUBE_HOSTS = ('youtube.com', 'youtu.be')
+
+
+def is_youtube_url(url: str) -> bool:
+    """Return True if the URL's host is a YouTube domain (youtube.com / youtu.be) or a subdomain of one.
+
+    Parses the hostname so unrelated hosts like `youtube.com.example.org` or `notyoutube.com` are rejected."""
+    if not url:
+        return False
+    host = (urlparse(url).hostname or '').lower()
+    return any(host == h or host.endswith(f'.{h}') for h in YOUTUBE_HOSTS)
+
+
 async def get_youtube_duration(video_url: str) -> Optional[int]:
     """Get video duration using YouTube's internal API. Returns None if URL is not YouTube or API fails."""
     video_id = get_youtube_video_id(video_url)
@@ -1038,7 +1051,7 @@ class VideoDownloader(Downloader, ABC):
             video_paths = self._delete_part_files(video_path, video_paths)
             video_paths = self.normalize_video_file_names(video_path, video_paths)
 
-            if url and ('youtube.com' in url or 'youtu.be' in url):
+            if is_youtube_url(url):
                 # YouTube auto-captions pin the text to the bottom-left; center them at the source.  Runs
                 # before the FileGroup is created, so the first index reads the corrected file.
                 for path in video_paths:

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from modules.videos.downloader import VideoDownloader, \
     get_or_create_channel, channel_downloader, video_downloader, preview_filename, \
     prepare_filename, convert_wrolpi_filename_format, _bot_blocked, _skip_download, \
-    parse_ytdlp_progress, is_youtube_rss_feed_url
+    parse_ytdlp_progress, is_youtube_rss_feed_url, is_youtube_url
 from modules.videos.lib import get_videos_downloader_config
 from modules.videos.models import Channel, Video
 from wrolpi.conftest import test_directory, await_switches
@@ -1405,3 +1405,22 @@ def test_prepare_uses_existing_video_location(test_session, video_factory):
 
     assert prepared.location == existing.location
     assert prepared.location is not None
+
+
+@pytest.mark.parametrize('url,expected', [
+    ('https://www.youtube.com/watch?v=abc123', True),
+    ('https://youtube.com/watch?v=abc123', True),
+    ('https://m.youtube.com/watch?v=abc123', True),
+    ('https://music.youtube.com/watch?v=abc123', True),
+    ('https://youtu.be/abc123', True),
+    # Lookalike / malicious hosts must be rejected.
+    ('https://youtube.com.example.org/watch?v=abc123', False),
+    ('https://notyoutube.com/watch?v=abc123', False),
+    ('https://vimeo.com/12345', False),
+    ('https://example.com/youtube.com', False),
+    ('', False),
+    (None, False),
+])
+def test_is_youtube_url(url, expected):
+    """is_youtube_url matches YouTube hosts (and subdomains) but rejects lookalike hosts."""
+    assert is_youtube_url(url) is expected

--- a/wrolpi/captions.py
+++ b/wrolpi/captions.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 import pathlib
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -11,7 +12,35 @@ import webvtt
 from wrolpi.cmd import FFMPEG_BIN
 from wrolpi.common import logger
 
-__all__ = ['read_captions', 'read_captions_with_timestamps', 'extract_captions']
+__all__ = ['read_captions', 'read_captions_with_timestamps', 'extract_captions',
+           'strip_youtube_caption_positioning']
+
+# YouTube auto-generated captions (downloaded via yt-dlp) stamp every cue's timing line with
+# `align:start position:0%`, which pins the on-screen text to the bottom-left of the player and makes it hard
+# to read.  This matches only that exact signature on a cue timing line so we never touch a deliberately
+# positioned cue.  The `<c>` word-timing tags in the cue text are left untouched.
+YOUTUBE_CUE_SETTINGS = re.compile(
+    r'^(\d{2}:\d{2}:\d{2}\.\d{3} --> \d{2}:\d{2}:\d{2}\.\d{3}) align:start position:0%[ \t]*$',
+    re.MULTILINE,
+)
+
+
+def strip_youtube_caption_positioning(caption_path: Union[str, Path]) -> bool:
+    """Remove YouTube's `align:start position:0%` cue settings from a .vtt file so the browser renders the
+    captions centered.  Rewrites the file in place only if something changed.
+
+    This is intended for captions downloaded from youtube.com; the caller is responsible for that gate.
+
+    :return: True if the file was modified.
+    """
+    caption_path = pathlib.Path(caption_path)
+    text = caption_path.read_text()
+    new_text = YOUTUBE_CUE_SETTINGS.sub(r'\1', text)
+    if new_text != text:
+        caption_path.write_text(new_text)
+        logger.info(f'Centered YouTube captions in {caption_path}')
+        return True
+    return False
 
 
 def _parse_vtt_timestamp(timestamp: str) -> float:

--- a/wrolpi/captions.py
+++ b/wrolpi/captions.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import os
 import pathlib
 import re
 import subprocess
@@ -36,11 +37,19 @@ def strip_youtube_caption_positioning(caption_path: Union[str, Path]) -> bool:
     caption_path = pathlib.Path(caption_path)
     text = caption_path.read_text()
     new_text = YOUTUBE_CUE_SETTINGS.sub(r'\1', text)
-    if new_text != text:
-        caption_path.write_text(new_text)
-        logger.info(f'Centered YouTube captions in {caption_path}')
-        return True
-    return False
+    if new_text == text:
+        return False
+    # Write to a temp file in the same directory, then atomically replace the original.  A failed or partial
+    # write (e.g. the volume runs out of space) can never truncate/corrupt the existing caption file.
+    tmp_path = caption_path.with_name(f'{caption_path.name}.tmp')
+    try:
+        tmp_path.write_text(new_text)
+        os.replace(tmp_path, caption_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    logger.info(f'Centered YouTube captions in {caption_path}')
+    return True
 
 
 def _parse_vtt_timestamp(timestamp: str) -> float:

--- a/wrolpi/test/test_captions.py
+++ b/wrolpi/test/test_captions.py
@@ -67,3 +67,58 @@ def test_read_captions_with_timestamps(fixture_name, request):
     caption_file = request.getfixturevalue(fixture_name)
     chunks = captions.read_captions_with_timestamps(caption_file)
     assert chunks == EXPECTED_CAPTION_CHUNKS
+
+
+def test_strip_youtube_caption_positioning(vtt_file1):
+    """YouTube's `align:start position:0%` cue settings are removed so captions render centered."""
+    original = vtt_file1.read_text()
+    assert 'align:start position:0%' in original
+
+    changed = captions.strip_youtube_caption_positioning(vtt_file1)
+    assert changed is True
+
+    new_text = vtt_file1.read_text()
+    # The mis-positioning cue settings are gone...
+    assert 'align:start position:0%' not in new_text
+    # ...but the timestamps and the `<c>` word-timing tags in the cue text survive untouched.
+    assert '00:00:00.000 --> 00:00:05.269' in new_text
+    assert '<00:00:01.310><c> welcome</c>' in new_text
+    # The captions are still readable/parseable and unchanged in content.
+    assert list(captions.read_captions_with_timestamps(vtt_file1)) == EXPECTED_CAPTION_CHUNKS
+
+    # Idempotent: a second pass changes nothing.
+    assert captions.strip_youtube_caption_positioning(vtt_file1) is False
+    assert vtt_file1.read_text() == new_text
+
+
+def test_strip_youtube_caption_positioning_leaves_clean_files(vtt_file2):
+    """A VTT with no cue settings (already centered) is not rewritten."""
+    original = vtt_file2.read_text()
+    assert 'align:start position:0%' not in original
+
+    assert captions.strip_youtube_caption_positioning(vtt_file2) is False
+    assert vtt_file2.read_text() == original
+
+
+def test_strip_youtube_caption_positioning_preserves_deliberate_placement(test_directory):
+    """A cue deliberately positioned (with a `line` setting) is not the auto-caption signature; leave it."""
+    vtt = test_directory / 'deliberate.en.vtt'
+    content = (
+        'WEBVTT\n'
+        '\n'
+        '00:00:00.000 --> 00:00:02.000 align:start position:0% line:0\n'
+        'top-left on purpose\n'
+        '\n'
+        '00:00:02.000 --> 00:00:04.000 align:start position:0%\n'
+        'auto-caption line\n'
+    )
+    vtt.write_text(content)
+
+    changed = captions.strip_youtube_caption_positioning(vtt)
+    assert changed is True
+
+    new_text = vtt.read_text()
+    # The deliberate `line:0` cue is untouched...
+    assert '00:00:00.000 --> 00:00:02.000 align:start position:0% line:0' in new_text
+    # ...while the plain auto-caption cue is centered.
+    assert '00:00:02.000 --> 00:00:04.000\nauto-caption line' in new_text


### PR DESCRIPTION
## Problem

YouTube auto-generated captions (downloaded via yt-dlp) stamp **every** cue timing line with `align:start position:0%`, which pins the on-screen text to the **bottom-left** of the player and makes it hard to read:

```
00:00:00.400 --> 00:00:02.230 align:start position:0%
```

Across the entire test corpus, **every** cue setting is that exact string (23k+ occurrences) — there is no legitimate positioning variety in YouTube captions.

## Fix

Strip that exact cue setting from the downloaded `.vtt` files so browsers render the captions centered by default.

- **`strip_youtube_caption_positioning()`** in `wrolpi/captions.py` — a targeted text replacement (matched to the exact `align:start position:0%` signature on a cue timing line), *not* a `webvtt` parse→`.save()` round-trip, so the `<c>` word-timing tags inside the cue text are preserved byte-for-byte. Idempotent; rewrites in place only when something changed. Deliberately positioned cues (e.g. ones that also carry a `line` setting) are left untouched.
- Called from `VideoDownloader` right after `normalize_video_file_names`, **gated on a `youtube.com` / `youtu.be` source URL**. It runs *before* the `FileGroup` is created, so the first index reads the corrected file — no re-index plumbing needed. Re-downloads (which WROLPi does to refresh metadata) just re-strip harmlessly.

## Relationship to #543

Complementary — keep both:

- **#543 (frontend)** centers captions in WROLPi's own player for **any source and existing/already-downloaded** files, purely in-memory.
- **This PR (backend)** makes **new YouTube downloads** correct at the source, so the files themselves are right for any consumer and we don't rely solely on a client-side mutation.

No retroactive migration of existing files (those are covered by #543).

## Tests

`wrolpi/test/test_captions.py` — new cases: strips the signature + preserves timestamps/`<c>` tags/parseability, is idempotent, leaves clean (no-setting) files untouched, and preserves a deliberately `line`-positioned cue while still centering a plain auto-caption cue. Full `test_captions.py` suite passes (7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)