### PR TITLE
Strip whitespace from inventory item string values on save

### DIFF
--- a/modules/inventory/common.py
+++ b/modules/inventory/common.py
@@ -55,7 +55,7 @@ def _allowed_item_keys(fields_: list) -> set:
 
 
 def _normalize_items(items: list, fields_: list) -> list:
-    """Filter each item to the schema's allowed keys and assign stable ids (fresh id for any missing/duplicate)."""
+    """Filter each item to the schema's allowed keys, strip whitespace from string values, and assign stable ids (fresh id for any missing/duplicate)."""
     if not isinstance(items, list):
         raise ValidationError('items must be a list')
     allowed = _allowed_item_keys(fields_)
@@ -63,7 +63,7 @@ def _normalize_items(items: list, fields_: list) -> list:
     used = set()
     normalized = []
     for raw in items:
-        clean = {k: v for k, v in raw.items() if k in allowed}
+        clean = {k: (v.strip() if isinstance(v, str) else v) for k, v in raw.items() if k in allowed}
         item_id = raw.get('id')
         if not isinstance(item_id, int) or item_id in used:
             counter += 1

--- a/modules/inventory/test/test_inventory.py
+++ b/modules/inventory/test/test_inventory.py
@@ -68,6 +68,19 @@ def test_save_inventory_items(food_inventory_factory, test_inventory_configs):
     assert [i['name'] for i in saved['items']] == ['Rice']
 
 
+def test_save_inventory_strips_whitespace(food_inventory_factory, test_inventory_configs):
+    """Leading/trailing whitespace in string field values is stripped on save (categories, names, etc.)."""
+    config = test_inventory_configs
+    slug = food_inventory_factory()
+    saved = config.save_inventory(slug, dict(items=[
+        dict(name='  Rice  ', category=' grains ', count='4'),
+    ]))
+    item = saved['items'][0]
+    assert item['name'] == 'Rice'
+    assert item['category'] == 'grains'
+    assert item['count'] == '4'
+  
+
 def test_save_inventory_fields(food_inventory_factory, test_inventory_configs):
     config = test_inventory_configs
     slug = food_inventory_factory()


### PR DESCRIPTION
## What changed

modules/inventory/common.py: `_normalize_items` now strips leading/trailing whitespace from any string-valued item field before persisting an inventory (name, category, subcategory, location, etc.). Non-string values (numbers, None) are left untouched.

## Why

Inventory items are saved to disk exactly as typed, with no trimming, either client-side or server-side. Since inventory summaries and grouping (see InventorySummary/summarize.js) group items by exact string match on fields like category, a value saved as "grains " would silently form its own group separate from "grains". This has been open as #52 since 2021; the underlying inventory storage has since moved to the config-only YAML model, but the same gap exists in the current `_normalize_items`.

## Testing

Added `test_save_inventory_strips_whitespace` in modules/inventory/test/test_inventory.py, following the existing `test_save_inventory_items` pattern: saves an item with leading/trailing spaces in `name` and `category`, and asserts both come back trimmed.

Closes #52