### PR TITLE
ui: Statistic and StatisticGroup, and the four defects they had

### DIFF
--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -166,9 +166,12 @@ export function ThemeSamplePage() {
                 <Statistic value={0} label='Downloading'/>
             </StatisticGroup>
 
-            {/* Status colours a reading that carries meaning.  Check these in night, where
-                there is no hue to spend and the value has to read by brightness. */}
-            <StatisticGroup style={{marginTop: 14}}>
+            {/* Status colours a reading that carries meaning.  Check these in night and amber,
+                where there is no hue to spend and the value has to read some other way. */}
+            {/* The group above ends in a label, and a heading has no margin of its own, so
+                without this the two run together. */}
+            <Header as='h5' style={{marginTop: 24}}>Coloured readings, as Status draws them</Header>
+            <StatisticGroup>
                 <Statistic value='0.4' label='1 Min. Load'/>
                 <Statistic value='2.6' label='5 Min. Load' color='orange'/>
                 <Statistic value='4.1' label='15 Min. Load' color='red'/>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -151,12 +151,28 @@ export function ThemeSamplePage() {
         </Section>
 
         <Section label='Statistics'>
+            {/*
+              * Seven, deliberately: enough to wrap on a narrow window, which is where the row
+              * hairlines are worth looking at.  The group rules both axes from --border, so the
+              * grid holds together however the tracks fall.
+              */}
             <StatisticGroup>
                 <Statistic value='1,432' label='Videos'/>
                 <Statistic value='896' label='Archives'/>
                 <Statistic value='12,904' label='Files'/>
                 <Statistic value='87.4 GiB' label='Free space'/>
                 <Statistic value='14' label='Zim files'/>
+                <Statistic value='312' label='eBooks'/>
+                <Statistic value={0} label='Downloading'/>
+            </StatisticGroup>
+
+            {/* Status colours a reading that carries meaning.  Check these in night, where
+                there is no hue to spend and the value has to read by brightness. */}
+            <StatisticGroup style={{marginTop: 14}}>
+                <Statistic value='0.4' label='1 Min. Load'/>
+                <Statistic value='2.6' label='5 Min. Load' color='orange'/>
+                <Statistic value='4.1' label='15 Min. Load' color='red'/>
+                <Statistic value='48' label='Temp C°'/>
             </StatisticGroup>
         </Section>
 

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -795,7 +795,7 @@ export function VideosStatistics() {
             <StatisticGroup>
                 {names.map(
                     ({key, label}) =>
-                        <Statistic key={key} value={stats[key]} label={label} style={{margin: '2em'}}/>
+                        <Statistic key={key} value={stats[key]} label={label}/>
                 )}
             </StatisticGroup>
         </Panel>

--- a/app/src/components/ui/Surfaces.tsx
+++ b/app/src/components/ui/Surfaces.tsx
@@ -76,16 +76,21 @@ export function Panel({danger, className, children, ...props}: PanelProps) {
 
 // ---------------------------------------------------------------- Statistics
 
-export interface StatisticProps {
+export interface StatisticProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
+    /** The number.  Rendered as given, so `0` shows as a zero rather than nothing. */
     value: React.ReactNode;
     label: React.ReactNode;
+    /** A token colour name, for a reading that carries meaning: load, temperature, IO wait. */
     color?: string;
-    className?: string;
-    style?: React.CSSProperties;
 }
 
-export function Statistic({value, label, color, className, style}: StatisticProps) {
-    return <div className={['wrolpi-statistic', className].filter(Boolean).join(' ')} style={style}>
+/**
+ * One figure and its label.  The rest of the props reach the outer element, because
+ * `LoadStatistic` and the four Status wrappers all end in `{...props}` and used to have
+ * everything past the named five silently dropped.
+ */
+export function Statistic({value, label, color, className, ...props}: StatisticProps) {
+    return <div className={['wrolpi-statistic', className].filter(Boolean).join(' ')} {...props}>
         <div className='wrolpi-statistic-value' style={{color: color ? `var(--${color})` : undefined}}>
             {value}
         </div>
@@ -93,25 +98,16 @@ export function Statistic({value, label, color, className, style}: StatisticProp
     </div>
 }
 
-/** A row of statistics separated by hairlines, sharing one outer border. */
-export function StatisticGroup({children}: {children: React.ReactNode}) {
-    const items = React.Children.toArray(children);
-    return <div style={{
-        display: 'grid',
-        gridTemplateColumns: `repeat(auto-fit, minmax(150px, 1fr))`,
-        border: '1px solid var(--border)',
-    }}>
-        {items.map((child, index) => <div
-            key={index}
-            className='wrolpi-statistic-cell'
-            style={{
-                background: 'var(--panel)',
-                padding: '14px 16px',
-                borderRight: index === items.length - 1 ? undefined : '1px solid var(--border)',
-            }}
-        >
-            {child}
-        </div>)}
+/**
+ * A row of statistics separated by hairlines, sharing one outer border.  The cells carry
+ * no inline style of their own so that `.wrolpi-statistic-cell:empty` can hide the ones
+ * whose statistic rendered nothing — Status omits the fan reading on the devices, most of
+ * them, with no fan connector.
+ */
+export function StatisticGroup({children, className, ...props}: React.HTMLAttributes<HTMLDivElement>) {
+    return <div className={['wrolpi-statistic-group', className].filter(Boolean).join(' ')} {...props}>
+        {React.Children.toArray(children).map((child, index) =>
+            <div key={index} className='wrolpi-statistic-cell'>{child}</div>)}
     </div>
 }
 
@@ -161,12 +157,26 @@ export function Card({media, title, meta, children, onClick, color, className}: 
     </MCard>
 }
 
-export function CardGroup({children, minWidth = 200}: {children: React.ReactNode; minWidth?: number}) {
-    return <div style={{
-        display: 'grid',
-        gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth}px, 1fr))`,
-        gap: 14,
-    }}>
+export interface CardGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    /**
+     * The narrowest a card may be laid out.  `auto-fill` rather than `auto-fit`, so a group
+     * of two cards in a wide column keeps them card-sized instead of stretching each to half
+     * the page.
+     */
+    minWidth?: number;
+}
+
+export function CardGroup({children, minWidth = 200, className, style, ...props}: CardGroupProps) {
+    return <div
+        className={['wrolpi-card-group', className].filter(Boolean).join(' ')}
+        style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth}px, 1fr))`,
+            gap: 14,
+            ...style,
+        }}
+        {...props}
+    >
         {children}
     </div>
 }

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActionInput, Button, PathInput, TextInput} from './index';
+import {ActionInput, Button, PathInput, Statistic, StatisticGroup, TextInput} from './index';
 import {themeNames} from '../../themes/names';
 
 /*
@@ -130,6 +130,171 @@ describe('ActionInput', () => {
         );
 
         cy.shouldNotOverlap('.wrolpi-action-input input', '.wrolpi-action-input button');
+    });
+});
+
+describe('StatisticGroup rules every row it ends up with', () => {
+    /*
+     * The group wraps: `auto-fit` with a 150px minimum gives seven statistics one row on a
+     * desktop and four on a phone, and how many rows there are is decided by the viewport at
+     * paint time.  Only a browser can say -- jsdom has no tracks, no rows and no widths -- so
+     * the row-separator claims live here.
+     */
+
+    // Narrow enough that six statistics cannot fit on one row at a 150px minimum.
+    const inNarrowColumn = (children) => <div style={{width: 340}}>{children}</div>;
+
+    const sixStatistics = <StatisticGroup>
+        <Statistic value='1,432' label='Videos'/>
+        <Statistic value='896' label='Archives'/>
+        <Statistic value='12,904' label='Files'/>
+        <Statistic value='87.4 GiB' label='Free space'/>
+        <Statistic value='14' label='Zim files'/>
+        <Statistic value='312' label='eBooks'/>
+    </StatisticGroup>;
+
+    const rowTops = (cells) => [...new Set(
+        [...cells].map((cell) => Math.round(cell.getBoundingClientRect().top))
+    )].sort((a, b) => a - b);
+
+    it('wraps into rows at this width, so the rest of these tests mean something', () => {
+        cy.mountUI(inNarrowColumn(sixStatistics));
+
+        cy.get('.wrolpi-statistic-cell').should(($cells) =>
+            expect(rowTops($cells).length, 'rows the group wrapped into').to.be.greaterThan(1));
+    });
+
+    it('draws a hairline between wrapped rows', () => {
+        /*
+         * This is the defect: the old group put a `border-right` on every cell but the last,
+         * which rules between columns and says nothing about rows.  Wrapped rows sat flush
+         * against each other, so the Docs page's seven statistics ran together into one block
+         * on a phone.  A row boundary must be a visible 1px of border colour.
+         */
+        cy.mountUI(inNarrowColumn(sixStatistics));
+
+        cy.get('.wrolpi-statistic-cell').should(($cells) => {
+            const cells = [...$cells].map((cell) => cell.getBoundingClientRect());
+            const tops = rowTops($cells);
+
+            for (let row = 1; row < tops.length; row++) {
+                const previousRowBottom = Math.max(...cells
+                    .filter((rect) => Math.round(rect.top) === tops[row - 1])
+                    .map((rect) => rect.bottom));
+                const separation = tops[row] - previousRowBottom;
+                expect(separation, `hairline above row ${row + 1}`).to.be.closeTo(1, 0.6);
+            }
+        });
+    });
+
+    it('draws a hairline between columns too', () => {
+        cy.mountUI(inNarrowColumn(sixStatistics));
+
+        cy.get('.wrolpi-statistic-cell').should(($cells) => {
+            const cells = [...$cells].map((cell) => cell.getBoundingClientRect());
+            const firstRowTop = rowTops($cells)[0];
+            const firstRow = cells
+                .filter((rect) => Math.round(rect.top) === firstRowTop)
+                .sort((a, b) => a.left - b.left);
+
+            expect(firstRow.length, 'columns in the first row').to.be.greaterThan(1);
+            for (let column = 1; column < firstRow.length; column++) {
+                expect(firstRow[column].left - firstRow[column - 1].right, 'hairline between columns')
+                    .to.be.closeTo(1, 0.6);
+            }
+        });
+    });
+
+    it('does not double the outer border where a row ends', () => {
+        /*
+         * The old code suppressed `border-right` on the last child only, so the cell ending
+         * every earlier row -- there is one per wrap -- drew its own hairline directly onto the
+         * group's outer border, giving a 2px edge on the right and a 1px edge on the left.
+         * Now no cell has a border at all and the single outer one is the edge.
+         */
+        cy.mountUI(inNarrowColumn(sixStatistics));
+
+        cy.get('.wrolpi-statistic-cell').each(($cell) =>
+            expect(getComputedStyle($cell[0]).borderRightWidth, 'cell draws no border of its own')
+                .to.equal('0px'));
+        cy.get('.wrolpi-statistic-group').should(($group) =>
+            expect(getComputedStyle($group[0]).borderRightWidth, 'one outer hairline').to.equal('1px'));
+    });
+
+    it('leaves no painted block in a track no statistic landed in', () => {
+        /*
+         * An odd count leaves the last row short: seven statistics in two columns fill the
+         * eighth slot with nothing.  Ruling the gaps with a border-coloured background behind
+         * the grid -- the obvious way to do it -- painted that empty slot a solid block of
+         * border grey, which read as a broken cell.  The hairlines are outlines on the cells
+         * instead, so a track with no cell in it is just surface.
+         */
+        cy.mountUI(inNarrowColumn(<StatisticGroup>
+            <Statistic value='1,432' label='Videos'/>
+            <Statistic value='896' label='Archives'/>
+            <Statistic value='12,904' label='Files'/>
+            <Statistic value='87.4 GiB' label='Free space'/>
+            <Statistic value='14' label='Zim files'/>
+            <Statistic value='312' label='eBooks'/>
+            <Statistic value={0} label='Downloading'/>
+        </StatisticGroup>));
+
+        cy.get('.wrolpi-statistic-cell').should(($cells) => {
+            // An odd number of cells over an even number of columns, or this proves nothing.
+            expect($cells.length % 2, 'a short last row').to.equal(1);
+        });
+        cy.get('.wrolpi-statistic-group').should(($group) => {
+            const group = getComputedStyle($group[0]);
+            expect(group.backgroundColor, 'the empty track shows surface, not hairline')
+                .to.not.equal(group.borderRightColor);
+        });
+    });
+
+    it('hides the cell of a statistic that rendered nothing', () => {
+        /*
+         * Status omits the fan reading on a device with no fan connector -- most of them --
+         * by returning null from FanRPMStatistic.  The group still emits its cell, because it
+         * cannot render a child to find out, so `:empty` has to take the cell out of the grid.
+         * Left in, it was a blank padded panel and a stray hairline in the middle of the row.
+         */
+        const NoFanFitted = () => null;
+        cy.mountUI(<StatisticGroup>
+            <Statistic value='0.4' label='1 Min. Load'/>
+            <NoFanFitted/>
+            <Statistic value='48' label='Temp C°'/>
+        </StatisticGroup>);
+
+        cy.get('.wrolpi-statistic-cell').should('have.length', 3);
+        cy.get('.wrolpi-statistic-cell').filter(':empty').should('not.be.visible');
+        cy.get('.wrolpi-statistic-cell').filter(':empty').should(($cell) =>
+            expect($cell[0].getBoundingClientRect().width, 'the empty cell takes no track').to.equal(0));
+    });
+
+    themeNames.forEach((theme) => {
+        it(`takes its hairline and surface from ${theme}'s tokens`, () => {
+            // Drawn from --border and --panel rather than a fixed grey, which is what lets the
+            // group survive night mode without putting a non-red pixel on the screen.
+            cy.mountUI(inNarrowColumn(sixStatistics), {theme});
+
+            cy.get('.wrolpi-statistic-group').then(($group) => {
+                const group = getComputedStyle($group[0]);
+
+                cy.get('.wrolpi-statistic-cell').first().should(($cell) => {
+                    const cell = getComputedStyle($cell[0]);
+
+                    // The inner hairlines are the cells' outlines and the outer one is the
+                    // group's border; they meet at every edge, so a theme that resolved them
+                    // to different values would show a two-tone frame.
+                    expect(cell.outlineColor, 'inner hairline matches the outer')
+                        .to.equal(group.borderRightColor);
+                    // And the hairline has to be visible against the surface it sits on --
+                    // both resolved from tokens, so a theme that forgot one shows up here.
+                    expect(cell.outlineColor, 'hairline is not the surface colour')
+                        .to.not.equal(cell.backgroundColor);
+                    expect(cell.backgroundColor, 'cell has a surface').to.not.equal('rgba(0, 0, 0, 0)');
+                });
+            });
+        });
     });
 });
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActionInput, Button, PathInput, Statistic, StatisticGroup, TextInput} from './index';
+import {ActionInput, Button, Header, PathInput, Statistic, StatisticGroup, TextInput} from './index';
 import {themeNames} from '../../themes/names';
 
 /*
@@ -133,12 +133,13 @@ describe('ActionInput', () => {
     });
 });
 
-describe('StatisticGroup rules every row it ends up with', () => {
+describe('StatisticGroup separates its statistics with nothing but space', () => {
     /*
-     * The group wraps: `auto-fit` with a 150px minimum gives seven statistics one row on a
-     * desktop and four on a phone, and how many rows there are is decided by the viewport at
-     * paint time.  Only a browser can say -- jsdom has no tracks, no rows and no widths -- so
-     * the row-separator claims live here.
+     * The group has no frame, no rules between cells and no surface of its own: the
+     * statistics sit on whatever they were dropped onto and take its colour.  That leaves
+     * the gap as the only thing keeping them apart, and `auto-fit` decides how many rows
+     * there are at paint time -- so whether they actually stay apart is a question only a
+     * browser can answer.  jsdom has no tracks, no rows and no widths.
      */
 
     // Narrow enough that six statistics cannot fit on one row at a 150px minimum.
@@ -164,12 +165,12 @@ describe('StatisticGroup rules every row it ends up with', () => {
             expect(rowTops($cells).length, 'rows the group wrapped into').to.be.greaterThan(1));
     });
 
-    it('draws a hairline between wrapped rows', () => {
+    it('leaves real space between wrapped rows', () => {
         /*
-         * This is the defect: the old group put a `border-right` on every cell but the last,
-         * which rules between columns and says nothing about rows.  Wrapped rows sat flush
-         * against each other, so the Docs page's seven statistics ran together into one block
-         * on a phone.  A row boundary must be a visible 1px of border colour.
+         * With nothing drawn between them, the space *is* the separation.  The old group ruled
+         * columns only -- a `border-right` on every cell but the last, which says nothing about
+         * rows -- so wrapped rows sat flush and the Docs page's seven statistics ran together
+         * into one block on a phone.  A row boundary has to be a gap you can see.
          */
         cy.mountUI(inNarrowColumn(sixStatistics));
 
@@ -181,72 +182,99 @@ describe('StatisticGroup rules every row it ends up with', () => {
                 const previousRowBottom = Math.max(...cells
                     .filter((rect) => Math.round(rect.top) === tops[row - 1])
                     .map((rect) => rect.bottom));
-                const separation = tops[row] - previousRowBottom;
-                expect(separation, `hairline above row ${row + 1}`).to.be.closeTo(1, 0.6);
+                expect(tops[row] - previousRowBottom, `space above row ${row + 1}`)
+                    .to.be.at.least(12);
             }
         });
     });
 
-    it('draws a hairline between columns too', () => {
+    it('leaves more space between columns than between rows', () => {
+        /*
+         * Two statistics side by side have only air between them, and a value sitting close to
+         * the label of the one beside it reads as a single column of text.  Stacked statistics
+         * already have the label's own line between them, so they need less.
+         */
         cy.mountUI(inNarrowColumn(sixStatistics));
+
+        cy.get('.wrolpi-statistic-group').should(($group) => {
+            const styles = getComputedStyle($group[0]);
+            const columnGap = parseFloat(styles.columnGap);
+            const rowGap = parseFloat(styles.rowGap);
+            expect(rowGap, 'row gap').to.be.at.least(12);
+            expect(columnGap, 'column gap is the wider of the two').to.be.greaterThan(rowGap);
+        });
 
         cy.get('.wrolpi-statistic-cell').should(($cells) => {
             const cells = [...$cells].map((cell) => cell.getBoundingClientRect());
-            const firstRowTop = rowTops($cells)[0];
             const firstRow = cells
-                .filter((rect) => Math.round(rect.top) === firstRowTop)
+                .filter((rect) => Math.round(rect.top) === rowTops($cells)[0])
                 .sort((a, b) => a.left - b.left);
 
             expect(firstRow.length, 'columns in the first row').to.be.greaterThan(1);
             for (let column = 1; column < firstRow.length; column++) {
-                expect(firstRow[column].left - firstRow[column - 1].right, 'hairline between columns')
-                    .to.be.closeTo(1, 0.6);
+                expect(firstRow[column].left - firstRow[column - 1].right, 'space between columns')
+                    .to.be.at.least(20);
             }
         });
     });
 
-    it('does not double the outer border where a row ends', () => {
+    it('takes no colour of its own, so it sits on the surface it is given', () => {
         /*
-         * The old code suppressed `border-right` on the last child only, so the cell ending
-         * every earlier row -- there is one per wrap -- drew its own hairline directly onto the
-         * group's outer border, giving a 2px edge on the right and a 1px edge on the left.
-         * Now no cell has a border at all and the single outer one is the edge.
+         * This is the point of having no chrome: dropped on the page it reads as page, dropped
+         * in a Panel it reads as panel.  A background on the group or a cell -- which is how
+         * this was built first, to carry hairlines -- would show as a patch of the wrong colour
+         * on every surface but the one it was picked for.
          */
-        cy.mountUI(inNarrowColumn(sixStatistics));
+        cy.mountUI(<div style={{background: 'rgb(1, 2, 3)', padding: 10}}>{sixStatistics}</div>);
 
-        cy.get('.wrolpi-statistic-cell').each(($cell) =>
-            expect(getComputedStyle($cell[0]).borderRightWidth, 'cell draws no border of its own')
-                .to.equal('0px'));
-        cy.get('.wrolpi-statistic-group').should(($group) =>
-            expect(getComputedStyle($group[0]).borderRightWidth, 'one outer hairline').to.equal('1px'));
+        cy.get('.wrolpi-statistic-group').should(($group) => {
+            const styles = getComputedStyle($group[0]);
+            expect(styles.backgroundColor, 'group is transparent').to.equal('rgba(0, 0, 0, 0)');
+            expect(styles.borderTopWidth, 'no frame').to.equal('0px');
+            expect(styles.borderRightWidth, 'no frame').to.equal('0px');
+            expect(styles.borderBottomWidth, 'no frame').to.equal('0px');
+            expect(styles.borderLeftWidth, 'no frame').to.equal('0px');
+            expect(styles.outlineStyle, 'no outline standing in for a frame').to.equal('none');
+        });
+
+        cy.get('.wrolpi-statistic-cell').each(($cell) => {
+            const styles = getComputedStyle($cell[0]);
+            expect(styles.backgroundColor, 'cell is transparent').to.equal('rgba(0, 0, 0, 0)');
+            expect(styles.borderRightWidth, 'no rule between cells').to.equal('0px');
+            expect(styles.outlineStyle, 'no rule between cells').to.equal('none');
+        });
     });
 
-    it('leaves no painted block in a track no statistic landed in', () => {
+    it('clears whatever precedes it, but does not indent itself', () => {
         /*
-         * An odd count leaves the last row short: seven statistics in two columns fill the
-         * eighth slot with nothing.  Ruling the gaps with a border-coloured background behind
-         * the grid -- the obvious way to do it -- painted that empty slot a solid block of
-         * border grey, which read as a broken cell.  The hairlines are outlines on the cells
-         * instead, so a track with no cell in it is just surface.
+         * Nothing frames the group any more, so a Header directly above it put the heading
+         * text against the first row of values.  A plain `margin-top` fixed that and broke
+         * Apps, which opens each of its Panels with a group: the values were pushed down off
+         * the panel's top padding while the bottom stayed put, leaving every panel lopsided.
+         * So the margin is conditional on having a sibling before it.
          */
-        cy.mountUI(inNarrowColumn(<StatisticGroup>
-            <Statistic value='1,432' label='Videos'/>
-            <Statistic value='896' label='Archives'/>
-            <Statistic value='12,904' label='Files'/>
-            <Statistic value='87.4 GiB' label='Free space'/>
-            <Statistic value='14' label='Zim files'/>
-            <Statistic value='312' label='eBooks'/>
-            <Statistic value={0} label='Downloading'/>
-        </StatisticGroup>));
+        cy.mountUI(<div>
+            <div className='probe-panel' style={{padding: 20}}>
+                <StatisticGroup>
+                    <Statistic value='1,097' label='All files'/>
+                </StatisticGroup>
+            </div>
+            <div className='probe-with-header' style={{padding: 20}}>
+                <Header as='h2'>Files</Header>
+                <StatisticGroup>
+                    <Statistic value='1,097' label='All files'/>
+                </StatisticGroup>
+            </div>
+        </div>);
 
-        cy.get('.wrolpi-statistic-cell').should(($cells) => {
-            // An odd number of cells over an even number of columns, or this proves nothing.
-            expect($cells.length % 2, 'a short last row').to.equal(1);
-        });
-        cy.get('.wrolpi-statistic-group').should(($group) => {
-            const group = getComputedStyle($group[0]);
-            expect(group.backgroundColor, 'the empty track shows surface, not hairline')
-                .to.not.equal(group.borderRightColor);
+        cy.get('.probe-panel .wrolpi-statistic-group').should(($group) =>
+            expect(getComputedStyle($group[0]).marginTop, 'first child of a panel adds nothing')
+                .to.equal('0px'));
+
+        cy.get('.probe-with-header').then(($panel) => {
+            const header = $panel[0].querySelector('.wrolpi-header').getBoundingClientRect();
+            const group = $panel[0].querySelector('.wrolpi-statistic-group').getBoundingClientRect();
+            expect(group.top - header.bottom, 'space below a heading').to.be.at.least(10);
         });
     });
 
@@ -255,13 +283,13 @@ describe('StatisticGroup rules every row it ends up with', () => {
          * Status omits the fan reading on a device with no fan connector -- most of them --
          * by returning null from FanRPMStatistic.  The group still emits its cell, because it
          * cannot render a child to find out, so `:empty` has to take the cell out of the grid.
-         * Left in, it was a blank padded panel and a stray hairline in the middle of the row.
+         * Left in, it held a track open and opened a hole in the middle of the row.
          */
         const NoFanFitted = () => null;
         cy.mountUI(<StatisticGroup>
             <Statistic value='0.4' label='1 Min. Load'/>
             <NoFanFitted/>
-            <Statistic value='48' label='Temp C°'/>
+            <Statistic value='48' label='Temp C'/>
         </StatisticGroup>);
 
         cy.get('.wrolpi-statistic-cell').should('have.length', 3);
@@ -271,27 +299,21 @@ describe('StatisticGroup rules every row it ends up with', () => {
     });
 
     themeNames.forEach((theme) => {
-        it(`takes its hairline and surface from ${theme}'s tokens`, () => {
-            // Drawn from --border and --panel rather than a fixed grey, which is what lets the
-            // group survive night mode without putting a non-red pixel on the screen.
+        it(`reads its value and label from ${theme}'s tokens`, () => {
+            // The contrast between value and label is all that structures a statistic now that
+            // there is no cell around it, so both colours have to resolve in every theme.
             cy.mountUI(inNarrowColumn(sixStatistics), {theme});
 
-            cy.get('.wrolpi-statistic-group').then(($group) => {
-                const group = getComputedStyle($group[0]);
+            cy.get('.wrolpi-statistic-value').first().then(($value) => {
+                const value = getComputedStyle($value[0]).color;
 
-                cy.get('.wrolpi-statistic-cell').first().should(($cell) => {
-                    const cell = getComputedStyle($cell[0]);
-
-                    // The inner hairlines are the cells' outlines and the outer one is the
-                    // group's border; they meet at every edge, so a theme that resolved them
-                    // to different values would show a two-tone frame.
-                    expect(cell.outlineColor, 'inner hairline matches the outer')
-                        .to.equal(group.borderRightColor);
-                    // And the hairline has to be visible against the surface it sits on --
-                    // both resolved from tokens, so a theme that forgot one shows up here.
-                    expect(cell.outlineColor, 'hairline is not the surface colour')
-                        .to.not.equal(cell.backgroundColor);
-                    expect(cell.backgroundColor, 'cell has a surface').to.not.equal('rgba(0, 0, 0, 0)');
+                cy.get('.wrolpi-statistic-label').first().should(($label) => {
+                    const label = getComputedStyle($label[0]).color;
+                    expect(value, 'value colour resolved').to.match(/^rgba?\(/);
+                    expect(label, 'label colour resolved').to.match(/^rgba?\(/);
+                    // The label is the muted token and the value is body text; if either fell
+                    // back the two would come out the same and the statistic would flatten.
+                    expect(label, 'label is distinct from the value').to.not.equal(value);
                 });
             });
         });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -852,15 +852,54 @@ html[data-theme="amber"] .wrolpi-card-tag {
 /* ------------------------------------------------------------- Statistics */
 /*
  * A statistic carries its own spacing rather than relying on a parent to supply
- * it: unmigrated pages still drop these inside Semantic's `Statistic.Group`,
- * whose CSS only spaces elements carrying Semantic's own classes, and without
- * this the labels run together into one unreadable line.
+ * it, so that one dropped on a page by itself still sits clear of its
+ * neighbours.  Semantic's `Statistic.Group` only spaced elements carrying
+ * Semantic's own classes, so without this the labels ran together into one
+ * unreadable line.
  */
 
 .wrolpi-statistic {
     display: inline-block;
     vertical-align: top;
     margin: 0 26px 10px 0;
+}
+
+/*
+ * The group's hairlines are an outline on each cell, drawn into a 1px grid gap.
+ *
+ * Not a border per cell: a border can only separate the siblings the author can
+ * count -- the old code suppressed `border-right` on the last child -- and
+ * `auto-fit` wraps, so the seven statistics on the Docs page became four rows on
+ * a phone with no rule between them, while the cell ending each earlier row drew
+ * its border straight onto the outer one.
+ *
+ * Nor a border-coloured background behind the gaps, which rules both axes but
+ * also paints every track no cell landed in: seven statistics in two columns
+ * left the eighth slot a solid grey block.  An outline is drawn outside the
+ * cell, so it appears only where a cell actually is.  Adjacent outlines meet in
+ * the same 1px of gap, and the outer ones land on the group's own border, all in
+ * the same colour, so every rule reads as a single hairline.
+ */
+.wrolpi-statistic-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px;
+    background-color: var(--panel);
+    border: 1px solid var(--border);
+}
+
+.wrolpi-statistic-cell {
+    background-color: var(--panel);
+    outline: 1px solid var(--border);
+    padding: 14px 16px;
+}
+
+/*
+ * A statistic that renders nothing -- Status omits the fan reading on a device
+ * with no fan connector -- must not leave a padded cell and a hairline behind.
+ */
+.wrolpi-statistic-cell:empty {
+    display: none;
 }
 
 /* Inside our own group the grid does the spacing, so the intrinsic margin goes. */

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -865,38 +865,44 @@ html[data-theme="amber"] .wrolpi-card-tag {
 }
 
 /*
- * The group's hairlines are an outline on each cell, drawn into a 1px grid gap.
+ * The group is spacing and nothing else: no frame, no rules between cells, and
+ * no surface of its own, so the statistics sit on whatever they are dropped onto
+ * -- the page in one place, a Panel in another -- and pick up its colour.
  *
- * Not a border per cell: a border can only separate the siblings the author can
- * count -- the old code suppressed `border-right` on the last child -- and
- * `auto-fit` wraps, so the seven statistics on the Docs page became four rows on
- * a phone with no rule between them, while the cell ending each earlier row drew
- * its border straight onto the outer one.
+ * That also settles a question this went round twice on.  Ruling the cells needs
+ * a technique that survives wrapping, because `auto-fit` decides the number of
+ * rows at paint time: a `border-right` per cell rules columns but not rows, and
+ * a border-coloured background behind a 1px gap rules both but paints every
+ * track no cell landed in.  With no rules at all, neither problem exists.
  *
- * Nor a border-coloured background behind the gaps, which rules both axes but
- * also paints every track no cell landed in: seven statistics in two columns
- * left the eighth slot a solid grey block.  An outline is drawn outside the
- * cell, so it appears only where a cell actually is.  Adjacent outlines meet in
- * the same 1px of gap, and the outer ones land on the group's own border, all in
- * the same colour, so every rule reads as a single hairline.
+ * The gap is wider across than down.  Two statistics side by side have nothing
+ * between them but air, so they need enough of it not to read as one column of
+ * text; stacked ones are already separated by the label's line.
  */
 .wrolpi-statistic-group {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1px;
-    background-color: var(--panel);
-    border: 1px solid var(--border);
+    gap: 18px 30px;
 }
 
-.wrolpi-statistic-cell {
-    background-color: var(--panel);
-    outline: 1px solid var(--border);
-    padding: 14px 16px;
+/*
+ * With the frame gone there is nothing holding the group off whatever precedes it, and on
+ * most pages that is a Header -- the first row of values sat directly against the heading.
+ *
+ * Only when something does precede it, though.  Apps opens each of its Panels with a group,
+ * and a blanket `margin-top` there pushed the values down off the panel's own top padding
+ * while leaving the bottom where it was, so the whole panel read as lopsided.
+ */
+* + .wrolpi-statistic-group {
+    margin-top: 18px;
 }
 
 /*
  * A statistic that renders nothing -- Status omits the fan reading on a device
- * with no fan connector -- must not leave a padded cell and a hairline behind.
+ * with no fan connector -- must not hold a track open.  The group cannot know in
+ * advance, since it would have to render the child to find out, so the cell is
+ * emitted either way and this takes the empty ones back out.  It is also why the
+ * cells carry no inline style: there is nothing here for it to outrank.
  */
 .wrolpi-statistic-cell:empty {
     display: none;

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -725,8 +725,8 @@ describe('StatisticGroup', () => {
     it('leaves a cell empty when its statistic renders nothing', () => {
         // `FanRPMStatistic` returns null on a device with no fan connector, which is most of
         // them.  The group cannot know that in advance, so the cell is still emitted and
-        // `.wrolpi-statistic-cell:empty` hides it -- which only works while the cell has no
-        // padding or background of its own inline for that rule to have to outrank.
+        // `.wrolpi-statistic-cell:empty` takes it back out -- which only works while the cell
+        // has nothing of its own inline for that rule to have to outrank.
         const Nothing = () => null;
         const {container} = renderUI(<StatisticGroup>
             <Statistic value='1,432' label='Videos'/>
@@ -738,21 +738,30 @@ describe('StatisticGroup', () => {
         expect(cells[1].getAttribute('style')).toBeNull();
     });
 
-    it('draws its hairlines with the grid, not a border per cell', () => {
-        // A per-cell border can only separate siblings the author can count -- the old code
-        // suppressed `borderRight` on the last child -- and `auto-fit` wraps.  Seven
-        // statistics on a phone became four rows with no rule between them, while the cell
-        // ending each earlier row drew its border straight onto the outer one.  A 1px gap
-        // over a border-coloured background rules both axes however the tracks fall.
+    it('draws no chrome of its own, in markup or in style', () => {
+        // The group is spacing only: the statistics sit on whatever surface they were dropped
+        // onto and take its colour.  An inline border or background here would override the
+        // stylesheet and could not be themed, so nothing may set one.
         const {container} = renderUI(<StatisticGroup>
             <Statistic value='1,432' label='Videos'/>
             <Statistic value='896' label='Archives'/>
         </StatisticGroup>);
 
+        const group = container.querySelector('.wrolpi-statistic-group');
+        expect(group.style.border).toBe('');
+        expect(group.style.background).toBe('');
+        expect(group.style.backgroundColor).toBe('');
         for (const cell of container.querySelectorAll('.wrolpi-statistic-cell')) {
-            expect(cell.style.borderRight).toBe('');
+            expect(cell.getAttribute('style')).toBeNull();
         }
-        expect(container.querySelector('.wrolpi-statistic-group')).toBeInTheDocument();
+    });
+
+    it('still passes a style from the caller through', () => {
+        const {container} = renderUI(<StatisticGroup style={{maxWidth: 600}}>
+            <Statistic value='1,432' label='Videos'/>
+        </StatisticGroup>);
+
+        expect(container.querySelector('.wrolpi-statistic-group')).toHaveStyle({maxWidth: '600px'});
     });
 });
 

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -12,6 +12,7 @@ import {
     ActionInput,
     Button,
     Card,
+    CardGroup,
     Confirm,
     Header,
     Icon,
@@ -28,6 +29,8 @@ import {
     PathInput,
     Progress,
     resolveIconName,
+    Statistic,
+    StatisticGroup,
     Status,
     Table,
     ThemePicker,
@@ -642,6 +645,114 @@ describe('Card', () => {
         const {container} = renderUI(<Card title='Plain'/>);
 
         expect(container.firstChild.style.borderBottom).toBe('');
+    });
+});
+
+describe('CardGroup', () => {
+    it('renders every card it is given', () => {
+        renderUI(<CardGroup>
+            <Card title='One'/>
+            <Card title='Two'/>
+            <Card title='Three'/>
+        </CardGroup>);
+
+        expect(screen.getByText('One')).toBeInTheDocument();
+        expect(screen.getByText('Two')).toBeInTheDocument();
+        expect(screen.getByText('Three')).toBeInTheDocument();
+    });
+
+    it('lays cards out on a track no narrower than minWidth', () => {
+        // The default suits file results; a group of wide cards raises it.  If the value were
+        // dropped the grid would fall back to one column, which is how a card wall becomes a
+        // list on a desktop.
+        const {container} = renderUI(<CardGroup minWidth={320}><Card title='One'/></CardGroup>);
+
+        expect(container.querySelector('.wrolpi-card-group'))
+            .toHaveStyle({gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))'});
+    });
+});
+
+describe('Statistic', () => {
+    it('shows the value and its label', () => {
+        renderUI(<Statistic value='87.4 GiB' label='Free space'/>);
+
+        expect(screen.getByText('87.4 GiB')).toBeInTheDocument();
+        expect(screen.getByText('Free space')).toBeInTheDocument();
+    });
+
+    it('colours the value from a token, not a hex', () => {
+        // Status turns load, temperature and IO wait red or orange.  A hex here would not
+        // remap in night mode, putting a green or orange pixel on a red-only screen.
+        const {container} = renderUI(<Statistic value='3.9' label='1 Min. Load' color='red'/>);
+
+        expect(container.querySelector('.wrolpi-statistic-value')).toHaveStyle({color: 'var(--red)'});
+    });
+
+    it('leaves the value in body text when no colour is given', () => {
+        const {container} = renderUI(<Statistic value='0.4' label='1 Min. Load'/>);
+
+        expect(container.querySelector('.wrolpi-statistic-value').style.color).toBe('');
+    });
+
+    it('renders a zero rather than nothing', () => {
+        // `pending_downloads` is 0 on an idle WROLPi, and a falsy check would blank the cell.
+        renderUI(<Statistic value={0} label='Downloading'/>);
+
+        expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('forwards the props its wrappers spread onto it', () => {
+        // `LoadStatistic` and the four Status wrappers (`CPUTemperatureStatistic`,
+        // `FanRPMStatistic`, `IOWaitStatistic`, `UptimeStatistic`) all end in `{...props}`.
+        // Statistic destructured a fixed five and dropped the rest on the floor, so anything
+        // a caller passed through a wrapper vanished with no error anywhere.
+        renderUI(<Statistic value='42' label='Fan RPM' title='Reported by the fan connector'/>);
+
+        expect(screen.getByTitle('Reported by the fan connector')).toBeInTheDocument();
+    });
+});
+
+describe('StatisticGroup', () => {
+    it('gives each statistic its own cell', () => {
+        const {container} = renderUI(<StatisticGroup>
+            <Statistic value='1,432' label='Videos'/>
+            <Statistic value='896' label='Archives'/>
+        </StatisticGroup>);
+
+        expect(container.querySelectorAll('.wrolpi-statistic-cell')).toHaveLength(2);
+    });
+
+    it('leaves a cell empty when its statistic renders nothing', () => {
+        // `FanRPMStatistic` returns null on a device with no fan connector, which is most of
+        // them.  The group cannot know that in advance, so the cell is still emitted and
+        // `.wrolpi-statistic-cell:empty` hides it -- which only works while the cell has no
+        // padding or background of its own inline for that rule to have to outrank.
+        const Nothing = () => null;
+        const {container} = renderUI(<StatisticGroup>
+            <Statistic value='1,432' label='Videos'/>
+            <Nothing/>
+        </StatisticGroup>);
+
+        const cells = container.querySelectorAll('.wrolpi-statistic-cell');
+        expect(cells[1].childNodes).toHaveLength(0);
+        expect(cells[1].getAttribute('style')).toBeNull();
+    });
+
+    it('draws its hairlines with the grid, not a border per cell', () => {
+        // A per-cell border can only separate siblings the author can count -- the old code
+        // suppressed `borderRight` on the last child -- and `auto-fit` wraps.  Seven
+        // statistics on a phone became four rows with no rule between them, while the cell
+        // ending each earlier row drew its border straight onto the outer one.  A 1px gap
+        // over a border-coloured background rules both axes however the tracks fall.
+        const {container} = renderUI(<StatisticGroup>
+            <Statistic value='1,432' label='Videos'/>
+            <Statistic value='896' label='Archives'/>
+        </StatisticGroup>);
+
+        for (const cell of container.querySelectorAll('.wrolpi-statistic-cell')) {
+            expect(cell.style.borderRight).toBe('');
+        }
+        expect(container.querySelector('.wrolpi-statistic-group')).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
`Statistic`, `StatisticGroup` and `CardGroup` had no test of their own. `Statistic` had already been caught out once — it relied on Semantic's `Statistic.Group` for its spacing, so it broke silently when that was uninstalled — and these three are on the Status, Dashboard, Apps, Docs, Videos, Archive and Channels pages.

Writing the tests turned up four defects. Then, on review, the group lost its chrome entirely.

## The group is now spacing and nothing else

No frame, no rules between cells, no surface of its own — a plain responsive grid, transparent, so the statistics sit on whatever they were dropped onto and take its colour: the page on the gallery, a `Panel` on Apps and Status.

That also retires a problem this went two rounds on. Ruling the cells needs a technique that survives wrapping, because `auto-fit` settles the number of rows at paint time:

- a `border-right` per cell rules columns but says nothing about rows — the original bug, which left the Docs page's seven statistics as four rows on a phone **with no rule between them**, while the cell ending each earlier row drew its border straight onto the group's outer one (2px right edge, 1px left);
- a border-coloured background behind a 1px gap rules both axes but paints every track no cell landed in, so an odd count left the last slot a solid grey block.

With no rules to draw, neither case exists. The gap is wider across than down: two statistics side by side have only air between them, while stacked ones already have the label's own line.

**The top margin is conditional on having a sibling before it.** A plain `margin-top` reads correctly under the `Header` that precedes most groups, but Apps opens each of its `Panel`s with one, and there it pushed the values down off the panel's top padding while the bottom stayed put — every panel lopsided. So it is `* + .wrolpi-statistic-group`.

## The other three defects

**A statistic that renders nothing left a cell holding a track open.** `FanRPMStatistic` returns `null` on a device with no fan connector, which is most of them — so a blank cell mid-row was the Status page's *normal* appearance. The group cannot render a child to find out, so the cell is still emitted and `.wrolpi-statistic-cell:empty` takes it back out. That is why the cells carry nothing inline: there is nothing for the `:empty` rule to have to outrank.

**`Statistic` dropped every prop past the five it named.** `LoadStatistic` and the four Status wrappers (`CPUTemperatureStatistic`, `FanRPMStatistic`, `IOWaitStatistic`, `UptimeStatistic`) all end in `{...props}`. Anything passed through a wrapper vanished, with no error anywhere.

**`VideosStatistics` carried Semantic-era spacing.** `style={{margin: '2em'}}` on every statistic, which beat the group's own rule by being inline and made that one page's statistics sit differently from the other six.

## Also

`CardGroup` was the only component in the library without a class of its own, which left nothing to assert against — `container.firstChild` in jsdom is Mantine's injected `<style>` element, worth knowing generally. It has one now, and takes `className`/`style`/rest like its siblings.

The gallery grows a seventh statistic so the group wraps at an ordinary window width, plus a second group of coloured readings as Status draws them.

## Testing

- jest: **997 passing**, 57 suites. 16 new.
- `ui-layout.cy.js`: **25 passing**, 11 new. Geometry, spacing and per-theme token resolution live here rather than in jest because jsdom returns zeros from `getBoundingClientRect` and never resolves a `var()`.
- `npm run build` clean.
- Checked by eye in all four themes, on `/theme-sample`, `/more/statistics` (Panel-wrapped, multiple groups) and `/admin/status` (where the absent fan reading leaves no hole).
- **Every geometry test was verified red against a deliberately planted regression** — flush rows for the spacing claims, a background-carried hairline for the transparency claims, and an unconditional `margin-top` for the panel case. The CSS was restored from a backup after each.

Per-theme, the pair worth checking is no longer the hairline and the surface but the value and the label: with nothing framing a statistic, the contrast between those two is the only thing giving it structure.

Pre-existing, unrelated: `Tags.cy.js`, `Channels.cy.js`, `Download.cy.js` and `Inventory.cy.js` fail with 11 errors on Semantic-era selectors (`div.ui.label.large`, `div.divider.text`, `attribute 'error'`). Confirmed identical on a clean worktree at the base commit — these specs were never migrated.

## Follow-up, not in this PR

The gallery's coloured readings show that **`color='orange'` is invisible in night and inverted in amber**:

| theme | plain | `orange` | `red` |
|---|---|---|---|
| night | `rgb(224,74,74)` | `rgb(224,74,74)` | `rgb(255,59,59)` |
| amber | `rgb(255,149,0)` | `rgb(240,148,40)` | `rgb(255,192,64)` |

In night, `--orange` is byte-identical to `--text`, so a warning-level load or temperature reads exactly like a healthy one. In amber it is *dimmer* than normal text, so a warning reads as **less** urgent. On the Status page that is the difference between noticing a Pi is overheating and not.

That is a `tokens.css` change affecting every `--orange` consumer, not just `Statistic`, and picking the values is a judgement about the night ramp — the design note says brightness carries meaning there, but `--red` already has *lower* luminance than `--text`, so the ramp is really ordered by saturation. Worth deciding deliberately rather than folding into this PR.
