### PR TITLE
zim: drop --address 0.0.0.0 in Docker entrypoint so kiwix-serve works on trixie

### DIFF
--- a/docker/zim/entrypoint.sh
+++ b/docker/zim/entrypoint.sh
@@ -4,4 +4,7 @@ rm -f /library.xml
 # Find all Zim files and import them.
 find /media/wrolpi -iname '*.zim' -exec /import_zim.sh {} \;
 
-kiwix-serve --monitorLibrary --library /library.xml --address 0.0.0.0 --port 80
+# Bind all interfaces by omitting --address: kiwix-serve defaults to all
+# interfaces, and trixie's kiwix-tools 3.7.0 rejects the literal
+# "--address 0.0.0.0" ("IP address is not available on this system").
+kiwix-serve --monitorLibrary --library /library.xml --port 80


### PR DESCRIPTION
## Problem

On 10.0.0.5 the `zim` Docker container fails to start after loading the library:

```
Loading the library from the following files:
    /library.xml
The library was successfully loaded.
ERROR: IP address is not available on this system: 0.0.0.0
```

`docker/zim/Dockerfile` is `FROM debian:13` and installs `kiwix-tools`, which on trixie is **3.7.0**. That version rejects the literal `--address 0.0.0.0` argument the entrypoint passed to `kiwix-serve`, so the server exits immediately after importing the zims.

## Fix

Drop `--address 0.0.0.0` from `docker/zim/entrypoint.sh`. `kiwix-serve` defaults to binding all interfaces, so behavior is unchanged on the working (older) versions and fixed on trixie.

This mirrors `9e92732a`, which applied the identical fix to the systemd `scripts/start_kiwix_serve.sh` path — the Docker entrypoint was simply missed.

## Testing

Shell-only one-line change (`bash -n` clean). Verify on 10.0.0.5 by rebuilding/restarting the `zim` service and confirming Kiwix comes up on its port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)