### PR TITLE
install: create Controller venv and generate a UTF-8 locale

### DIFF
--- a/scripts/install_debian_12.sh
+++ b/scripts/install_debian_12.sh
@@ -4,6 +4,13 @@ echo "Debian 12 install start: $(date '+%Y-%m-%d %H:%M:%S')"
 set -x
 set -e
 
+# Run the install in a predictable UTF-8 locale.  Fresh images (or SSH sessions
+# forwarding LC_* variables from the client) may reference an ungenerated
+# locale, which makes apt/perl/python emit "Cannot set LC_CTYPE" warnings
+# throughout the install.  C.UTF-8 is built into glibc, always present, and
+# locale-neutral, so this does not change the user's configured locale.
+export LC_ALL=C.UTF-8
+
 # Update if we haven't updated in the last day.
 [ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -1)" ] && apt update
 # Install dependencies.

--- a/scripts/install_debian_12.sh
+++ b/scripts/install_debian_12.sh
@@ -44,6 +44,10 @@ npm install || npm install || npm install || npm install # try install multiple 
 python3 -m venv /opt/wrolpi/venv
 /opt/wrolpi/venv/bin/pip3 install --upgrade -r /opt/wrolpi/requirements.txt
 
+# Create the Controller venv (kept separate from the main API venv).
+python3 -m venv /opt/wrolpi/controller/venv
+/opt/wrolpi/controller/venv/bin/pip3 install --upgrade -r /opt/wrolpi/controller/requirements.txt
+
 # Create the WROLPi user
 grep wrolpi: /etc/passwd || useradd -md /home/wrolpi wrolpi -s "$(command -v bash)"
 

--- a/scripts/install_raspberrypios.sh
+++ b/scripts/install_raspberrypios.sh
@@ -4,6 +4,13 @@ echo "Raspberry Pi OS install start: $(date '+%Y-%m-%d %H:%M:%S')"
 set -x
 set -e
 
+# Run the install in a predictable UTF-8 locale.  Fresh images (or SSH sessions
+# forwarding LC_* variables from the client) may reference an ungenerated
+# locale, which makes apt/perl/python emit "Cannot set LC_CTYPE" warnings
+# throughout the install.  C.UTF-8 is built into glibc, always present, and
+# locale-neutral, so this does not change the user's configured locale.
+export LC_ALL=C.UTF-8
+
 # Update if we haven't updated in the last day.
 [ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -1)" ] && apt update
 # Install dependencies.

--- a/scripts/install_raspberrypios.sh
+++ b/scripts/install_raspberrypios.sh
@@ -44,6 +44,10 @@ npm install || npm install || npm install || npm install # try install multiple 
 python3 -m venv /opt/wrolpi/venv
 /opt/wrolpi/venv/bin/pip3 install --upgrade -r /opt/wrolpi/requirements.txt
 
+# Create the Controller venv (kept separate from the main API venv).
+python3 -m venv /opt/wrolpi/controller/venv
+/opt/wrolpi/controller/venv/bin/pip3 install --upgrade -r /opt/wrolpi/controller/requirements.txt
+
 # Create the WROLPi user
 grep wrolpi: /etc/passwd || useradd -md /home/wrolpi wrolpi -s "$(command -v bash)"
 


### PR DESCRIPTION
Two fixes for fresh `install.sh` runs, both found while reproducing an install on a fresh Raspberry Pi OS Trixie (Debian 13) image on real hardware (Pi 4B, 10.0.0.8).

## 1. Controller venv never created on fresh install

`wrolpi-controller` crash-loops with `203/EXEC`:

```
wrolpi-controller.service: Unable to locate executable '/opt/wrolpi/controller/venv/bin/python': No such file or directory
```

The Controller venv (`/opt/wrolpi/controller/venv`) is only ever created by `upgrade.sh` and `reset_virtual_environments.sh` — neither runs during a fresh install. Both install scripts created only the main API venv. `repair.sh` then skips controller repair when the venv is absent (fresh-install case) but still `systemctl start wrolpi-controller` unconditionally, so the service restart-loops forever. Affects **any** fresh `install.sh` install (not Trixie-specific); pi-gen-built images escape it because the venv is baked at image-build time.

**Fix:** create the Controller venv inline right after the main venv in both install scripts.

## 2. Ungenerated locale spams the install log

Fresh installs (and SSH sessions that forward `LC_*` from the client) can reference an ungenerated locale, so apt/perl/python emit `Cannot set LC_CTYPE to default locale` throughout the install.

**Fix:** `export LC_ALL=C.UTF-8` for the install run. `C.UTF-8` is built into glibc, always present, and locale-neutral — it silences the warnings without generating a locale, without adding a dependency, and **without changing the user's configured locale** (an `en_GB.UTF-8` system stays `en_GB.UTF-8`; the install-time export is not persisted and never touches `/etc/default/locale`).

## Testing

Verified on the fresh Trixie install on 10.0.0.8:

- Controller: went from 1016 crash-loops to `active` with **0 restarts**; all `help.sh` controller checks pass; full stack green via Caddy `:443` (app 200, API 200).
- Locale: under `LC_ALL=C.UTF-8`, apt/perl/`locale` run with no `LC_CTYPE` warning; the system default locale is unchanged.
- `help.sh` is otherwise all-green; remaining non-OK items are expected on a content-less machine with no external drive (no imported files, no mounted drive, no map/zim content) or stock-Debian behavior (`smartd` exits when no SMART device is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)