### PR TITLE
upgrade: don't treat a detached HEAD as a branch

### DIFF
--- a/wrolpi/test/test_upgrade.py
+++ b/wrolpi/test/test_upgrade.py
@@ -68,6 +68,18 @@ class TestGitFunctions:
         with patch('wrolpi.upgrade.PROJECT_DIR', mock_path):
             assert get_current_branch() is None
 
+    def test_get_current_branch_detached_head(self):
+        """A detached HEAD (abbrev-ref prints the literal "HEAD") is not a branch."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = b'HEAD\n'
+        mock_path = MagicMock()
+        mock_path.is_dir.return_value = True
+
+        with patch('wrolpi.upgrade.PROJECT_DIR', mock_path), \
+                patch('subprocess.run', return_value=mock_result):
+            assert get_current_branch() is None
+
     def test_get_local_commit(self):
         """get_local_commit returns the short commit hash."""
         mock_result = MagicMock()

--- a/wrolpi/upgrade.py
+++ b/wrolpi/upgrade.py
@@ -62,7 +62,13 @@ def get_current_branch() -> str | None:
             timeout=10,
         )
         if result.returncode == 0:
-            return result.stdout.decode().strip()
+            branch = result.stdout.decode().strip()
+            # A detached HEAD makes `--abbrev-ref HEAD` print the literal
+            # "HEAD" (not a branch).  Comparing origin/HEAD — the remote's
+            # default branch — against it yields a bogus "commits behind"
+            # count and a false "update available", so report no branch.
+            if branch and branch != 'HEAD':
+                return branch
     except Exception as e:
         logger.error('Failed to get current branch', exc_info=e)
 


### PR DESCRIPTION
`get_current_branch()` returned the literal `HEAD` on a detached HEAD (that's what `git rev-parse --abbrev-ref HEAD` prints). `check_for_update()` then compared against `origin/HEAD` (the remote default branch = master) and reported a bogus *N commits behind on HEAD* → a false "update available" banner.

Observed on 10.0.0.8 during the Debian 12 guard QA: the box was at the release tip but detached, and the UI showed "32 commits behind on HEAD" while it was actually 0 behind `origin/release`.

**Fix:** treat a detached HEAD as "no branch" (return None), so no phantom upgrade is offered. Added `test_get_current_branch_detached_head`; `test_upgrade.py` 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)