### PR TITLE
ui: PathInput, and a browser layer that can see layout

### DIFF
--- a/app/cypress/e2e/settings/special-directories.cy.js
+++ b/app/cypress/e2e/settings/special-directories.cy.js
@@ -1,0 +1,117 @@
+/*
+ * The five Special Directories fields on /admin/settings.
+ *
+ * These are the fields that shipped printing their own prefix over their own value, and the
+ * ones whose visible labels were never associated with their inputs.  Both faults were
+ * invisible to the jest suite: the overlap because jsdom computes no layout, and the naming
+ * because the page needs enough provider and API mocking that it had no test at all.
+ *
+ * Intercepting the API is not mocking the component -- the page really renders, so the
+ * accessible names and the real geometry are the ones a user gets.
+ */
+describe('Special Directories settings', () => {
+    const mockSettings = {
+        archive_destination: 'archive/%(domain_tag)s/%(domain)s',
+        download_manager_disabled: false,
+        download_manager_stopped: false,
+        download_on_startup: true,
+        download_timeout: 0,
+        download_wait: 20,
+        download_window_start: null,
+        download_window_end: null,
+        hotspot_device: 'wlan0',
+        hotspot_on_startup: true,
+        hotspot_password: 'wrolpi hotspot',
+        hotspot_ssid: 'WROLPi',
+        check_for_upgrades: true,
+        ignore_outdated_zims: false,
+        log_level: 'info',
+        map_destination: 'map',
+        nav_color: 'violet',
+        media_directory: '/media/wrolpi',
+        playlists_destination: 'playlists',
+        tags_directory: true,
+        throttle_on_startup: false,
+        version: '1.0.0',
+        videos_destination: 'videos/%(channel_tag)s/%(channel_name)s',
+        wrol_mode: false,
+        zims_destination: 'zims',
+        save_ffprobe_json: true,
+    };
+
+    const directories = [
+        ['Archive Directory', 'archive/%(domain_tag)s/%(domain)s'],
+        ['Videos Directory', 'videos/%(channel_tag)s/%(channel_name)s'],
+        ['Map Directory', 'map'],
+        ['Zims Directory', 'zims'],
+        ['Playlists Directory', 'playlists'],
+    ];
+
+    beforeEach(() => {
+        cy.intercept('GET', '/api/status', {
+            statusCode: 200,
+            body: {
+                version: '1.0.0',
+                flags: {},
+                cpu_percent: 10,
+                memory_percent: 30,
+                downloads: {
+                    pending: 0, recurring: 0, disabled: false, stopped: false,
+                    outside_download_window: false,
+                },
+            },
+        }).as('getStatus');
+        cy.intercept('GET', '/api/tags', {statusCode: 200, body: {tags: []}}).as('getTags');
+        cy.intercept('GET', '/api/events', {statusCode: 200, body: {events: []}}).as('getEvents');
+        cy.intercept('POST', '/api/search/suggestions', {
+            statusCode: 200,
+            body: {fileGroups: 0, zimsEstimates: [], channels: [], domains: []},
+        }).as('getSuggestions');
+        cy.intercept('GET', '/api/settings', {statusCode: 200, body: {...mockSettings}})
+            .as('getSettings');
+
+        cy.visit('/admin/settings');
+        cy.wait('@getSettings');
+    });
+
+    it('names every directory field, so they can be told apart', () => {
+        /*
+         * All five fields sit in one grid, hold similar-looking relative paths, and share the
+         * same prefix.  Without a name attached to the input, a screen reader user hears five
+         * fields described only as "/media/wrolpi/" and cannot tell which one saves videos.
+         */
+        directories.forEach(([label, value]) => {
+            cy.contains('label', label)
+                .invoke('attr', 'for')
+                .should('be.a', 'string')
+                .then((inputId) => {
+                    cy.get(`#${CSS.escape(inputId)}`)
+                        .should('have.value', value)
+                        .and('match', 'input');
+                });
+        });
+    });
+
+    it('shows the media directory beside each value, never over it', () => {
+        // The reported bug: `a/media/wrolpi/hain_tag)s/%(domain)s`.
+        cy.get('.wrolpi-path-input').should('have.length', directories.length);
+
+        cy.get('.wrolpi-path-input').each(($field) => {
+            const prefix = $field.find('.wrolpi-path-input-prefix')[0].getBoundingClientRect();
+            const input = $field.find('input')[0].getBoundingClientRect();
+            expect(prefix.right, 'prefix ends where the input begins')
+                .to.be.at.most(input.left + 0.5);
+            expect(input.width, 'input is wide enough to read and edit').to.be.greaterThan(60);
+        });
+    });
+
+    it('keeps the prefix out of the value the user edits and saves', () => {
+        cy.contains('label', 'Archive Directory').invoke('attr', 'for').then((inputId) => {
+            cy.get(`#${CSS.escape(inputId)}`)
+                .should('have.value', 'archive/%(domain_tag)s/%(domain)s')
+                .and('not.have.value', '/media/wrolpi/archive/%(domain_tag)s/%(domain)s');
+        });
+
+        cy.get('.wrolpi-path-input-prefix').first().should('have.text', '/media/wrolpi/');
+    });
+});

--- a/app/cypress/support/component.js
+++ b/app/cypress/support/component.js
@@ -104,8 +104,9 @@ Cypress.Commands.add('shouldNotOverlap', {prevSubject: false}, (firstSelector, s
         cy.get(secondSelector).then(($second) => {
             const a = $first[0].getBoundingClientRect();
             const b = $second[0].getBoundingClientRect();
-            const overlaps = a.right > b.left + 0.5 && b.right > a.left + 0.5
-                && a.bottom > b.top + 0.5 && b.bottom > a.top + 0.5;
+            const overlapsHorizontally = (a.right > b.left + 0.5) && (b.right > a.left + 0.5);
+            const overlapsVertically = (a.bottom > b.top + 0.5) && (b.bottom > a.top + 0.5);
+            const overlaps = overlapsHorizontally && overlapsVertically;
             expect(
                 overlaps,
                 `${firstSelector} [${a.left}, ${a.right}] must not overlap `

--- a/app/cypress/support/component.js
+++ b/app/cypress/support/component.js
@@ -25,6 +25,7 @@ import {QueryProvider} from "../../src/hooks/customHooks";
 import {TagsProvider} from "../../src/Tags";
 import {MantineProvider} from "@mantine/core";
 import {cssVariablesResolver, mantineTheme} from "../../src/themes/mantine";
+import {MediaFilterDefs} from "../../src/themes/MediaFilterDefs";
 import React from "react";
 
 Cypress.on('uncaught:exception', (err, runnable) => {
@@ -58,6 +59,60 @@ Cypress.Commands.add('mountWithRouter', (component, options) => {
         </MemoryRouter>,
         options
     );
+});
+
+/*
+ * Mount a component from src/components/ui with nothing but Mantine's provider and the
+ * theme stamped on <html> -- no router, no query client, no tag fixtures.
+ *
+ * That spartan setup is the whole point.  These components take props and read no ambient
+ * state, so a real browser can render one in isolation, which is what lets a spec assert
+ * things jsdom cannot compute: whether two boxes overlap, whether text is clipped, whether
+ * a token actually resolved.  The Settings page shipped five unreadable inputs because
+ * `padding-inline-start: auto` silently became zero, and no jsdom test could have seen it --
+ * getBoundingClientRect() returns zeros there.
+ *
+ * `theme` stamps data-theme the way ThemeProvider does; `mediaFilter` stamps
+ * data-media-filter and mounts the SVG filter definitions, since a filter referenced but
+ * never defined silently does nothing.
+ */
+Cypress.Commands.add('mountUI', (component, options = {}) => {
+    const {theme = 'light', mediaFilter, ...mountOptions} = options;
+
+    const html = document.documentElement;
+    html.dataset.theme = theme;
+    if (mediaFilter) html.dataset.mediaFilter = mediaFilter;
+    else delete html.dataset.mediaFilter;
+
+    return cy.mount(
+        <MantineProvider theme={mantineTheme} cssVariablesResolver={cssVariablesResolver}>
+            {mediaFilter ? <MediaFilterDefs/> : null}
+            {component}
+        </MantineProvider>,
+        mountOptions
+    );
+});
+
+/**
+ * Fail unless two elements are laid out side by side.
+ *
+ * Reads real geometry, so it catches an element painted over another regardless of how the
+ * overlap came about -- an invalid length, a collapsed flex row, a stale absolute position.
+ */
+Cypress.Commands.add('shouldNotOverlap', {prevSubject: false}, (firstSelector, secondSelector) => {
+    cy.get(firstSelector).then(($first) => {
+        cy.get(secondSelector).then(($second) => {
+            const a = $first[0].getBoundingClientRect();
+            const b = $second[0].getBoundingClientRect();
+            const overlaps = a.right > b.left + 0.5 && b.right > a.left + 0.5
+                && a.bottom > b.top + 0.5 && b.bottom > a.top + 0.5;
+            expect(
+                overlaps,
+                `${firstSelector} [${a.left}, ${a.right}] must not overlap `
+                + `${secondSelector} [${b.left}, ${b.right}]`,
+            ).to.equal(false);
+        });
+    });
 });
 
 Cypress.Commands.add('mountWithTags', (component, options) => {

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -16,6 +16,7 @@ import {
     Modal,
     Pagination,
     Panel,
+    PathInput,
     Placeholder,
     Progress,
     SearchBox,
@@ -280,6 +281,14 @@ export function ThemeSamplePage() {
                 </div>
                 <div style={{marginTop: 12}}>
                     <Textarea label='Notes' placeholder='Notes about this download…' minRows={2}/>
+                </div>
+                <div style={{marginTop: 12}}>
+                    <PathInput
+                        prefix='/media/wrolpi/'
+                        label='Videos Directory'
+                        description="A fixed prefix beside the value, not layered over it."
+                        defaultValue='videos/%(channel_name)s'
+                    />
                 </div>
                 <div style={{marginTop: 12}}>
                     <ActionInput

--- a/app/src/components/admin/Settings.js
+++ b/app/src/components/admin/Settings.js
@@ -28,6 +28,7 @@ import {
     Select,
     ThemePicker,
     toast,
+    PathInput,
     TextInput,
 } from "../ui";
 
@@ -776,9 +777,8 @@ export function SettingsPage() {
                                 position='top'
                             />
                         </label>
-                        <TextInput
-                            leftSectionWidth='auto'
-                            leftSection={<span style={{fontSize: '0.85em', paddingLeft: 4}}>{mediaDirectoryLabel}</span>}
+                        <PathInput
+                            prefix={mediaDirectoryLabel}
                             value={state.archive_destination}
                             disabled={!editSpecialDirectories}
                             onChange={e => handleInputChange('archive_destination', e.currentTarget.value)}
@@ -804,9 +804,8 @@ export function SettingsPage() {
                                 position='top'
                             />
                         </label>
-                        <TextInput
-                            leftSectionWidth='auto'
-                            leftSection={<span style={{fontSize: '0.85em', paddingLeft: 4}}>{mediaDirectoryLabel}</span>}
+                        <PathInput
+                            prefix={mediaDirectoryLabel}
                             value={state.videos_destination}
                             disabled={!editSpecialDirectories}
                             onChange={e => handleInputChange('videos_destination', e.currentTarget.value)}
@@ -814,9 +813,8 @@ export function SettingsPage() {
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
                         <label>Map Directory</label>
-                        <TextInput
-                            leftSectionWidth='auto'
-                            leftSection={<span style={{fontSize: '0.85em', paddingLeft: 4}}>{mediaDirectoryLabel}</span>}
+                        <PathInput
+                            prefix={mediaDirectoryLabel}
                             value={state.map_destination}
                             disabled={!editSpecialDirectories}
                             onChange={e => handleInputChange('map_destination', e.currentTarget.value)}
@@ -824,9 +822,8 @@ export function SettingsPage() {
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
                         <label>Zims Directory</label>
-                        <TextInput
-                            leftSectionWidth='auto'
-                            leftSection={<span style={{fontSize: '0.85em', paddingLeft: 4}}>{mediaDirectoryLabel}</span>}
+                        <PathInput
+                            prefix={mediaDirectoryLabel}
                             value={state.zims_destination}
                             disabled={!editSpecialDirectories}
                             onChange={e => handleInputChange('zims_destination', e.currentTarget.value)}
@@ -834,9 +831,8 @@ export function SettingsPage() {
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
                         <label>Playlists Directory</label>
-                        <TextInput
-                            leftSectionWidth='auto'
-                            leftSection={<span style={{fontSize: '0.85em', paddingLeft: 4}}>{mediaDirectoryLabel}</span>}
+                        <PathInput
+                            prefix={mediaDirectoryLabel}
                             value={state.playlists_destination}
                             disabled={!editSpecialDirectories}
                             onChange={e => handleInputChange('playlists_destination', e.currentTarget.value)}

--- a/app/src/components/admin/Settings.js
+++ b/app/src/components/admin/Settings.js
@@ -759,25 +759,25 @@ export function SettingsPage() {
 
                 <Grid>
                     <Grid.Col span={{base: 12, sm: 6}}>
-                        <label>
-                            Archive Directory
-                            <InfoPopup
-                                w={340}
-                                content={<>
-                                    <p>Variables:</p>
-                                    <ul>
-                                        <li><code>%(domain)s</code> - Domain name (e.g., "example.com")</li>
-                                        <li><code>%(domain_tag)s</code> - Tag name for the domain (empty if no
-                                            tag)
-                                        </li>
-                                        <li><code>%(tag)s</code> - Alias for the tag name</li>
-                                        <li><code>%(name)s</code> - Alias for the domain name</li>
-                                    </ul>
-                                </>}
-                                position='top'
-                            />
-                        </label>
                         <PathInput
+                            label={<>
+                                Archive Directory
+                                <InfoPopup
+                                    w={340}
+                                    content={<>
+                                        <p>Variables:</p>
+                                        <ul>
+                                            <li><code>%(domain)s</code> - Domain name (e.g., "example.com")</li>
+                                            <li><code>%(domain_tag)s</code> - Tag name for the domain (empty if no
+                                                tag)
+                                            </li>
+                                            <li><code>%(tag)s</code> - Alias for the tag name</li>
+                                            <li><code>%(name)s</code> - Alias for the domain name</li>
+                                        </ul>
+                                    </>}
+                                    position='top'
+                                />
+                            </>}
                             prefix={mediaDirectoryLabel}
                             value={state.archive_destination}
                             disabled={!editSpecialDirectories}
@@ -785,26 +785,26 @@ export function SettingsPage() {
                         />
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
-                        <label>
-                            Videos Directory
-                            <InfoPopup
-                                w={340}
-                                content={<>
-                                    <p>Variables:</p>
-                                    <ul>
-                                        <li><code>%(channel_name)s</code> - Channel name</li>
-                                        <li><code>%(channel_tag)s</code> - Tag name for the channel (empty if no
-                                            tag)
-                                        </li>
-                                        <li><code>%(channel_domain)s</code> - Domain from the channel URL</li>
-                                        <li><code>%(tag)s</code> - Alias for the tag name</li>
-                                        <li><code>%(name)s</code> - Alias for the channel name</li>
-                                    </ul>
-                                </>}
-                                position='top'
-                            />
-                        </label>
                         <PathInput
+                            label={<>
+                                Videos Directory
+                                <InfoPopup
+                                    w={340}
+                                    content={<>
+                                        <p>Variables:</p>
+                                        <ul>
+                                            <li><code>%(channel_name)s</code> - Channel name</li>
+                                            <li><code>%(channel_tag)s</code> - Tag name for the channel (empty if no
+                                                tag)
+                                            </li>
+                                            <li><code>%(channel_domain)s</code> - Domain from the channel URL</li>
+                                            <li><code>%(tag)s</code> - Alias for the tag name</li>
+                                            <li><code>%(name)s</code> - Alias for the channel name</li>
+                                        </ul>
+                                    </>}
+                                    position='top'
+                                />
+                            </>}
                             prefix={mediaDirectoryLabel}
                             value={state.videos_destination}
                             disabled={!editSpecialDirectories}
@@ -812,8 +812,8 @@ export function SettingsPage() {
                         />
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
-                        <label>Map Directory</label>
                         <PathInput
+                            label='Map Directory'
                             prefix={mediaDirectoryLabel}
                             value={state.map_destination}
                             disabled={!editSpecialDirectories}
@@ -821,8 +821,8 @@ export function SettingsPage() {
                         />
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
-                        <label>Zims Directory</label>
                         <PathInput
+                            label='Zims Directory'
                             prefix={mediaDirectoryLabel}
                             value={state.zims_destination}
                             disabled={!editSpecialDirectories}
@@ -830,8 +830,8 @@ export function SettingsPage() {
                         />
                     </Grid.Col>
                     <Grid.Col span={{base: 12, sm: 6}}>
-                        <label>Playlists Directory</label>
                         <PathInput
+                            label='Playlists Directory'
                             prefix={mediaDirectoryLabel}
                             value={state.playlists_destination}
                             disabled={!editSpecialDirectories}

--- a/app/src/components/ui/Inputs.tsx
+++ b/app/src/components/ui/Inputs.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef} from 'react';
+import React, {forwardRef, useId} from 'react';
 import {
     Checkbox as MCheckbox,
     MultiSelect,
@@ -57,6 +57,66 @@ export function Toggle({style, className, ...props}: ToggleProps) {
         {...props}
     />
 }
+
+export interface PathInputProps
+    extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
+    label?: React.ReactNode;
+    description?: React.ReactNode;
+    error?: React.ReactNode;
+    /**
+     * A fixed, non-editable path the value hangs off — the media directory, say.  It is
+     * not part of the value, and typing never changes it.
+     */
+    prefix: string;
+}
+
+/**
+ * A path input with a fixed prefix shown to the left of what the user types.
+ *
+ * The prefix is a *sibling* of the input rather than a section layered inside it, which is
+ * the point: Mantine positions `leftSection` absolutely and reserves room for it with
+ * `--input-padding-inline-start`, so a call site that gets that width wrong prints the
+ * prefix straight through the value.  Passing `leftSectionWidth='auto'` did exactly that
+ * — `padding-inline-start: auto` is invalid, so it resolved to zero and every one of these
+ * fields rendered its path on top of its own contents.
+ *
+ * As two boxes in a flex row there is no width to compute and nothing to overlap.  It also
+ * sizes itself to any prefix, which matters here: the media directory is `/media/wrolpi`
+ * on a Pi and something else entirely under Docker.
+ */
+export const PathInput = forwardRef<HTMLInputElement, PathInputProps>((
+    {prefix, label, description, error, required, disabled, className, id, ...props}, ref
+) => {
+    const generated = useId();
+    const inputId = id ?? `${generated}-input`;
+    const prefixId = `${generated}-prefix`;
+
+    return <div className={['wrolpi-path-input', className].filter(Boolean).join(' ')}>
+        {label && <label className='wrolpi-path-input-label' htmlFor={inputId}>
+            {label}{required && <span aria-hidden='true'> *</span>}
+        </label>}
+        <div className='wrolpi-path-input-control' data-disabled={disabled ? true : undefined}
+             data-error={error ? true : undefined}>
+            {/*
+              Described rather than hidden: a screen reader should hear which directory the
+              typed path is relative to, since that is the whole point of showing it.
+            */}
+            <span className='wrolpi-path-input-prefix' id={prefixId}>{prefix}</span>
+            <input
+                ref={ref}
+                id={inputId}
+                type='text'
+                required={required}
+                disabled={disabled}
+                aria-describedby={prefixId}
+                {...props}
+            />
+        </div>
+        {description && <div className='wrolpi-path-input-description'>{description}</div>}
+        {error && <div className='wrolpi-path-input-error'>{error}</div>}
+    </div>
+});
+PathInput.displayName = 'PathInput';
 
 export interface ActionInputProps extends React.ComponentProps<typeof MTextInput> {
     /** Button (or buttons) attached to the input's trailing edge. */

--- a/app/src/components/ui/Inputs.tsx
+++ b/app/src/components/ui/Inputs.tsx
@@ -90,6 +90,20 @@ export const PathInput = forwardRef<HTMLInputElement, PathInputProps>((
     const generated = useId();
     const inputId = id ?? `${generated}-input`;
     const prefixId = `${generated}-prefix`;
+    const descriptionId = `${generated}-description`;
+    const errorId = `${generated}-error`;
+
+    /*
+     * Everything that explains the field, in reading order.  Drawing the description and the
+     * error on screen does not announce them -- an unreferenced element is invisible to a
+     * screen reader, which would leave a user hearing the label and the prefix but never the
+     * variables the path accepts, nor the reason a path was just rejected.
+     */
+    const describedBy = [
+        prefixId,
+        description ? descriptionId : null,
+        error ? errorId : null,
+    ].filter(Boolean).join(' ');
 
     return <div className={['wrolpi-path-input', className].filter(Boolean).join(' ')}>
         {label && <label className='wrolpi-path-input-label' htmlFor={inputId}>
@@ -100,20 +114,27 @@ export const PathInput = forwardRef<HTMLInputElement, PathInputProps>((
             {/*
               Described rather than hidden: a screen reader should hear which directory the
               typed path is relative to, since that is the whole point of showing it.
+
+              `title` carries the full path because the prefix truncates when it is long --
+              the media directory is whatever the API reports, and a prefix that refused to
+              shrink took the entire row and left the input 18px wide.
             */}
-            <span className='wrolpi-path-input-prefix' id={prefixId}>{prefix}</span>
+            <span className='wrolpi-path-input-prefix' id={prefixId} title={prefix}>{prefix}</span>
             <input
                 ref={ref}
                 id={inputId}
                 type='text'
                 required={required}
                 disabled={disabled}
-                aria-describedby={prefixId}
+                aria-describedby={describedBy}
+                aria-invalid={error ? true : undefined}
                 {...props}
             />
         </div>
-        {description && <div className='wrolpi-path-input-description'>{description}</div>}
-        {error && <div className='wrolpi-path-input-error'>{error}</div>}
+        {description && <div className='wrolpi-path-input-description' id={descriptionId}>
+            {description}
+        </div>}
+        {error && <div className='wrolpi-path-input-error' id={errorId}>{error}</div>}
     </div>
 });
 PathInput.displayName = 'PathInput';

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -63,6 +63,32 @@ describe('PathInput lays its prefix beside the value, never over it', () => {
         });
     });
 
+    it('still leaves somewhere to type when the media directory is a long path', () => {
+        /*
+         * The prefix is whatever the API reports as the media directory, so its length is not
+         * ours to assume.  It is `/media/wrolpi` on a Pi, but a development box or an unusual
+         * Docker mount can report something far longer, and a prefix that refuses to shrink
+         * would take the whole row and leave the input at zero width -- a field that cannot
+         * be typed into at all.
+         */
+        cy.mountUI(
+            <div style={{width: 320}}>
+                <PathInput
+                    label='Archive Destination'
+                    prefix='/mnt/storage/external/wrolpi-media-library-volume/'
+                    defaultValue='archive/%(domain)s'
+                />
+            </div>,
+        );
+
+        cy.shouldNotOverlap('.wrolpi-path-input-prefix', '.wrolpi-path-input-control input');
+        cy.get('.wrolpi-path-input-control input').should(($input) =>
+            expect($input[0].clientWidth, 'input keeps a usable width').to.be.greaterThan(60));
+        // The control must not spill out of the column it was given either.
+        cy.get('.wrolpi-path-input-control').should(($control) =>
+            expect($control[0].getBoundingClientRect().width).to.be.at.most(320));
+    });
+
     it('detects the overlap that started this, so the check has teeth', () => {
         /*
          * The original defect, reproduced deliberately: Mantine turns leftSectionWidth into

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,0 +1,175 @@
+import React from 'react';
+import {ActionInput, Button, PathInput, TextInput} from './index';
+import {themeNames} from '../../themes/names';
+
+/*
+ * Layout and theming assertions for the component library, run in a real browser.
+ *
+ * These belong here rather than in ui.test.js because jsdom parses CSS but never lays it
+ * out: getBoundingClientRect() returns zeros, getComputedStyle() will not resolve a custom
+ * property through the cascade, and no filter is ever applied.  A jest test therefore
+ * cannot tell whether two boxes overlap, whether a token resolved, or whether media got
+ * tinted -- which is precisely how five unreadable inputs reached the Settings page.
+ *
+ * Keep this file to claims that need real layout.  Behaviour that jsdom can judge belongs
+ * in ui.test.js, which runs in about two seconds against the whole library.
+ */
+
+describe('PathInput lays its prefix beside the value, never over it', () => {
+    // Every theme, because a theme is free to restyle borders and padding, and the fix has
+    // to hold in all four rather than in whichever one happened to be open.
+    themeNames.forEach((theme) => {
+        it(`keeps the prefix clear of the input in ${theme}`, () => {
+            cy.mountUI(
+                <PathInput
+                    label='Archive Destination'
+                    prefix='/media/wrolpi'
+                    defaultValue='archive/%(domain)s'
+                />,
+                {theme},
+            );
+
+            cy.shouldNotOverlap('.wrolpi-path-input-prefix', '.wrolpi-path-input-control input');
+
+            // Sharing one outline is the reason the pair reads as a single control; a gap
+            // would mean the flex row broke and they are two separate fields again.
+            cy.get('.wrolpi-path-input-prefix').then(($prefix) => {
+                cy.get('.wrolpi-path-input-control input').then(($input) => {
+                    const prefix = $prefix[0].getBoundingClientRect();
+                    const input = $input[0].getBoundingClientRect();
+                    expect(input.left - prefix.right, 'gap between prefix and input')
+                        .to.be.closeTo(0, 2);
+                });
+            });
+        });
+    });
+
+    it('shows the whole value, with room left to type', () => {
+        cy.mountUI(
+            <PathInput prefix='/media/wrolpi' defaultValue='archive/%(domain)s'/>,
+        );
+
+        /*
+         * scrollWidth well beyond clientWidth means the value is cut off -- the visible
+         * symptom when a prefix eats the input's usable width.  Both are rounded to whole
+         * pixels from a fractional layout, so they disagree by a pixel on a field that fits
+         * perfectly; the tolerance is for that, and is far below the tens of pixels a real
+         * clip costs.
+         */
+        cy.get('.wrolpi-path-input-control input').should(($input) => {
+            const el = $input[0];
+            expect(el.scrollWidth, 'value is not clipped').to.be.at.most(el.clientWidth + 2);
+            expect(el.clientWidth, 'input has usable width').to.be.greaterThan(80);
+        });
+    });
+
+    it('detects the overlap that started this, so the check has teeth', () => {
+        /*
+         * The original defect, reproduced deliberately: Mantine turns leftSectionWidth into
+         * --input-padding-inline-start, and `padding-inline-start: auto` is invalid, so it
+         * resolves to zero and the absolutely-positioned section prints over the value.
+         *
+         * Asserting that this DOES overlap proves shouldNotOverlap is measuring something
+         * real.  A geometry check that has never once gone red is indistinguishable from a
+         * check that cannot fail.
+         */
+        cy.mountUI(
+            <TextInput
+                leftSectionWidth='auto'
+                leftSection={<span className='probe-section'>/media/wrolpi</span>}
+                defaultValue='archive/%(domain)s'
+            />,
+        );
+
+        cy.get('.probe-section').then(($section) => {
+            cy.get('input').then(($input) => {
+                const section = $section[0].getBoundingClientRect();
+                const input = $input[0].getBoundingClientRect();
+                expect(
+                    section.right > input.left + 0.5,
+                    'the historical bug still overlaps, so the geometry check is meaningful',
+                ).to.equal(true);
+            });
+        });
+    });
+});
+
+describe('ActionInput', () => {
+    it('joins its button to the field without covering it', () => {
+        cy.mountUI(
+            <ActionInput
+                defaultValue='https://example.com'
+                action={<Button>Fetch</Button>}
+            />,
+        );
+
+        cy.shouldNotOverlap('.wrolpi-action-input input', '.wrolpi-action-input button');
+    });
+});
+
+describe('theme tokens actually resolve', () => {
+    themeNames.forEach((theme) => {
+        it(`paints text and borders from ${theme}'s table`, () => {
+            cy.mountUI(<PathInput prefix='/media/wrolpi' defaultValue='x'/>, {theme});
+
+            /*
+             * A token that a theme forgot to define resolves to the empty string, and the
+             * property falls back to something inherited -- usually black text on a dark
+             * panel.  jsdom cannot catch that; it does not resolve var() at all.
+             */
+            cy.get('.wrolpi-path-input-control input').should(($input) => {
+                const colour = getComputedStyle($input[0]).color;
+                expect(colour, 'input text colour resolved').to.match(/^rgba?\(/);
+                // Only an rgba() alpha of zero is invisible.  Matching a trailing ", 0)"
+                // loosely would flag amber's opaque rgb(255, 149, 0) for its blue channel.
+                expect(colour, 'input text is not transparent')
+                    .not.to.match(/^rgba\(.*,\s*0(\.0+)?\)$/);
+            });
+
+            cy.get('.wrolpi-path-input-control').should(($control) => {
+                expect(getComputedStyle($control[0]).borderTopColor, 'border resolved')
+                    .to.match(/^rgba?\(/);
+            });
+        });
+    });
+});
+
+describe('media filtering', () => {
+    it('tints a bare image in night', () => {
+        cy.mountUI(<img alt='poster' src='/logo.png' width='80' height='80'/>,
+            {theme: 'night', mediaFilter: 'night-red'});
+
+        cy.get('img').should(($img) =>
+            expect(getComputedStyle($img[0]).filter).to.contain('wrolpi-night-red'));
+    });
+
+    it('filters a .media wrapper once, not its contents twice', () => {
+        /*
+         * Two passes of a luminance-to-red matrix is not the same as one -- the second pass
+         * takes the luminance of an already-red pixel and the image comes out markedly
+         * darker than its surroundings.  So a `.media` wrapper is filtered as a unit and the
+         * leaf inside it must come back `none`.
+         */
+        cy.mountUI(
+            <div className='media'>
+                <img alt='poster' src='/logo.png' width='80' height='80'/>
+            </div>,
+            {theme: 'night', mediaFilter: 'night-red'},
+        );
+
+        cy.get('.media').should(($wrapper) =>
+            expect(getComputedStyle($wrapper[0]).filter).to.contain('wrolpi-night-red'));
+        cy.get('.media img').should(($img) =>
+            expect(getComputedStyle($img[0]).filter).to.equal('none'));
+    });
+
+    it('leaves media alone when the user has turned the filter off', () => {
+        // The attribute is absent rather than empty when filtering is off, so night with the
+        // setting disabled must match no rule at all.
+        cy.mountUI(<img alt='poster' src='/logo.png' width='80' height='80'/>,
+            {theme: 'night'});
+
+        cy.get('img').should(($img) =>
+            expect(getComputedStyle($img[0]).filter).to.equal('none'));
+    });
+});

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -429,11 +429,24 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     background: var(--bg);
 }
 
-/* Muted and on the header surface: it reads as context, not as something to edit. */
+/*
+ * Muted and on the header surface: it reads as context, not as something to edit.
+ *
+ * It shrinks and ellipsises rather than holding its full width.  The prefix is whatever the
+ * API reports as the media directory -- `/media/wrolpi` on a Pi, but a development box or an
+ * unusual Docker mount can report a much longer path -- and at `flex: none` a long one took
+ * the whole row and left the input 18px wide, a field nobody could type into.  Capping it at
+ * half the control keeps the editable part editable; the full path stays available through
+ * `title` and is read out in full by the accessible description either way.
+ */
 .wrolpi-path-input-prefix {
     display: flex;
     align-items: center;
-    flex: none;
+    flex: 0 1 auto;
+    min-width: 3ch;
+    max-width: 50%;
+    overflow: hidden;
+    text-overflow: ellipsis;
     padding: 0 6px 0 9px;
     background: var(--head);
     border-right: 1px solid var(--border);

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -390,6 +390,91 @@ html[data-theme="amber"] .wrolpi-form-field input:focus {
     background: var(--bg);
 }
 
+/* --------------------------------------------------------------- Path input */
+/*
+ * Prefix and input are siblings in a flex row sharing one outline, so the prefix cannot
+ * print over the value -- the failure that Mantine's absolutely-positioned `leftSection`
+ * allowed when its reserved width was wrong.  The prefix takes its natural width, so any
+ * media directory fits without a number being maintained anywhere.
+ */
+
+.wrolpi-path-input-label {
+    display: block;
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 4px;
+}
+
+.wrolpi-path-input-control {
+    display: flex;
+    align-items: stretch;
+    background: var(--panel);
+    border: 1px solid var(--border);
+}
+
+.wrolpi-path-input-control:focus-within {
+    border-color: var(--blue);
+}
+
+html[data-theme="night"] .wrolpi-path-input-control:focus-within,
+html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
+    border-color: var(--text);
+}
+
+.wrolpi-path-input-control[data-error] {
+    border: 1.5px dashed var(--red);
+}
+
+.wrolpi-path-input-control[data-disabled] {
+    background: var(--bg);
+}
+
+/* Muted and on the header surface: it reads as context, not as something to edit. */
+.wrolpi-path-input-prefix {
+    display: flex;
+    align-items: center;
+    flex: none;
+    padding: 0 6px 0 9px;
+    background: var(--head);
+    border-right: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 12px;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.wrolpi-path-input-control input {
+    flex: 1;
+    min-width: 0;
+    padding: 7px 9px;
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--text);
+    font: inherit;
+    font-size: 13px;
+}
+
+.wrolpi-path-input-control input::placeholder {
+    color: var(--muted);
+}
+
+.wrolpi-path-input-control input:disabled {
+    color: var(--muted);
+}
+
+.wrolpi-path-input-description {
+    font-size: 12px;
+    color: var(--muted);
+    margin-top: 3px;
+}
+
+.wrolpi-path-input-error {
+    font-size: 12px;
+    color: var(--red);
+    margin-top: 3px;
+}
+
 /* ---------------------------------------------------------- Action inputs */
 /*
  * Input and button share one outline: the input gives up its right border and

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -343,6 +343,42 @@ describe('PathInput', () => {
         expect(screen.getByText('Not a directory')).toBeInTheDocument();
     });
 
+    it('reads out its help text as well as the prefix', () => {
+        /*
+         * Rendering the description on screen is not the same as announcing it.  Unless it is
+         * referenced, a screen reader user hears the label and the prefix and never learns
+         * what the field expects -- the help text is the part that explains the variables
+         * these paths are allowed to contain.
+         */
+        renderUI(<PathInput
+            prefix='/media/wrolpi/'
+            label='Archive Directory'
+            description='Accepts %(domain)s and %(tag)s.'
+            value=''
+            onChange={jest.fn()}
+        />);
+
+        expect(screen.getByLabelText(/Archive Directory/))
+            .toHaveAccessibleDescription('/media/wrolpi/ Accepts %(domain)s and %(tag)s.');
+    });
+
+    it('announces the reason a path was rejected', () => {
+        // The dashed border and red text carry the failure for sighted users; without the
+        // error in the accessible description nothing carries it for anyone else.
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Zims Directory'
+                            error='Not a directory' value='' onChange={jest.fn()}/>);
+
+        const input = screen.getByLabelText(/Zims Directory/);
+        expect(input).toHaveAccessibleDescription(/Not a directory/);
+        expect(input).toBeInvalid();
+    });
+
+    it('is not marked invalid when there is nothing wrong with it', () => {
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Fine' value='' onChange={jest.fn()}/>);
+
+        expect(screen.getByLabelText(/Fine/)).toBeValid();
+    });
+
     it('forwards a ref to the input, for callers that focus it', () => {
         const ref = React.createRef();
         renderUI(<PathInput ref={ref} prefix='/media/wrolpi/' label='Focusable'

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -25,6 +25,7 @@ import {
     Message,
     Modal,
     Panel,
+    PathInput,
     Progress,
     resolveIconName,
     Status,
@@ -277,6 +278,111 @@ describe('Header', () => {
 
         expect(container.querySelector('svg')).toBeInTheDocument();
         expect(screen.getByText('Paste this into the extension')).toBeInTheDocument();
+    });
+});
+
+describe('PathInput', () => {
+    /*
+     * These need no mocks at all -- no context, no API, no router.  That is the point of
+     * putting the field in the library: the page that uses it needs a pile of provider and
+     * fetch mocks, so its inputs were never covered, which is how a field shipped printing
+     * its own prefix over its own value.
+     */
+
+    it('keeps the prefix out of the value', () => {
+        // The bug this exists to prevent: the prefix must be its own element, never part of
+        // the text the user is editing, so it cannot be typed over or submitted.
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Archive Directory'
+                            value='archive/%(domain)s' onChange={jest.fn()}/>);
+
+        const input = screen.getByLabelText(/Archive Directory/);
+        expect(input).toHaveValue('archive/%(domain)s');
+        expect(input.value).not.toContain('/media/wrolpi');
+        // A sibling, not a child: an element inside the box could overlap it.
+        expect(input.querySelector('*')).toBeNull();
+        expect(screen.getByText('/media/wrolpi/')).not.toBe(input);
+    });
+
+    it('reports only what was typed, never the prefix', async () => {
+        // Read the value inside the handler: React nulls `currentTarget` once the event has
+        // been dispatched, so inspecting it afterwards from mock.calls throws.
+        const seen = [];
+        const onChange = jest.fn(event => seen.push(event.currentTarget.value));
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Map Directory' onChange={onChange}/>);
+
+        await userEvent.type(screen.getByLabelText(/Map Directory/), 'map');
+
+        expect(seen).toEqual(['m', 'ma', 'map']);
+        seen.forEach(value => expect(value).not.toContain('/media/wrolpi'));
+    });
+
+    it('tells assistive technology what the path is relative to', () => {
+        // Sighted users get that from the prefix; hiding it would leave everyone else
+        // typing a relative path with no idea what it is relative to.
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Zims Directory' value='' onChange={jest.fn()}/>);
+
+        expect(screen.getByLabelText(/Zims Directory/)).toHaveAccessibleDescription('/media/wrolpi/');
+    });
+
+    it('disables the input, not just the wrapper', async () => {
+        const onChange = jest.fn();
+        renderUI(<PathInput prefix='/media/wrolpi/' label='Videos Directory' disabled
+                            value='videos' onChange={onChange}/>);
+
+        const input = screen.getByLabelText(/Videos Directory/);
+        expect(input).toBeDisabled();
+        await userEvent.type(input, 'x');
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('marks an invalid path so the dashed danger treatment applies', () => {
+        const {container} = renderUI(<PathInput prefix='/media/wrolpi/' label='Bad'
+                                                error='Not a directory' value='' onChange={jest.fn()}/>);
+
+        expect(container.querySelector('[data-error]')).toBeInTheDocument();
+        expect(screen.getByText('Not a directory')).toBeInTheDocument();
+    });
+
+    it('forwards a ref to the input, for callers that focus it', () => {
+        const ref = React.createRef();
+        renderUI(<PathInput ref={ref} prefix='/media/wrolpi/' label='Focusable'
+                            value='' onChange={jest.fn()}/>);
+
+        expect(ref.current.tagName).toBe('INPUT');
+    });
+});
+
+describe('no input reserves space for a section it cannot measure', () => {
+    it('nothing passes leftSectionWidth="auto"', () => {
+        /*
+         * `leftSectionWidth` becomes `--input-padding-inline-start`, and
+         * `padding-inline-start: auto` is not valid CSS -- it resolves to zero, so the
+         * section prints straight over the value.  Five fields on the Settings page shipped
+         * that way and were unreadable.  It fails silently, in CSS, at runtime only, which
+         * is exactly the kind of thing worth a source check.
+         */
+        const offenders = [];
+        const walk = (dir) => {
+            for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) walk(full);
+                else if (/\.(js|jsx|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+                    // Comments are stripped first: the component that replaced this
+                    // pattern documents it by name, and prose about a mistake is not the
+                    // mistake.
+                    const source = fs.readFileSync(full, 'utf8')
+                        .replace(/\/\*[\s\S]*?\*\//g, '')
+                        .replace(/^\s*\/\/.*$/gm, '');
+                    if (/leftSectionWidth\s*=\s*['"`]auto['"`]/.test(source)
+                        || /rightSectionWidth\s*=\s*['"`]auto['"`]/.test(source)) {
+                        offenders.push(path.relative(path.join(__dirname, '..', '..'), full));
+                    }
+                }
+            }
+        };
+        walk(path.join(__dirname, '..', '..'));
+
+        expect(offenders).toEqual([]);
     });
 });
 

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -366,7 +366,10 @@ describe('no input reserves space for a section it cannot measure', () => {
             for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
                 const full = path.join(dir, entry.name);
                 if (entry.isDirectory()) walk(full);
-                else if (/\.(js|jsx|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+                // Specs are exempt: ui-layout.cy.js reproduces this exact mistake on
+                // purpose, to prove its overlap check can still detect it.
+                else if (/\.(js|jsx|tsx)$/.test(entry.name)
+                    && !/\.test\.|\.cy\./.test(entry.name)) {
                     // Comments are stripped first: the component that replaced this
                     // pattern documents it by name, and prose about a mistake is not the
                     // mistake.
@@ -381,6 +384,56 @@ describe('no input reserves space for a section it cannot measure', () => {
             }
         };
         walk(path.join(__dirname, '..', '..'));
+
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe('the library stays mockable-free', () => {
+    /*
+     * The whole reason these 80-odd tests need no setup is that a library component takes
+     * props and reaches for nothing else -- no module-level fetch, no API helper, no
+     * ambient state it has to be lied to about.  Pages are the opposite: DomainEditPage
+     * needs seven jest.mock calls before it will render at all, which is precisely why the
+     * inputs on the Settings page had no test when they broke.
+     *
+     * That property is worth asserting rather than hoping for.  The day a library
+     * component grows a fetch, the mock somebody has to add to keep this file passing
+     * trips the first check, and the import trips the second.
+     */
+
+    const libraryFiles = () => fs.readdirSync(__dirname)
+        .filter(name => /\.(ts|tsx)$/.test(name) && !/\.test\./.test(name))
+        .map(name => [name, fs.readFileSync(path.join(__dirname, name), 'utf8')]);
+
+    it('needs no module mocked to render any of it', () => {
+        const source = fs.readFileSync(path.join(__dirname, 'ui.test.js'), 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/^\s*\/\/.*$/gm, '');
+
+        expect(source).not.toMatch(/jest\.mock\s*\(/);
+    });
+
+    it('asks the network for nothing', () => {
+        const offenders = libraryFiles()
+            .filter(([, source]) => /\bfetch\s*\(|\bapiCall\b|\baxios\b/
+                .test(source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')))
+            .map(([name]) => name);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('reads ambient state only in the theme controls', () => {
+        /*
+         * ThemePicker and MediaFilterToggle are the deliberate exception -- a control whose
+         * entire job is to show and change the current theme has to know it.  Their tests
+         * pass a real ThemeContext.Provider holding plain values, which is supplying data,
+         * not mocking a module.  Everything else takes props.
+         */
+        const offenders = libraryFiles()
+            .filter(([name]) => name !== 'ThemePicker.tsx')
+            .filter(([, source]) => /useContext\s*\(/.test(source))
+            .map(([name]) => name);
 
         expect(offenders).toEqual([]);
     });

--- a/app/src/themes/tokens.css
+++ b/app/src/themes/tokens.css
@@ -261,8 +261,15 @@ html[data-media-filter="amber-mono"] :is(img, video, canvas, iframe, embed, obje
  *
  * The audio player's poster is the case that found this — the poster sits under
  * custom control glyphs, so the wrapper is filtered to keep the two tinted together.
+ *
+ * The trailing `:not(.night-unfiltered)` is here for specificity, not for its meaning.
+ * The rule above scores (0,3,1) — an attribute, a `.media` inside `:is()`, and a `:not()`
+ * — so this reset had to reach three class-level components to win it; without the extra
+ * one it scored (0,2,2) and silently lost every time, which is exactly what it did until
+ * a browser test measured the leaf and found it filtered twice.  jsdom cannot catch this:
+ * it never resolves `filter` at all.
  */
-html[data-media-filter] .media :is(img, video, canvas, iframe, embed, object) {
+html[data-media-filter] .media :is(img, video, canvas, iframe, embed, object):not(.night-unfiltered) {
     filter: none;
 }
 

--- a/app/src/themes/tokens.test.js
+++ b/app/src/themes/tokens.test.js
@@ -120,11 +120,52 @@ describe('media filter rules', () => {
     });
 
     it('does not filter leaf media twice inside a filtered wrapper', () => {
-        // A `.media` wrapper filters its subtree as a unit; the img/video inside it also
-        // matches the element-type rule, and two passes of the matrix take the luminance
-        // of an already-red pixel, leaving that image much darker than its surroundings.
-        expect(tokensCss).toMatch(
-            /html\[data-media-filter] \.media :is\([^)]*\)\s*{\s*filter:\s*none/);
+        /*
+         * A `.media` wrapper filters its subtree as a unit; the img/video inside it also
+         * matches the element-type rule, and two passes of the matrix take the luminance of
+         * an already-red pixel, leaving that image much darker than its surroundings.
+         *
+         * This used to assert only that the reset rule's text was present, and so it passed
+         * for as long as the rule existed -- including the whole time the rule lost on
+         * specificity and never applied to anything.  Presence is not effect.  What has to
+         * hold is that the reset outranks the rule it is correcting, which is computable
+         * from the selectors themselves.  ui-layout.cy.js measures the resulting `filter` in
+         * a real browser, which is the only place the effect itself is observable.
+         */
+        const specificity = (selector) => {
+            // Enough of the algorithm for these selectors: :is() and :not() contribute the
+            // highest specificity among their arguments.
+            let classes = 0, elements = 0;
+            const counted = selector.replace(/:(is|not)\(([^)]*)\)/g, (_, __, args) => {
+                const best = args.split(',')
+                    .map(arg => specificity(arg.trim()))
+                    .sort((a, b) => (b.classes - a.classes) || (b.elements - a.elements))[0];
+                classes += best.classes;
+                elements += best.elements;
+                return ' ';
+            });
+            classes += (counted.match(/\.[\w-]+|\[[^\]]*]|:[\w-]+/g) || []).length;
+            elements += (counted.match(/(^|[\s>+~])[a-z][\w-]*/gi) || []).length;
+            return {classes, elements};
+        };
+        const rank = (selector) => {
+            const {classes, elements} = specificity(selector);
+            return classes * 1000 + elements;
+        };
+
+        const selectorFor = (needle) => {
+            const match = tokensCss.split('}')
+                .map(block => block.split('{')[0].trim())
+                .filter(Boolean)
+                .find(selector => selector.includes(needle));
+            if (!match) throw new Error(`tokens.css has no rule matching ${needle}`);
+            return match.split('\n').pop().trim();
+        };
+
+        const reset = selectorFor('.media :is(img');
+        const filtered = selectorFor('[data-media-filter="night-red"] :is(img');
+
+        expect(rank(reset)).toBeGreaterThan(rank(filtered));
     });
 
     it('never filters an ancestor, only leaf media', () => {


### PR DESCRIPTION
Two commits: the bug the user reported, and the test layer that would have caught it — which found a second, older bug on its first run.

## 1. The reported bug

Five fields on `/admin/settings` passed **`leftSectionWidth='auto'`**. Mantine forwards that to the `--input-padding-inline-start` custom property, and `padding-inline-start: auto` is not valid CSS — it resolves to **zero**. The input reserved no room for the absolutely-positioned `leftSection` on top of it, so Archive Directory rendered as:

```
a/media/wrolpi/hain_tag)s/%(domain)s
```

It failed only in CSS, only at runtime, with no warning from webpack, `tsc`, or jest.

**The fix is structural, not a width.** `PathInput` makes the prefix and the input **flex siblings** sharing one outline, rather than one painted over the other. There is no width to compute and nothing to overlap, so the failure is impossible rather than corrected. It also sizes to any prefix, which matters: the media directory is `/media/wrolpi` on a Pi and differs under Docker, so any hardcoded width would have been wrong somewhere.

Six behaviour tests, no mocks beyond the provider: prefix is a sibling not a child; the value never contains the prefix; `onChange` reports only typed text; the prefix is the accessible description; `disabled` reaches the input; the ref forwards to the `INPUT`.

## 2. The layer that should have caught it

jsdom computes no layout — `getBoundingClientRect()` returns zeros, `var()` never resolves, no filter is ever applied. So the only guard available was a grep for one spelling of one mistake. `ui-layout.cy.js` adds the missing layer: `cy.mountUI()` mounts a library component in a real browser with Mantine's provider and a stamped `data-theme`, and **nothing else**.

That spartan setup is the argument. These components read no ambient state, so a spec can isolate one and assert real geometry, resolved tokens, and applied filters across **all four themes** — which until now was verified only by me looking at a browser.

It also **reproduces the `leftSectionWidth='auto'` overlap deliberately and asserts it still overlaps**, because a geometry check that has never once gone red is indistinguishable from one that cannot fail.

## 3. The bug that layer found

The rule resetting `filter` on leaf media inside a `.media` wrapper scored **(0,2,2)** against the **(0,3,1)** rule it was correcting. It lost every time. **It has never applied to anything.**

So every image inside a filtered wrapper has been through the luminance matrix *twice* since that rule landed — the second pass takes 0.2126 of an already-red pixel, leaving it markedly darker than its surroundings, which is precisely what the rule was written to prevent.

`tokens.test.js` asserted only that the rule's **text was present**, and so stayed green the whole time. Presence is not effect. It now compares the two selectors' computed specificity — catchable in jest, no browser needed — and goes red on the old selector.

## 4. Keeping the library mock-free by construction

`ui.test.js` runs 80 tests with **zero `jest.mock`**; `DomainEditPage.test.js` needs seven mocks before it renders at all. That gap is the reason the Settings inputs had no test when they broke. Three guards make the property structural rather than habitual: no `jest.mock` in the library's own tests, no `fetch`/`apiCall` in any library file, and no `useContext` outside `ThemePicker`, whose job is to read the theme.

## Verification

- 959 jest tests, 55 suites
- 14 new browser component tests
- 43 e2e tests
- clean `npm run build` after `rm -rf node_modules/.cache`

Every new guard was verified **red against a planted violation** before being trusted — the three mock guards, the specificity check, and the overlap check.

**Honest limits:** the `.media` fix is confirmed by measuring computed `filter` in a browser, not by eyeballing an audio poster. And the source-grep guard still only catches its one spelling; the browser layer is what generalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)