### PR TITLE
upgrade: rebuild venvs after a Python major-version change

### DIFF
--- a/scripts/reset_virtual_environments.sh
+++ b/scripts/reset_virtual_environments.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # Deletes and recreates all WROLPi Python virtual environments.
 # This script requires internet access for pip install.
+#
+# Usage: reset_virtual_environments.sh [-y|--yes]
+#   -y, --yes   Skip the confirmation prompt.  Used by automated upgrades
+#               (wrolpi-upgrade.service), which run without a tty -- the
+#               interactive prompt would otherwise loop forever on EOF.
+
+ASSUME_YES=false
+for arg in "$@"; do
+  case "${arg}" in
+  -y | --yes) ASSUME_YES=true ;;
+  esac
+done
 
 # Re-execute this script if it wasn't called with sudo.
 if [ $EUID != 0 ]; then
@@ -10,7 +22,9 @@ fi
 
 source /opt/wrolpi/wrolpi/scripts/lib.sh
 
-yes_or_no "This script requires internet access. Do you want to continue?" || exit 0
+if [ "${ASSUME_YES}" != true ]; then
+  yes_or_no "This script requires internet access. Do you want to continue?" || exit 0
+fi
 
 set -e
 set -x

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -119,6 +119,37 @@ EOF
 debian12_guard "$@"
 # ---------------------------------------------------------------------------
 
+# --- Rebuild virtual environments after a Python major-version change -------
+# A Debian major upgrade (e.g. 12 -> 13) replaces /usr/bin/python3 (3.11 -> 3.13).
+# The existing venvs still resolve their `python3` to the system interpreter,
+# but their packages live in lib/python3.11/site-packages, which the new
+# interpreter never searches -- so every import fails and `pip install --upgrade`
+# cannot repair them.  Detect this by comparing each venv's recorded Python
+# version against the current one, and do a full rebuild (delete + recreate +
+# reinstall) via reset_virtual_environments.sh when they differ.
+rebuild_stale_venvs() {
+    local current
+    current=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null) || return 0
+    local cfg venv_version
+    for cfg in /opt/wrolpi/venv/pyvenv.cfg \
+               /opt/wrolpi/controller/venv/pyvenv.cfg \
+               /opt/wrolpi-help/venv/pyvenv.cfg; do
+        [ -r "${cfg}" ] || continue
+        # pyvenv.cfg records e.g. "version = 3.11.2"; match that key exactly so
+        # the newer "version_info = ..." line is ignored.  Reduce to major.minor.
+        venv_version=$(awk -F'=' '$1 ~ /^[[:space:]]*version[[:space:]]*$/ {gsub(/[[:space:]]/,"",$2); print $2; exit}' "${cfg}")
+        venv_version=${venv_version%.*}
+        if [ -n "${venv_version}" ] && [ "${venv_version}" != "${current}" ]; then
+            echo "Python changed (venv at ${cfg%/pyvenv.cfg} built for ${venv_version}, system is now ${current}); rebuilding all virtual environments..."
+            /opt/wrolpi/scripts/reset_virtual_environments.sh -y
+            return 0
+        fi
+    done
+}
+
+rebuild_stale_venvs
+# ---------------------------------------------------------------------------
+
 # Upgrade Controller first so users can monitor the rest of the upgrade.
 upgrade_controller() {
     echo "Upgrading WROLPi Controller..."


### PR DESCRIPTION
## Problem

Upgrading a device from Debian 12 to 13 in place (as done on 10.0.0.9) replaces `/usr/bin/python3` (3.11 → 3.13) and removes `python3.11` entirely. The existing venvs still resolve `python3` to the system interpreter, but their packages live in `lib/python3.11/site-packages`, which Python 3.13 never searches. Every import fails, so `pip install --upgrade` (what `upgrade.sh` does) can't repair them — it just crash-loops the **API** (`sanic`), **Controller** (`fastapi`), **yt-dlp**, and **Help** (`mkdocs`).

Observed on 10.0.0.9: venvs report `version = 3.11.2` while the system is now `3.13.5`; `import sanic` / `import fastapi` / `yt_dlp` all `ModuleNotFoundError`.

## Fix

- **`scripts/upgrade.sh`** — new `rebuild_stale_venvs()`, run right after the Debian 12 guard and before any `pip install`. It reads each venv's `pyvenv.cfg` `version =` (major.minor), compares to the running `python3`, and on a mismatch does a full rebuild via `reset_virtual_environments.sh -y`.
  - Detects a *mismatch* rather than literally "3.11" → also self-heals future bumps; no-op when versions match or on a fresh install (no `pyvenv.cfg` yet).
  - Ignores the `version_info = ...` line so parsing can't grab the wrong value.
- **`scripts/reset_virtual_environments.sh`** — added `-y`/`--yes` to skip the confirmation prompt. Required for automation: `yes_or_no` loops on `read`, so under the tty-less `wrolpi-upgrade.service` it would spin forever on EOF. The flag passes through the `sudo` re-exec.

## Testing

- `bash -n` clean on both scripts.
- awk `version` parse verified against real 3.11 and 3.13 `pyvenv.cfg` contents (correctly ignores `version_info`).
- Decision logic verified: stale → rebuild; matching (both directions) → no-op; missing cfg (fresh install) → no-op.
- To be validated on 10.0.0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)