### PR TITLE
Chunk upsert_directories INSERT to respect SQLite variable limit

### DIFF
--- a/wrolpi/files/lib.py
+++ b/wrolpi/files/lib.py
@@ -26,7 +26,7 @@ from wrolpi import flags
 from wrolpi.cmd import which
 from wrolpi.common import get_media_directory, wrol_mode_check, logger, \
     partition, \
-    get_files_and_directories, chunks_by_stem, walk, \
+    get_files_and_directories, chunks, chunks_by_stem, walk, \
     get_wrolpi_config, \
     unique_by_predicate, get_paths_in_media_directory, TRACE_LEVEL, get_relative_to_media_directory, strip_surrogates
 from wrolpi.dates import now, from_timestamp, months_selector_to_where, date_range_to_where
@@ -1006,15 +1006,18 @@ def upsert_directories(parent_directories, directories):
 
     if directories:
         # Insert any directories that were created, update any directories which previously existed.
+        # Chunk the rows so the multi-row VALUES clause stays under SQLite's bound-variable limit;
+        # a large media directory can hold tens of thousands of directories.
+        values = [(str(i.absolute()), i.name, idempotency) for i in directories]
         with get_db_curs(commit=True) as curs:
-            values = [(str(i.absolute()), i.name, idempotency) for i in directories]
-            placeholders, params = values_clause(values)
-            stmt = f'''
-                INSERT INTO directory (path, name, idempotency) VALUES {placeholders}
-                ON CONFLICT (path) DO UPDATE
-                SET idempotency = EXCLUDED.idempotency
-            '''
-            curs.execute(stmt, params)
+            for chunk in chunks(values, BULK_SQL_CHUNK_SIZE):
+                placeholders, params = values_clause(chunk)
+                stmt = f'''
+                    INSERT INTO directory (path, name, idempotency) VALUES {placeholders}
+                    ON CONFLICT (path) DO UPDATE
+                    SET idempotency = EXCLUDED.idempotency
+                '''
+                curs.execute(stmt, params)
 
     with get_db_curs(commit=True) as curs:
         # Delete the children of any parent directory which no longer exists.

--- a/wrolpi/files/test/test_lib.py
+++ b/wrolpi/files/test/test_lib.py
@@ -18,7 +18,7 @@ from wrolpi.conftest import await_switches
 from wrolpi.dates import now
 from wrolpi.errors import InvalidFile, UnknownDirectory, FileGroupIsTagged, NoPrimaryFile
 from wrolpi.files import lib, indexers
-from wrolpi.files.models import FileGroup
+from wrolpi.files.models import FileGroup, Directory
 from wrolpi.tags import TagFile
 from wrolpi.test.common import only_macos, skip_circleci
 from wrolpi.vars import PROJECT_DIR, IS_MACOS
@@ -854,6 +854,25 @@ async def test_refresh_directories(test_session, test_directory, assert_director
     foo.mkdir()
     await refresh_files([foo])
     assert_directories({'foo', 'baz'})
+
+
+@pytest.mark.asyncio
+async def test_upsert_directories_chunks_large_batches(test_session, test_directory):
+    """A media directory with more directories than SQLite can bind in one statement is inserted in chunks.
+
+    Regression: SQLite limits the number of bound variables per statement, so a single multi-row VALUES
+    clause over tens of thousands of directories raised RuntimeError('values_clause: too many parameters')."""
+    from wrolpi.db import SQLITE_MAX_VARIABLES
+    # upsert_directories binds 3 columns per directory; exceed the limit so the un-chunked path would fail.
+    count = SQLITE_MAX_VARIABLES // 3 + 50
+    paths = [test_directory / f'd{i:05d}' for i in range(count)]
+    for path in paths:
+        path.mkdir()
+
+    lib.upsert_directories([test_directory], paths)
+
+    stored = {i.path for i in test_session.query(Directory).all()}
+    assert set(paths).issubset(stored), 'all discovered directories should be inserted'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

\`Refresh all files\` fails on a large media directory (observed on the 10.0.0.5 Docker WROLPi):

```
RuntimeError: values_clause: too many parameters (44454 rows x 3); chunk the rows
  File "wrolpi/files/lib.py", line 1011, in upsert_directories
```

After the Postgres → SQLite cutover, `values_clause` (`wrolpi/db.py`) guards against exceeding SQLite's bound-variable limit (`SQLITE_MAX_VARIABLES = 32000`). But `upsert_directories` still built a **single** multi-row VALUES clause over every discovered directory — 44,454 dirs × 3 columns = 133k params — aborting the entire refresh. Worked under Postgres (no such limit); not under SQLite.

## Fix

Insert directories in `BULK_SQL_CHUNK_SIZE` (1000) batches via the existing `chunks()` helper — the same pattern the bulk tag-file callers already use. The other three `values_clause` callers in `files/lib.py` already chunk; this was the one gap.

## Test

`test_upsert_directories_chunks_large_batches` creates `SQLITE_MAX_VARIABLES // 3 + 50` directories and asserts they all insert. Verified it fails first with the exact reported `RuntimeError (… rows x 3)`, then passes with the fix. `test_refresh_directories` and full `test_lib.py` + `test_worker.py` (159 passed, 1 skipped) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)