### PR TITLE
upgrade: force-update the debian12-final tag fetch

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -58,11 +58,14 @@ debian12_guard() {
         return 0
     fi
 
-    # Debian 12 (or older): make sure the cutoff tag is present locally.
+    # Debian 12 (or older): make sure the cutoff tag is present AND current.
     # `debian12-final` is off the release line, so a plain fetch of the branch
-    # would not follow it.
-    git -C /opt/wrolpi fetch origin "refs/tags/${GUARD_TAG}:refs/tags/${GUARD_TAG}" 2>/dev/null \
-        || git -C /opt/wrolpi fetch origin --tags 2>/dev/null || :
+    # would not follow it.  Force (+ / --force) so a moved tag (e.g. a bumped
+    # final release) overwrites a stale local tag instead of being rejected as
+    # "would clobber existing tag" — otherwise the guard pins to the old target.
+    # Safe to force: the commit's signature is verified before checkout below.
+    git -C /opt/wrolpi fetch origin "+refs/tags/${GUARD_TAG}:refs/tags/${GUARD_TAG}" 2>/dev/null \
+        || git -C /opt/wrolpi fetch --force --tags origin 2>/dev/null || :
 
     # --verify --quiet: fail cleanly (empty, non-zero) instead of echoing the
     # unresolved arg when the tag is absent.


### PR DESCRIPTION
Follow-up to #550. The guard fetched `debian12-final` with a non-forcing refspec, so a box that already had the tag kept a **stale** local copy when the tag moved (git rejects the update as "would clobber existing tag"). Result: after bumping the final release and moving the tag, the guard pinned to the **old** commit.

**Found on real Debian 12 hardware (10.0.0.8):** after moving `debian12-final` `ac69ec10 → f0858af2` for the 0.27.3-beta bump, a bare `upgrade.sh` rolled the box back to the *old* `ac69ec10` (0.27.2-beta) instead of `f0858af2`. Confirmed: non-force fetch → `! [rejected] (would clobber existing tag)`; force fetch → `t [tag update]`.

**Fix:** force the tag fetch (`+refs/tags/…` / `--force --tags`). Safe because the commit signature is still verified before checkout. Sandbox harness gains a moved-tag/stale-local-tag scenario (now 17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)