### PR TITLE
Tolerate transient "database is locked" in download dispatch

### DIFF
--- a/wrolpi/downloader.py
+++ b/wrolpi/downloader.py
@@ -25,6 +25,7 @@ import feedparser
 import pytz
 from feedparser import FeedParserDict
 from sqlalchemy import Column, Integer, String, Text, ForeignKey, Index, JSON
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, relationship
 
 from wrolpi import flags
@@ -1060,6 +1061,23 @@ class DownloadManager:
             return
 
         # Find download whose domain isn't already being downloaded.
+        try:
+            await self._dispatch_new_downloads()
+        except OperationalError as e:
+            if 'locked' in str(e).lower():
+                # Transient SQLite write contention (e.g. the burst of RSS catalog refreshes,
+                # download claims, and config saves right after downloading is enabled at startup).
+                # This dispatch cycle is a no-op; the perpetual worker retries on its next cycle, so
+                # don't raise -- a raised error here floods the logs with tracebacks (and trips the
+                # traceback renderer's "Variable inspector failed" noise) for a self-healing condition.
+                self.log_debug('dispatch_downloads skipped: database is locked (will retry next cycle)')
+                return
+            raise
+
+    async def _dispatch_new_downloads(self):
+        """Claim and dispatch the next batch of `new` downloads.  Split out from `dispatch_downloads`
+        so a transient "database is locked" can be handled there without retrying the signal
+        dispatches inside this transaction."""
         with get_db_session(commit=True) as session:
             new_downloads = list(session.query(Download).filter(
                 Download.status == 'new',

--- a/wrolpi/test/test_downloader.py
+++ b/wrolpi/test/test_downloader.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import pathlib
+import sqlite3
 from abc import ABC
 from datetime import datetime, time, timezone, timedelta
 from http import HTTPStatus
@@ -10,6 +11,7 @@ from unittest import mock
 import pytest
 import pytz
 import yaml
+from sqlalchemy.exc import OperationalError
 
 from wrolpi.api_utils import api_app
 from wrolpi.common import get_wrolpi_config, normalize_domain
@@ -1704,6 +1706,32 @@ async def test_daily_limit_per_domain_allows_under_limit(test_session, test_down
     assert 'https://example.com/new' in _dispatched_urls(dispatch)
     test_session.refresh(new)
     assert new.last_download_attempt is not None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_downloads_tolerates_locked_db(test_session, test_download_manager, test_downloader):
+    """A transient 'database is locked' during dispatch is swallowed (retried next cycle), not raised.
+
+    Regression: once downloading is enabled at startup, the download worker races the write burst
+    (RSS catalog refresh, download claims, config saves) on the single SQLite file.  A raised
+    OperationalError flooded the logs with tracebacks -- and tripped the traceback renderer's
+    'Variable inspector failed' noise -- for a condition the next perpetual cycle resolves on its own.
+    """
+    locked = OperationalError('SELECT', {}, sqlite3.OperationalError('database is locked'))
+    with mock.patch.object(test_download_manager, '_dispatch_new_downloads',
+                           new_callable=mock.AsyncMock, side_effect=locked):
+        # Must return normally, not raise.
+        await test_download_manager.dispatch_downloads()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_downloads_reraises_other_db_errors(test_session, test_download_manager, test_downloader):
+    """Only transient locks are tolerated; a real database error still propagates."""
+    other = OperationalError('SELECT', {}, sqlite3.OperationalError('no such table: download'))
+    with mock.patch.object(test_download_manager, '_dispatch_new_downloads',
+                           new_callable=mock.AsyncMock, side_effect=other):
+        with pytest.raises(OperationalError):
+            await test_download_manager.dispatch_downloads()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

At startup, once downloading is enabled, `10.0.0.x` logs a stream of errors:

```
[wrolpi.api_utils:205] [ERROR] Perpetual worker …perpetual_download_worker had error
  … OperationalError: database is locked
[tracerite:42] [ERROR] Variable inspector failed (please report a bug)
```

## Root cause

The download worker races a **burst of concurrent SQLite writes** on the single DB file right after `enable()`:

- `retry_downloads()` (`main.py:302`) has just marked **every** download `'new'`
- RSS catalog refreshes call `create_downloads()`, which fires its **own background `dispatch_downloads()`** (`downloader.py:975`) — racing the perpetual one
- Multiple download workers claim downloads + write Archives
- `save_downloads_config` re-saves the config

`dispatch_downloads` reads-then-commits in a **deferred** transaction, so when another writer commits mid-cycle it fails with `SQLITE_BUSY_SNAPSHOT` — `"database is locked"`, which `busy_timeout` does **not** absorb (same class as the doc-modeler fix).

It's **self-healing** — the perpetual worker retries next cycle and downloads succeed — but the raised `OperationalError` floods the logs with tracebacks and trips Sanic's traceback renderer (`tracerite`) into its `"Variable inspector failed"` secondary errors.

Verified against the live log: the worker is **correctly gated** (`enable()` runs only after `import_all_db_configs()` completes — `contexts.py:58` starts it disabled), so this is *not* downloads starting before configs import. It's post-enable write contention.

## Fix

- Split the claim-and-dispatch DB work into `_dispatch_new_downloads()`.
- `dispatch_downloads()` swallows a **transient** lock (debug log + return) so the next perpetual cycle retries cleanly. Non-lock database errors still propagate.
- Keeping the retry decision *outside* the transaction (which also `await`s the download signal dispatches) means a lock is never "handled" by re-dispatching — **no double-dispatch**.

No change to download behavior; only removes the log noise for a condition that already recovered.

## Tests

- `test_dispatch_downloads_tolerates_locked_db` — transient lock → returns normally
- `test_dispatch_downloads_reraises_other_db_errors` — real DB error → propagates
- Full downloader suites (`test_downloader.py` + `test_downloads_config.py`): **80 passed**

## Not in scope

The underlying startup write *storm* (retry_downloads marking everything new + the `create_downloads`→background-dispatch self-race) is the pressure behind this, but reducing it means refactoring the download flow — deliberately left out. Other startup log lines (Event-loop-stopped shutdown noise, map_pins/flasher "does not exist", tag-dir "refusing to delete", media-dir `0o40775`) are benign/working-as-designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)