### PR TITLE
Fix "node.contains is not a function" crash on Modal/Popup triggers

### DIFF
--- a/app/src/components/Theme.test.js
+++ b/app/src/components/Theme.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Progress} from './Theme';
+import {Button, Modal, Progress} from './Theme';
 import {renderInDarkMode, renderInLightMode} from '../test-utils';
 
 // All semantic-ui colors.
@@ -9,6 +9,34 @@ const allColors = ['red', 'orange', 'yellow', 'olive', 'green', 'teal', 'blue', 
 const lightBarColors = ['yellow', 'olive', 'teal'];
 // Bar colors that need dark percent text only in dark mode (inverted makes bar lighter).
 const darkModeLightBarColors = ['grey', 'blue'];
+
+describe('Button ref forwarding', () => {
+    // Regression: SButton is a class component, so forwarding a ref straight to it resolves to the class instance
+    // (no `.contains`). Semantic UI's Modal/Popup Portal calls `node.contains(...)` on the trigger's ref during
+    // handleDocumentClick, throwing "node.contains is not a function". The forwarded ref must be the DOM <button>.
+    it('resolves a forwarded ref to the underlying DOM element', () => {
+        const ref = React.createRef();
+        renderInLightMode(<Button ref={ref} content='Click'/>);
+
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(typeof ref.current.contains).toBe('function');
+        expect(ref.current.tagName).toBe('BUTTON');
+    });
+
+    it('does not throw when a Button is used as a controlled Modal trigger and the document is clicked', () => {
+        // Reproduces the Control page crash: an open Modal whose trigger is a themed Button. A document click
+        // invokes the Portal's handleDocumentClick -> doesNodeContainClick(triggerRef.current, e).
+        renderInLightMode(
+            <Modal open trigger={<Button content='Open'/>}>
+                <Modal.Content>content</Modal.Content>
+            </Modal>
+        );
+
+        expect(() => {
+            document.body.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        }).not.toThrow();
+    });
+});
 
 describe('Progress component theme support', () => {
     describe('dark mode', () => {

--- a/app/src/components/Theme.tsx
+++ b/app/src/components/Theme.tsx
@@ -34,6 +34,7 @@ import {
     Placeholder as SPlaceholder,
     Popup as SPopup,
     Progress as SProgress,
+    Ref as SRef,
     Segment as SSegment,
     Statistic as SStatistic,
     StatisticGroup as SStatisticGroup,
@@ -287,7 +288,13 @@ const ButtonGroup: ButtonGroupComponent = (props) => {
 const ButtonBase = forwardRef<any, ButtonProps>((props, ref) => {
     const {i, inverted} = useContext(ThemeContext);
     const mergedProps = defaultGrey({...i, ...props}, !!inverted);
-    return <SButton ref={ref} {...mergedProps}/>
+    // SButton is a class component, so a forwarded `ref` would resolve to the class instance rather than the DOM
+    // node. Semantic UI's Modal/Popup use the trigger's ref with `node.contains(...)`, which throws on a non-DOM
+    // value. Wrap in Ref (findDOMNode) so the forwarded ref always resolves to the underlying <button> element.
+    if (ref) {
+        return <SRef innerRef={ref}><SButton {...mergedProps}/></SRef>
+    }
+    return <SButton {...mergedProps}/>
 });
 ButtonBase.displayName = 'ButtonBase';
 


### PR DESCRIPTION
## Problem

The Control page (`/admin/controller`) threw an uncaught runtime error:

```
TypeError: node.contains is not a function
    at doesNodeContainClick
    at Portal._this.handleDocumentClick
```

Reproduced by opening a **Service Logs** modal and then clicking anywhere — it fires on any document click while such a modal is open, which is why it appeared intermittently.

## Root cause

Semantic UI's Modal/Popup Portal runs `handleDocumentClick`, which calls `triggerRef.current.contains(e.target)`. Inspecting the live React fibers, the trigger ref was a semantic-ui **`Button` class instance**, not a DOM node — so `.contains` doesn't exist.

The themed `Button` in `Theme.tsx` is a `forwardRef` that passes its ref straight to `SButton`, a **class component**. `@fluentui/react-component-ref`'s `Ref` chooses its strategy via `ReactIs.isForwardRef(child)`:

- forwardRef child (our `Button`) → `RefForward` → ref lands on the `SButton` class **instance** ← the bug
- class/DOM child → `RefFindNode` (`findDOMNode`) → real DOM node

So every Modal/Popup that uses a themed `Button` as its `trigger` inherits the crash — Service Logs, the QR-hotspot modal on the same page, and the download-error modals in `Downloads.js`.

## Fix

One targeted change in `Theme.tsx`: when a ref is forwarded to `Button`, wrap `SButton` in semantic's `Ref` so the ref resolves to the underlying `<button>` DOM element. This fixes all trigger sites at once, so no call sites needed changing.

## Testing

- Added 2 regression tests in `Theme.test.js` (ref resolves to a DOM `<button>`; a themed Button as an open Modal trigger doesn't throw on document click). Both **fail without the fix, pass with it**.
- `tsc --noEmit` clean.
- Full frontend suite: **49 suites / 823 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)