### PR TITLE
Controller: hide Root CA download until drive is ready

### DIFF
--- a/controller/lib/config.py
+++ b/controller/lib/config.py
@@ -81,6 +81,24 @@ def is_primary_drive_mounted() -> bool:
     return CONFIG_PATH_ON_DRIVE.exists()
 
 
+def get_ca_certificate_path() -> Path:
+    """Path to the persistent WROLPi Root CA on the media directory."""
+    return get_media_directory() / "config" / "ssl" / "ca.crt"
+
+
+def is_ca_certificate_available() -> bool:
+    """True when the Root CA file is present on the media directory.
+
+    On native installs the primary drive must be mounted first so a CA that
+    already lives on the drive is visible (and so we never advertise a
+    transient CA written onto the root filesystem during onboarding).
+    Docker always has its media volume available.
+    """
+    if not is_docker_mode() and not is_primary_drive_mounted():
+        return False
+    return get_ca_certificate_path().is_file()
+
+
 def reload_config_from_drive() -> bool:
     """
     Load config from the mounted WROLPi drive and merge with defaults.

--- a/controller/main.py
+++ b/controller/main.py
@@ -33,14 +33,16 @@ from controller.api.scripts import router as scripts_router
 from controller.api.services import router as services_router
 from controller.api.status import router as status_router
 from controller.lib.config import (
+    get_ca_certificate_path,
     get_config_value,
-    get_media_directory,
+    is_ca_certificate_available,
     is_docker_mode,
     is_primary_drive_mounted,
     reload_config_from_drive,
     save_config,
     update_config,
 )
+from controller.lib.scripts import get_script_status
 from controller.lib.docker_services import (
     can_manage_containers,
     get_all_containers_status,
@@ -229,11 +231,22 @@ async def dashboard(request: Request):
     # Sort services by name for consistent display
     services = sorted(services, key=lambda s: s["name"])
 
+    # Root CA download is only useful after the media drive is mounted (so an
+    # existing CA on the drive is visible) and repair has finished generating
+    # or refreshing certificates. While repair is running the CA may not exist
+    # yet or the leaf/Caddyfile may still be mid-update.
+    script_status = get_script_status()
+    repair_running = (
+        script_status.get("running") and script_status.get("script_name") == "repair"
+    )
+    cert_download_ready = is_ca_certificate_available() and not repair_running
+
     context = {
         "version": __version__,
         "docker_mode": is_docker_mode(),
         "drive_mounted": is_primary_drive_mounted(),
         "hide_cert_banner": get_config_value("hide_cert_banner", False),
+        "cert_download_ready": cert_download_ready,
         "host": get_host(request),
 
         # Real status data
@@ -280,10 +293,20 @@ async def health_check() -> HealthResponse:
 
 @app.get("/ca.crt")
 async def download_ca_certificate():
-    """Serve the WROLPi Root CA certificate for browser trust setup."""
-    ca_path = get_media_directory() / "config" / "ssl" / "ca.crt"
+    """Serve the WROLPi Root CA certificate for browser trust setup.
+
+    Only available after the media drive is mounted so an existing CA on the
+    drive can be served (and never a transient pre-onboarding path).
+    """
+    from fastapi.responses import JSONResponse
+
+    if not is_docker_mode() and not is_primary_drive_mounted():
+        return JSONResponse(
+            status_code=404,
+            content={"error": "CA certificate not available until the media drive is mounted"},
+        )
+    ca_path = get_ca_certificate_path()
     if not ca_path.is_file():
-        from fastapi.responses import JSONResponse
         return JSONResponse(status_code=404, content={"error": "CA certificate not found"})
     return FileResponse(
         path=ca_path,

--- a/controller/templates/index.html
+++ b/controller/templates/index.html
@@ -730,13 +730,15 @@
     </div>
 </header>
 
-<!-- Certificate trust banner — shown by JS when HTTPS cert is not trusted -->
+<!-- Certificate trust banner — shown by JS when HTTPS cert is not trusted and Root CA is ready -->
 <div id="cert-banner" class="card" style="display: none; background: #16213e; border: 1px solid #1a3a5c; border-radius: 12px; padding: 1.5rem; margin-bottom: 1rem;">
     <h2 style="font-size: 1.1rem; margin-bottom: 0.75rem; color: #4cc9f0;">HTTPS Certificate Setup</h2>
     <p style="line-height: 1.6; color: #ccc; margin-bottom: 1rem;">
         Install the WROLPi Root CA certificate so your browser trusts all WROLPi HTTPS services.
     </p>
+    {% if cert_download_ready %}
     <a class="btn btn-info" href="/ca.crt" download="wrolpi-ca.crt" style="margin-bottom: 1rem; display: inline-block;">Download WROLPi Root CA</a>
+    {% endif %}
 
     <details style="margin-bottom: 0.75rem;">
         <summary style="cursor: pointer; padding: 0.5rem 0; font-weight: 600; color: #4cc9f0;">iOS / iPadOS</summary>
@@ -1211,8 +1213,10 @@
         var viewFilesBtn = document.getElementById('view-files-btn');
         if (viewFilesBtn) viewFilesBtn.href = httpsBase + '/media/';
 
-        // Skip cert check if user has permanently hidden the banner.
-        {% if hide_cert_banner %}return;{% endif %}
+        // Skip cert check if user permanently hid the banner, or if the Root CA
+        // is not ready yet (drive not mounted / repair still running / ca.crt missing).
+        // Advertising download before then 404s and can serve the wrong state.
+        {% if hide_cert_banner or not cert_download_ready %}return;{% endif %}
 
         // Probe the HTTPS endpoint; show the cert banner if it fails.
         var controller = new AbortController();

--- a/controller/test/test_api.py
+++ b/controller/test/test_api.py
@@ -187,3 +187,75 @@ class TestDriveMountedStatus:
             with TestClient(app) as client:
                 response = client.get("/")
                 assert "Primary drive not mounted" in response.text
+
+
+class TestCertDownloadReadiness:
+    """Root CA download should stay hidden until drive + certs are ready."""
+
+    def test_dashboard_hides_ca_download_when_not_ready(self, test_client):
+        """No CA download button when ca is not ready (default test env: no drive/CA)."""
+        response = test_client.get("/")
+        assert response.status_code == 200
+        assert "Download WROLPi Root CA" not in response.text
+        # Cert IIFE short-circuits before HTTPS probe when not ready.
+        assert "ca.crt missing" in response.text
+
+    def test_dashboard_shows_ca_download_when_ready(self, reset_runtime_config, mock_docker_mode, tmp_path, monkeypatch):
+        """Download button is rendered once drive is mounted and ca.crt exists."""
+        from controller.main import app
+
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        ca = tmp_path / "config" / "ssl" / "ca.crt"
+        ca.parent.mkdir(parents=True)
+        ca.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+
+        with mock.patch("controller.main.is_primary_drive_mounted", return_value=True), \
+             mock.patch("controller.main.is_ca_certificate_available", return_value=True), \
+             mock.patch("controller.main.get_script_status", return_value={"running": False}):
+            with TestClient(app) as client:
+                response = client.get("/")
+                assert response.status_code == 200
+                assert "Download WROLPi Root CA" in response.text
+                assert 'href="/ca.crt"' in response.text
+
+    def test_dashboard_hides_ca_download_while_repair_running(
+            self, reset_runtime_config, mock_docker_mode, tmp_path, monkeypatch
+    ):
+        """Hide CA download while repair is regenerating certificates."""
+        from controller.main import app
+
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        with mock.patch("controller.main.is_primary_drive_mounted", return_value=True), \
+             mock.patch("controller.main.is_ca_certificate_available", return_value=True), \
+             mock.patch(
+                 "controller.main.get_script_status",
+                 return_value={"running": True, "script_name": "repair"},
+             ):
+            with TestClient(app) as client:
+                response = client.get("/")
+                assert "Download WROLPi Root CA" not in response.text
+
+    def test_ca_crt_404_when_drive_not_mounted(self, test_client):
+        """/ca.crt should 404 before the media drive is mounted."""
+        with mock.patch("controller.main.is_primary_drive_mounted", return_value=False):
+            response = test_client.get("/ca.crt")
+            assert response.status_code == 404
+            assert "not available until the media drive is mounted" in response.json()["error"]
+
+    def test_ca_crt_serves_file_when_ready(self, reset_runtime_config, mock_docker_mode, tmp_path, monkeypatch):
+        """/ca.crt returns the PEM when drive is mounted and file exists."""
+        from controller.main import app
+
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        ca = tmp_path / "config" / "ssl" / "ca.crt"
+        ca.parent.mkdir(parents=True)
+        body = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+        ca.write_text(body)
+
+        with mock.patch("controller.main.is_primary_drive_mounted", return_value=True), \
+             mock.patch("controller.main.get_ca_certificate_path", return_value=ca):
+            with TestClient(app) as client:
+                response = client.get("/ca.crt")
+                assert response.status_code == 200
+                assert body.encode() in response.content
+                assert "attachment" in response.headers.get("content-disposition", "")

--- a/controller/test/test_config.py
+++ b/controller/test/test_config.py
@@ -7,8 +7,10 @@ import pytest
 import yaml
 
 from controller.lib.config import (
+    get_ca_certificate_path,
     get_config,
     get_config_value,
+    is_ca_certificate_available,
     is_docker_mode,
     is_primary_drive_mounted,
     reload_config_from_drive,
@@ -98,6 +100,41 @@ class TestIsPrimaryDriveMounted:
         # test_config_directory creates the config dir but not controller.yaml
         assert test_config_directory.exists()
         assert is_primary_drive_mounted() is False
+
+
+class TestCaCertificateAvailable:
+    """Tests for is_ca_certificate_available / get_ca_certificate_path."""
+
+    def test_false_when_drive_not_mounted(self, mock_drive_not_mounted, tmp_path, monkeypatch):
+        """Native mode without drive mounted should not advertise a CA."""
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        ca = tmp_path / "config" / "ssl" / "ca.crt"
+        ca.parent.mkdir(parents=True)
+        ca.write_text("fake-cert")
+        assert is_ca_certificate_available() is False
+
+    def test_false_when_drive_mounted_but_ca_missing(self, mock_drive_mounted, tmp_path, monkeypatch):
+        """Mounted drive without ca.crt is not ready."""
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        assert is_ca_certificate_available() is False
+
+    def test_true_when_drive_mounted_and_ca_exists(self, mock_drive_mounted, tmp_path, monkeypatch):
+        """Mounted drive with ca.crt is ready."""
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        ca = get_ca_certificate_path()
+        ca.parent.mkdir(parents=True)
+        ca.write_text("fake-cert")
+        assert is_ca_certificate_available() is True
+
+    def test_true_in_docker_when_ca_exists_without_drive_mount(
+            self, mock_docker_mode_enabled, mock_drive_not_mounted, tmp_path, monkeypatch
+    ):
+        """Docker media volume can serve CA without native drive-mount check."""
+        monkeypatch.setenv("MEDIA_DIRECTORY", str(tmp_path))
+        ca = get_ca_certificate_path()
+        ca.parent.mkdir(parents=True)
+        ca.write_text("fake-cert")
+        assert is_ca_certificate_available() is True
 
 
 class TestReloadConfigFromDrive:


### PR DESCRIPTION
## Summary
- During fresh onboarding the Controller showed **Download WROLPi Root CA** even though `ca.crt` is only created after the media drive is mounted and repair runs (or already lives on the drive from a previous install).
- Gate the download button and cert-setup banner on: primary drive mounted (Docker excepted), `config/ssl/ca.crt` present, and repair not currently running.
- `/ca.crt` also requires the media drive to be mounted on native installs so a transient pre-mount path is never served.

## Test plan
- [x] Controller unit/integration tests for CA readiness helpers, dashboard button visibility, and `/ca.crt` 404/serve paths
- [ ] Fresh RPi with drive unmounted: Controller page does **not** show Download WROLPi Root CA
- [ ] After mounting a drive that already has `config/ssl/ca.crt` and repair has finished: button appears when HTTPS is untrusted; download returns a real PEM
- [ ] While repair is running: button stays hidden
- [ ] Docker mode still serves CA when file exists on the media volume