### PR TITLE
install: always install serve; resolve it via PATH in wrolpi-app

### DIFF
--- a/etc/raspberrypios/wrolpi-app.service
+++ b/etc/raspberrypios/wrolpi-app.service
@@ -6,7 +6,9 @@ Conflicts=wrolpi-app-dev.service
 
 [Service]
 # Use explicit `serve.json` so `epub.html` is not lost.
-ExecStart=/usr/local/bin/serve build -l 3000 -c /opt/wrolpi/app/serve.json
+# Resolve `serve` via PATH so it works regardless of npm's global prefix
+# (/usr/local/bin vs /usr/bin depending on how node was installed).
+ExecStart=/usr/bin/env serve build -l 3000 -c /opt/wrolpi/app/serve.json
 Group=wrolpi
 User=wrolpi
 WorkingDirectory=/opt/wrolpi/app/

--- a/scripts/install_debian_12.sh
+++ b/scripts/install_debian_12.sh
@@ -20,8 +20,11 @@ apt-get install -y $(cat /opt/wrolpi/debian-live-config/config/package-lists/wro
 node -v
 npm -v
 
-# Install serve, and archiving tools.
-single-file --version || sudo npm i -g serve@12.0.1 single-file-cli@2.0.73 readability-extractor@0.0.6
+# Install serve, and archiving tools.  Check each independently so a present
+# single-file cannot mask a missing serve (which breaks wrolpi-app).
+command -v serve >/dev/null || sudo npm i -g serve@12.0.1
+single-file --version >/dev/null 2>&1 || sudo npm i -g single-file-cli@2.0.73
+command -v readability-extractor >/dev/null || sudo npm i -g readability-extractor@0.0.6
 
 # Install Deno runtime; single-file runs under it.
 command -v deno || {

--- a/scripts/install_raspberrypios.sh
+++ b/scripts/install_raspberrypios.sh
@@ -20,8 +20,11 @@ apt-get install -y $(cat /opt/wrolpi/pi-gen/stage2/04-wrolpi/01-packages-nr)
 node -v
 npm -v
 
-# Install serve, and archiving tools.
-single-file --version || sudo npm i -g serve@12.0.1 single-file-cli@2.0.73 readability-extractor@0.0.6
+# Install serve, and archiving tools.  Check each independently so a present
+# single-file cannot mask a missing serve (which breaks wrolpi-app).
+command -v serve >/dev/null || sudo npm i -g serve@12.0.1
+single-file --version >/dev/null 2>&1 || sudo npm i -g single-file-cli@2.0.73
+command -v readability-extractor >/dev/null || sudo npm i -g readability-extractor@0.0.6
 
 # Install Deno runtime; single-file runs under it.
 command -v deno || {


### PR DESCRIPTION
## Problem

`wrolpi-app` crash-loops with `203/EXEC` (`Unable to locate executable '/usr/local/bin/serve'`). Reported twice by real users on fresh Raspberry Pi OS installs; the second report (with `/opt/wrolpi/install.log`) confirmed the exact mechanism.

## Two independent causes, both fixed

**1. `serve` never installed on re-run / baked image.** The install scripts gated serve behind single-file:

```bash
single-file --version || sudo npm i -g serve@12.0.1 single-file-cli@2.0.73 readability-extractor@0.0.6
```

If `single-file` is already present, the `||` short-circuits and **serve is never installed** — and re-running `install.sh` can't fix it. The user's log shows exactly this: `single-file --version` → `2.0.73`, then no `npm i -g serve` anywhere. Fix: install each npm global independently based on its own presence.

**2. `serve` at the wrong prefix.** The unit hardcoded `/usr/local/bin/serve`, which breaks when npm's global prefix puts serve in `/usr/bin` (depends on how node was installed — the likely cause of the original screenshot). Fix: `ExecStart=/usr/bin/env serve …` resolves it via PATH.

## Testing

Verified on a fresh Raspberry Pi OS Trixie install (Pi 4B, 10.0.0.8):

- `/usr/bin/env serve` resolves under systemd as the `wrolpi` user (serve 12.0.1, exit 0).
- With the new `ExecStart`, `wrolpi-app` is `active` with **0 restarts** and serves `200`.
- Both install scripts pass `bash -n`.

## Affected-user remediation (no release needed)

```bash
sudo npm i -g serve@12.0.1
sudo systemctl restart wrolpi-app
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)