### PR TITLE
ui: tags look like tags, and stay readable in every theme

### DIFF
--- a/app/cypress/support/component.js
+++ b/app/cypress/support/component.js
@@ -116,6 +116,48 @@ Cypress.Commands.add('shouldNotOverlap', {prevSubject: false}, (firstSelector, s
     });
 });
 
+/**
+ * Contrast ratio between an element's text and the surface actually behind it, per WCAG.
+ *
+ * "The surface actually behind it" is the point.  A transparent element -- which is what a
+ * tag becomes in night mode -- has no background of its own to compare against, so a naive
+ * check reads `rgba(0,0,0,0)` and concludes anything is legible.  This walks up to the first
+ * ancestor that paints something, which is what the eye sees.
+ */
+const parseRgb = (value) => {
+    const parts = (value.match(/[\d.]+/g) || []).map(Number);
+    return {r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1};
+};
+
+const relativeLuminance = ({r, g, b}) => {
+    const channel = (v) => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+const effectiveBackground = (el) => {
+    let node = el;
+    while (node && node !== document.documentElement) {
+        const bg = parseRgb(getComputedStyle(node).backgroundColor);
+        if (bg.a > 0) return bg;
+        node = node.parentElement;
+    }
+    return parseRgb(getComputedStyle(document.documentElement).backgroundColor);
+};
+
+Cypress.Commands.add('contrastRatio', {prevSubject: false}, (selector) => {
+    return cy.get(selector).then(($el) => {
+        const el = $el[0];
+        const text = relativeLuminance(parseRgb(getComputedStyle(el).color));
+        const behind = relativeLuminance(effectiveBackground(el));
+        const lighter = Math.max(text, behind);
+        const darker = Math.min(text, behind);
+        return (lighter + 0.05) / (darker + 0.05);
+    });
+});
+
 Cypress.Commands.add('mountWithTags', (component, options) => {
     cy.fixture('tagsMock.json').then((mockTags) => {
         cy.intercept('GET', '**/api/tag', {

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -336,9 +336,16 @@ function EditTagsModal() {
             <Modal.Header>Edit Tags</Modal.Header>
             <div id='editModalContent'>
                 <Group gap={6}>
+                    {/*
+                      * `--label-text`, not `color`, for the same reason as the chip itself:
+                      * inline `color` cannot be overridden, so in night this preview showed
+                      * black text on a transparent outline over a near-black page.  It is the
+                      * preview of the colour being chosen, so being honest about how the tag
+                      * will actually look matters here more than anywhere.
+                      */}
                     <span
-                        className='wrolpi-label'
-                        style={{['--label-color']: tagColor, color: textColor}}
+                        className='wrolpi-label wrolpi-tag'
+                        style={{['--label-color']: tagColor, ['--label-text']: textColor}}
                     >
                         {tagName || 'Example Tag'}
                     </span>

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -111,18 +111,26 @@ export function useTags() {
         if (tag !== null && tag !== undefined) {
             const tagColor = tag['color'] || DEFAULT_TAG_COLOR;
             const textColor = contrastingColor(tagColor);
-            const className = ['wrolpi-label', props.onClick ? 'clickable' : ''].filter(Boolean).join(' ');
+            const className = ['wrolpi-label', 'wrolpi-tag', props.onClick ? 'clickable' : '']
+                .filter(Boolean).join(' ');
             return <span
                 {...props} // onClick passed here.
                 className={className}
-                style={{...props['style'], ['--label-color']: tagColor, color: textColor}}
+                /*
+                 * The contrasting text colour goes in a custom property, not in `color`.  As
+                 * `color` it was an inline declaration, which no stylesheet rule can outrank --
+                 * so night, where a tag becomes an outline over a near-black page, still got
+                 * the black text calculated for a bright tag's fill.  The tag was legible only
+                 * by its border.  A custom property lets each theme decide instead.
+                 */
+                style={{...props['style'], ['--label-color']: tagColor, ['--label-text']: textColor}}
             >
                 {name}
             </span>;
         }
 
         // No tags have been fetched.
-        return <Label>{name}</Label>;
+        return <Label tag>{name}</Label>;
     }
 
     const TagsGroup = ({tagNames, onClick}) => {

--- a/app/src/Tags.test.js
+++ b/app/src/Tags.test.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import {screen, waitFor} from '@testing-library/react';
+import {render} from './test-utils';
+import {queryContextFixture} from './test-fixtures';
+import {QueryContext} from './contexts/contexts';
+import {useTags} from './Tags';
+
+/*
+ * Tests for the real tag chip.
+ *
+ * Everything else in the suite takes `NameToTagLabel` from `tagsContextFixture`, which stubs
+ * it as a function returning the name -- so nothing exercised the component that actually
+ * paints a tag.  That is how a tag came to be unreadable in night mode without a single test
+ * noticing: the colours are decided here, in the one place in the app that paints with a
+ * value no theme chose.
+ */
+
+jest.mock('./api', () => ({
+    getTags: jest.fn(),
+    getRecentTags: jest.fn(),
+    saveTag: jest.fn(),
+    deleteTag: jest.fn(),
+}));
+
+import {getTags, getRecentTags} from './api';
+
+const BRIGHT = '#ffe066';   // contrastingColor -> black
+const DARK = '#1a1a2e';     // contrastingColor -> light
+
+// A harness that renders the real NameToTagLabel out of the real hook.
+const TagProbe = ({name}) => {
+    const {NameToTagLabel} = useTags();
+    return <NameToTagLabel name={name}/>;
+};
+
+const renderTag = (name, tags) => render(
+    <QueryContext.Provider value={queryContextFixture()}>
+        <TagProbe name={name}/>
+    </QueryContext.Provider>
+);
+
+const tagOf = (name) => screen.getByText(name);
+
+/*
+ * Wait for the fetched colours to arrive.  Before they do, `NameToTagLabel` falls back to a
+ * plain `<Label tag>` -- which also carries `wrolpi-tag`, so waiting on the class alone
+ * passes against the fallback and asserts nothing about the real chip.  Wait for the user's
+ * colour instead.
+ */
+const awaitColoured = async (name, color) => {
+    await waitFor(() =>
+        expect(tagOf(name).style.getPropertyValue('--label-color')).toBe(color));
+    return tagOf(name);
+};
+
+describe('a tag chip', () => {
+    beforeEach(() => {
+        getTags.mockResolvedValue({
+            tags: [
+                {id: 1, name: 'Water', color: BRIGHT},
+                {id: 2, name: 'Archived', color: DARK},
+                {id: 3, name: 'Uncoloured', color: null},
+            ],
+        });
+        getRecentTags.mockResolvedValue({tags: []});
+    });
+
+    it('carries the tag shape, not just the chip shape', async () => {
+        renderTag('Water');
+
+        const tag = await awaitColoured('Water', BRIGHT);
+        expect(tag).toHaveClass('wrolpi-tag');
+        expect(tag).toHaveClass('wrolpi-label');
+    });
+
+    it('puts the calculated text colour in a variable, never in `color`', async () => {
+        /*
+         * This is the whole defect.  As an inline `color` declaration nothing in a stylesheet
+         * could outrank it, so night -- which turns a tag into an outline over a near-black
+         * page -- was still painting the black text that had been calculated for a bright
+         * yellow fill.  The tag was legible only by its border.
+         */
+        renderTag('Water');
+
+        const tag = await awaitColoured('Water', BRIGHT);
+        expect(tag.style.getPropertyValue('--label-text')).toBe('#000000');
+        expect(tag.style.color).toBe('');
+    });
+
+    it('calculates light text for a dark tag', async () => {
+        renderTag('Archived');
+
+        const tag = await awaitColoured('Archived', DARK);
+        const text = tag.style.getPropertyValue('--label-text');
+        // Non-empty first: an absent variable would satisfy "not black" for free.
+        expect(text).toBeTruthy();
+        expect(text).not.toBe('#000000');
+    });
+
+    it('falls back to a default colour rather than leaving the fill unset', async () => {
+        renderTag('Uncoloured');
+
+        // The tag exists with no colour of its own, so the default stands in.
+        await waitFor(() =>
+            expect(tagOf('Uncoloured').style.getPropertyValue('--label-color')).toBeTruthy());
+    });
+
+    it('still shows the name before any tags have been fetched', async () => {
+        // The colours are not known yet; the word matters more than the colour.
+        getTags.mockResolvedValue({tags: []});
+        renderTag('Water');
+
+        expect(await screen.findByText('Water')).toBeInTheDocument();
+    });
+});

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1529,9 +1529,29 @@ export const toLocaleString = (num, locale = 'en-US') => {
     return num.toLocaleString(locale);
 }
 
-function luma(color) {
-    let rgb = (typeof color === 'string') ? hexToRGBArray(color) : color;
-    return (0.2126 * rgb[0]) + (0.7152 * rgb[1]) + (0.0722 * rgb[2]); // SMPTE C, Rec. 709 weightings
+/**
+ * WCAG relative luminance: sRGB channels linearised first, then Rec. 709 weighted.
+ *
+ * The linearisation is the part that matters.  Weighting the gamma-encoded bytes directly --
+ * which is what this did before -- is a rough approximation that misjudges mid-tone blues and
+ * purples badly enough to pick the wrong text colour for them.
+ */
+function relativeLuminance(color) {
+    const rgb = (typeof color === 'string') ? hexToRGBArray(color) : color;
+    if (!rgb) {
+        return 0;
+    }
+    const linear = rgb.map(value => {
+        const channel = value / 255;
+        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+    });
+    return (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2]);
+}
+
+/** WCAG contrast ratio between two colours, from 1:1 (identical) to 21:1 (black on white). */
+export function contrastRatio(a, b) {
+    const luminances = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+    return (luminances[0] + 0.05) / (luminances[1] + 0.05);
 }
 
 function hexToRGBArray(color) {
@@ -1547,8 +1567,21 @@ function hexToRGBArray(color) {
     return rgb;
 }
 
+export const TAG_TEXT_DARK = '#000000';
+export const TAG_TEXT_LIGHT = '#dddddd';
+
+/**
+ * Dark or light text, whichever a user's chosen tag colour actually reads better against.
+ *
+ * Measures both instead of comparing a brightness figure to a threshold.  The threshold
+ * version put light text on Semantic's blue (`#2185d0`) at 2.9:1 when dark text on the same
+ * fill gives 5.3:1 -- it had picked the worse of the only two options.  Every mid-tone blue,
+ * teal and purple a user might choose sat in that band.
+ */
 export function contrastingColor(color) {
-    return (luma(color) >= 120) ? '#000000' : '#dddddd';
+    return contrastRatio(TAG_TEXT_DARK, color) >= contrastRatio(TAG_TEXT_LIGHT, color)
+        ? TAG_TEXT_DARK
+        : TAG_TEXT_LIGHT;
 }
 
 export const encodeMediaPath = (path) => {

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1554,16 +1554,26 @@ export function contrastRatio(a, b) {
     return (luminances[0] + 0.05) / (luminances[1] + 0.05);
 }
 
+/**
+ * A hex colour as [r, g, b], accepting both `#rrggbb` and the shorthand `#rgb`.
+ *
+ * The shorthand matters because tag colours are not only chosen in the colour picker: they
+ * live in the database and in a config file, and a config is something a user edits by hand
+ * -- configs are the source of truth in WROLPi.  Rejecting `#fff` left the luminance at zero,
+ * so a near-white tag was treated as black and handed light text.
+ */
 function hexToRGBArray(color) {
-    if (color.length === 7) {
-        color = color.slice(1);
+    let hex = (typeof color === 'string' ? color : '').replace(/^#/, '');
+    if (hex.length === 3) {
+        // #abc means #aabbcc, not #0a0b0c.
+        hex = hex.split('').map(digit => digit + digit).join('');
     }
-    if (color.length !== 6) {
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
         console.error('Invalid hex color: ' + color);
         return;
     }
     let rgb = [];
-    for (let i = 0; i <= 2; i++) rgb[i] = parseInt(color.substr(i * 2, 2), 16);
+    for (let i = 0; i <= 2; i++) rgb[i] = parseInt(hex.substr(i * 2, 2), 16);
     return rgb;
 }
 

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -531,3 +531,32 @@ describe('contrastingColor', () => {
         expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
     });
 });
+
+describe('contrastingColor with shorthand hex', () => {
+    /*
+     * Tag colours reach the UI from the database, and a tags config is a file a user can edit
+     * by hand -- configs are the source of truth in WROLPi -- so a perfectly valid `#fff` can
+     * arrive here.  `hexToRGBArray` used to reject anything but six digits, which left the
+     * luminance at zero: a near-white tag was treated as black and given light text.
+     */
+
+    it('reads a three-digit hex as the colour it is', () => {
+        expect(contrastRatio('#000000', '#fff')).toBeCloseTo(21, 1);
+        expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(contrastRatio('#000000', '#fff'), 5);
+    });
+
+    it('picks dark text for a near-white shorthand fill', () => {
+        expect(contrastingColor('#fff')).toBe(TAG_TEXT_DARK);
+    });
+
+    it('picks light text for a near-black shorthand fill', () => {
+        expect(contrastingColor('#000')).toBe(TAG_TEXT_LIGHT);
+    });
+
+    it('agrees with the six-digit form of the same colour', () => {
+        for (const [short, long] of [['#fff', '#ffffff'], ['#000', '#000000'],
+                                     ['#f00', '#ff0000'], ['#1b2', '#11bb22']]) {
+            expect(contrastingColor(short)).toBe(contrastingColor(long));
+        }
+    });
+});

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import {act, render, screen, waitFor} from '../test-utils';
 import userEvent from '@testing-library/user-event';
-import {DirectorySearch, SearchResultsInput} from './Common';
+import {
+    contrastingColor, contrastRatio, DirectorySearch, SearchResultsInput, TAG_TEXT_DARK, TAG_TEXT_LIGHT,
+} from './Common';
 
 // Mock debounce to make tests run faster
 jest.mock('lodash/debounce', () => jest.fn(fn => {
@@ -477,5 +479,55 @@ describe('SearchResultsInput', () => {
         await userEvent.click(screen.getByRole('combobox'));
 
         expect(screen.getByText('rendered:Cooking')).toBeInTheDocument();
+    });
+});
+
+describe('contrastingColor', () => {
+    /*
+     * This decides the text colour on every tag, against a fill the user picked, so it is the
+     * one place in the app where legibility is computed rather than designed.
+     */
+
+    it('picks whichever of the two options actually reads better', () => {
+        // Semantic's blue.  The old threshold check chose light text here, at 2.9:1, when dark
+        // text on the same fill gives 5.3:1 -- the worse of the only two available answers.
+        // Every mid-tone blue, teal and purple a user might choose sat in that band.
+        const blue = '#2185d0';
+
+        const chosen = contrastingColor(blue);
+        const rejected = chosen === TAG_TEXT_DARK ? TAG_TEXT_LIGHT : TAG_TEXT_DARK;
+
+        expect(contrastRatio(chosen, blue)).toBeGreaterThan(contrastRatio(rejected, blue));
+        expect(chosen).toBe(TAG_TEXT_DARK);
+    });
+
+    it('never picks the worse option, for any colour', () => {
+        // The property, rather than a list of examples: whatever it returns must be at least as
+        // legible as the alternative would have been.
+        const colours = [
+            '#000000', '#ffffff', '#f2f2f2', '#1b1c1d', '#2185d0', '#21ba45', '#db2828',
+            '#fbbd08', '#6435c9', '#a5673f', '#00b5ad', '#e03997', '#b5cc18', '#767676',
+            '#808080', '#7f7f7f',
+        ];
+
+        for (const colour of colours) {
+            const chosen = contrastingColor(colour);
+            const rejected = chosen === TAG_TEXT_DARK ? TAG_TEXT_LIGHT : TAG_TEXT_DARK;
+            expect(contrastRatio(chosen, colour))
+                .toBeGreaterThanOrEqual(contrastRatio(rejected, colour));
+        }
+    });
+
+    it('returns one of the two text colours and nothing else', () => {
+        // It is written into `--label-text`; anything undefined leaves the tag unstyled.
+        for (const colour of ['#000000', '#ffffff', '#2185d0']) {
+            expect([TAG_TEXT_DARK, TAG_TEXT_LIGHT]).toContain(contrastingColor(colour));
+        }
+    });
+
+    it('measures contrast on the WCAG scale', () => {
+        // Anchors the ratio itself, so "better" above is comparing real numbers.
+        expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 1);
+        expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
     });
 });

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -783,9 +783,12 @@ export function FlasherPage() {
                                     <Table.Cell>{humanFileSize(result.size)}</Table.Cell>
                                     <Table.Cell>
                                         {result.esp_chip
+                                            // `--label-text` rather than `color`: an inline
+                                            // `color` cannot be overridden, and night and
+                                            // amber replace the chip's fill with their own.
                                             ? <span className='wrolpi-label' style={{
                                                 '--label-color': chipColor(result.esp_chip),
-                                                color: chipTextColor(chipColor(result.esp_chip)),
+                                                '--label-text': chipTextColor(chipColor(result.esp_chip)),
                                             }}>{result.esp_chip}</span>
                                             : <span style={{opacity: 0.5}}>—</span>}
                                     </Table.Cell>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -36,6 +36,7 @@ import {
     toast,
 } from './ui';
 import {semanticColorNames} from '../themes/mantine';
+import {contrastingColor} from './Common';
 
 /*
  * A gallery of every component in the library, in the current theme.
@@ -386,6 +387,38 @@ export function ThemeSamplePage() {
                     <Label color='white'>white</Label>
                     <Label color='blue' icon='tag'>tagged</Label>
                 </Row>
+            </Panel>
+        </Section>
+
+        <Section label='Tags'>
+            <Panel>
+                {/*
+                  * Tag colours are the user's, stored per tag, so these are raw hex values --
+                  * the only place in the app that paints with something no theme chose.  That
+                  * is exactly why they belong here: the gallery had label swatches in theme
+                  * colours and no user-coloured tag, so nobody saw that night was calculating
+                  * the text colour against a fill it had already thrown away.
+                  *
+                  * Deliberately spans the range: near-white and near-black fills, where the
+                  * black-or-light text decision flips, plus enough tags to wrap a row.
+                  */}
+                <Row>
+                    {[
+                        ['Water', '#2185d0'], ['Food', '#21ba45'], ['Medical', '#db2828'],
+                        ['Shelter', '#a5673f'], ['Power', '#fbbd08'], ['Comms', '#6435c9'],
+                        ['Reference', '#f2f2f2'], ['Archived', '#1b1c1d'],
+                        ['Seeds', '#b5cc18'], ['Tools', '#00b5ad'], ['Navigation', '#e03997'],
+                    ].map(([name, color]) => <span
+                        key={name}
+                        className='wrolpi-label wrolpi-tag'
+                        style={{'--label-color': color, '--label-text': contrastingColor(color)}}
+                    >{name}</span>)}
+                </Row>
+                <p style={{marginTop: 14, fontSize: 13, color: 'var(--muted)'}}>
+                    Every tag must be readable in all four themes. In night and amber the
+                    user's colour is discarded, so all tags look alike — that is the same
+                    trade the labels above make, and it is deliberate.
+                </p>
             </Panel>
         </Section>
 

--- a/app/src/components/ui/Feedback.tsx
+++ b/app/src/components/ui/Feedback.tsx
@@ -63,16 +63,23 @@ export function Message({kind = 'info', title, children, icon, onDismiss, classN
 export interface LabelProps {
     color?: SemanticColorName | 'black' | 'white';
     icon?: string | React.ComponentType<any>;
+    /**
+     * Draw it as a physical tag — pointed left edge and an eyelet — rather than a plain
+     * chip.  Reserved for things that actually are tags: the same component also carries
+     * the count badges in the Tags table, and a point on a number reads as an arrow.
+     */
+    tag?: boolean;
     children?: React.ReactNode;
     onClick?: React.MouseEventHandler<HTMLSpanElement>;
     className?: string;
 }
 
-/** A tag/chip.  Filled in light and dark; an outline in night, where a filled
+/** A chip.  Filled in light, dark and amber; an outline in night, where a filled
  *  patch would be a bright surface. */
-export function Label({color = 'grey', icon, children, onClick, className}: LabelProps) {
+export function Label({color = 'grey', icon, tag, children, onClick, className}: LabelProps) {
     return <span
-        className={['wrolpi-label', `wrolpi-label-${color}`, className].filter(Boolean).join(' ')}
+        className={['wrolpi-label', `wrolpi-label-${color}`, tag ? 'wrolpi-tag' : '', className]
+            .filter(Boolean).join(' ')}
         style={{['--label-color' as string]: `var(--${color})`, cursor: onClick ? 'pointer' : undefined}}
         onClick={onClick}
     >

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import {ActionInput, Button, Header, PathInput, Statistic, StatisticGroup, TextInput} from './index';
+import {
+    ActionInput, Button, Header, PathInput, Statistic, StatisticGroup, TabBar, tabClassName, TextInput,
+} from './index';
+import {contrastingColor} from '../Common';
 import {themeNames} from '../../themes/names';
 
 /*
@@ -316,6 +319,183 @@ describe('StatisticGroup separates its statistics with nothing but space', () =>
                     expect(label, 'label is distinct from the value').to.not.equal(value);
                 });
             });
+        });
+    });
+});
+
+describe('a tag is legible in every theme, whatever colour the user picked', () => {
+    /*
+     * Tag colours are the user's, stored per tag -- the only thing in the app painted with a
+     * value no theme chose.  Tags.js calculates black or light text against that fill, and
+     * night discards the fill entirely (a filled tag would be a bright patch) while amber
+     * replaces it with its own.  Whether the text still reads afterwards is a question about
+     * resolved colour against a real painted surface, so it can only be asked here.
+     */
+
+    // The extremes of the black-or-light decision, plus a mid tone.
+    const TAG_COLOURS = [
+        ['Reference', '#f2f2f2'],   // near-white: text is calculated black
+        ['Archived', '#1b1c1d'],    // near-black: text is calculated light
+        ['Water', '#2185d0'],
+    ];
+
+    const tags = <div>
+        {TAG_COLOURS.map(([name, color]) => <span
+            key={name}
+            className='wrolpi-label wrolpi-tag'
+            data-tag={name}
+            style={{'--label-color': color, '--label-text': contrastingColor(color)}}
+        >{name}</span>)}
+    </div>;
+
+    themeNames.forEach((theme) => {
+        TAG_COLOURS.forEach(([name]) => {
+            it(`reads ${name} against its real surface in ${theme}`, () => {
+                cy.mountUI(tags, {theme});
+
+                /*
+                 * 4.5:1 is WCAG AA for body text.  Before this, night measured 1.1:1 on a
+                 * near-white tag -- the black text calculated for that fill, painted onto a
+                 * transparent tag over a near-black page.  The tag was readable only as an
+                 * empty outline.
+                 */
+                cy.contrastRatio(`[data-tag="${name}"]`).should('be.at.least', 4.5);
+            });
+        });
+    });
+
+    it('detects the unreadable tag this started as, so the check has teeth', () => {
+        /*
+         * The original defect, reproduced deliberately: the calculated text colour written to
+         * `color` inline, which no stylesheet rule can outrank.  In night the tag becomes a
+         * transparent outline over a near-black page, so the black text calculated for a
+         * near-white fill is painted onto near-black.
+         *
+         * Asserting that this IS unreadable proves contrastRatio measures the surface actually
+         * behind the text rather than the tag's own missing background.  A contrast check that
+         * has never gone red is indistinguishable from one that cannot.
+         */
+        cy.mountUI(
+            <span
+                className='wrolpi-label wrolpi-tag'
+                data-tag='Legacy'
+                style={{'--label-color': '#f2f2f2', color: contrastingColor('#f2f2f2')}}
+            >Reference</span>,
+            {theme: 'night'},
+        );
+
+        cy.contrastRatio('[data-tag="Legacy"]').should('be.lessThan', 1.5);
+    });
+
+    it('is at least as large as the Semantic label it replaced', () => {
+        // The first pass came out at 11.5px against Semantic's 12px and read as shrunken.
+        // A tag is a hit target as well as a word, so it also has to stay tall enough to hit.
+        cy.mountUI(tags);
+
+        cy.get('.wrolpi-tag').first().should(($tag) => {
+            expect(parseFloat(getComputedStyle($tag[0]).fontSize), 'font size').to.be.at.least(12);
+            expect($tag[0].getBoundingClientRect().height, 'height').to.be.at.least(26);
+        });
+    });
+});
+
+describe('a tag looks like a physical tag', () => {
+    const tag = <span
+        className='wrolpi-label wrolpi-tag'
+        style={{'--label-color': '#2185d0', '--label-text': '#ffffff'}}
+    >Water</span>;
+
+    it('has a pointed left edge that spans the full height', () => {
+        /*
+         * The point is a square rotated 45 degrees behind the left edge.  Its diagonal has to
+         * equal the body's height, or the two edges meet the body short of its corners and the
+         * result reads as a notch stuck on the side rather than one tag-shaped outline.
+         */
+        cy.mountUI(tag);
+
+        cy.get('.wrolpi-tag').should(($tag) => {
+            const el = $tag[0];
+            const height = el.getBoundingClientRect().height;
+            const side = parseFloat(getComputedStyle(el, '::before').width);
+            expect(side, 'the point is drawn at all').to.be.greaterThan(0);
+            expect(side * Math.SQRT2, "the point's diagonal matches the body height")
+                .to.be.closeTo(height, 2);
+        });
+    });
+
+    it('protrudes to the left, and reserves the room it needs', () => {
+        // The point is drawn outside the body, so without a matching margin it would print
+        // over whatever sits to the left -- the previous tag in the row.
+        cy.mountUI(tag);
+
+        cy.get('.wrolpi-tag').should(($tag) => {
+            const el = $tag[0];
+            const side = parseFloat(getComputedStyle(el, '::before').width);
+            const protrusion = side / 2;
+            expect(parseFloat(getComputedStyle(el).marginLeft), 'room for the point')
+                .to.be.at.least(protrusion - 1);
+        });
+    });
+
+    it('does not print the point over the first letter', () => {
+        /*
+         * A positioned pseudo-element paints above the parent's text, not behind it, and the
+         * point's inner half lies over the body.  Removing the left padding once hid the first
+         * character of every tag: "Water" read as "ater".
+         */
+        cy.mountUI(tag);
+
+        cy.get('.wrolpi-tag').should(($tag) => {
+            const el = $tag[0];
+            const styles = getComputedStyle(el);
+            const overlapIntoBody = parseFloat(getComputedStyle(el, '::before').width) / 2;
+            const textStartsAt = parseFloat(styles.paddingLeft) + parseFloat(styles.borderLeftWidth);
+            expect(textStartsAt, 'text starts clear of the point').to.be.greaterThan(overlapIntoBody);
+        });
+    });
+
+    it('keeps wrapped rows of tags off each other', () => {
+        // Tags wrap wherever they are listed, and a wrapped row was sitting on the row above.
+        cy.mountUI(<div style={{width: 240}}>
+            {['Water', 'Food', 'Medical', 'Shelter', 'Power', 'Comms'].map((name) => <span
+                key={name}
+                className='wrolpi-label wrolpi-tag'
+                style={{'--label-color': '#2185d0', '--label-text': '#ffffff'}}
+            >{name}</span>)}
+        </div>);
+
+        cy.get('.wrolpi-tag').should(($tags) => {
+            const rects = [...$tags].map((el) => el.getBoundingClientRect());
+            const rows = [...new Set(rects.map((r) => Math.round(r.top)))].sort((a, b) => a - b);
+            expect(rows.length, 'the tags wrapped').to.be.greaterThan(1);
+
+            for (let row = 1; row < rows.length; row++) {
+                const previousBottom = Math.max(...rects
+                    .filter((r) => Math.round(r.top) === rows[row - 1])
+                    .map((r) => r.bottom));
+                expect(rows[row] - previousBottom, `gap above row ${row + 1}`).to.be.at.least(3);
+            }
+        });
+    });
+});
+
+describe('tabs', () => {
+    themeNames.forEach((theme) => {
+        it(`gives an inactive tab no surface of its own in ${theme}`, () => {
+            /*
+             * A tab is a NavLink in the app's nav bars but a <button> on Inventory and in the
+             * gallery, and a button carries the UA's `buttonface` background -- rgb(239,239,239).
+             * Only the active tab set a background, so every inactive one was a near-white block
+             * in dark, night and amber.
+             */
+            cy.mountUI(<TabBar>
+                <button className={tabClassName(true)}>Videos</button>
+                <button className={tabClassName(false)}>Channels</button>
+            </TabBar>, {theme});
+
+            cy.contains('button', 'Channels').should(($tab) =>
+                expect(getComputedStyle($tab[0]).backgroundColor, 'inactive tab is transparent')
+                    .to.equal('rgba(0, 0, 0, 0)'));
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -423,17 +423,60 @@ describe('a tag looks like a physical tag', () => {
         });
     });
 
-    it('protrudes to the left, and reserves the room it needs', () => {
-        // The point is drawn outside the body, so without a matching margin it would print
-        // over whatever sits to the left -- the previous tag in the row.
+    /*
+     * Where the tip of the point actually lands, relative to the body's left edge.
+     *
+     * The square's box spans [-side, 0] in padding-box coordinates (`right: 100%`), is shifted
+     * by the transform's resolved horizontal translation, and then rotates about its own centre
+     * -- so the tip reaches half a diagonal beyond that centre.  Padding-box coordinates are
+     * inside the border, which is the whole reason the point needed nudging, so the border
+     * width comes off at the end.
+     */
+    const tipOffset = (el) => {
+        const before = getComputedStyle(el, '::before');
+        const side = parseFloat(before.width);
+        const translateX = parseFloat(before.transform.match(/matrix\(([^)]+)\)/)[1].split(',')[4]);
+        const centre = -side + translateX + side / 2;
+        return centre - (side * Math.SQRT2 / 2) - parseFloat(getComputedStyle(el).borderLeftWidth);
+    };
+
+    /* Where the point's centre sits, relative to the body's visible (border-box) left edge. */
+    const pointCentreOffset = (el) => {
+        const before = getComputedStyle(el, '::before');
+        const side = parseFloat(before.width);
+        const translateX = parseFloat(before.transform.match(/matrix\(([^)]+)\)/)[1].split(',')[4]);
+        return (-side + translateX + side / 2) - parseFloat(getComputedStyle(el).borderLeftWidth);
+    };
+
+    it('grows the point out of the left edge rather than setting it into the body', () => {
+        /*
+         * `right: 100%` positions against the containing block's *padding* box, and the body
+         * carries a 1px border -- so a square centred there sits a pixel inside the visible left
+         * edge, and the point reads as set into the tag instead of growing out of it.
+         *
+         * Asserting the tip lands somewhere far to the left does not catch this: the un-nudged
+         * version's tip is only 2px further right, still well clear of the body.  The claim is
+         * about where the point is *centred*, which is the thing that differs.
+         */
+        cy.mountUI(tag);
+
+        cy.get('.wrolpi-tag').should(($tag) =>
+            expect(pointCentreOffset($tag[0]), 'the point is centred left of the visible edge')
+                .to.be.at.most(-2));
+    });
+
+    it('reserves exactly the room the point takes', () => {
+        // Without a margin covering the full protrusion the point prints over whatever sits to
+        // its left -- the previous tag in the row.  The old value, 15px, was 2px short of this.
         cy.mountUI(tag);
 
         cy.get('.wrolpi-tag').should(($tag) => {
             const el = $tag[0];
-            const side = parseFloat(getComputedStyle(el, '::before').width);
-            const protrusion = side / 2;
-            expect(parseFloat(getComputedStyle(el).marginLeft), 'room for the point')
-                .to.be.at.least(protrusion - 1);
+            const needed = Math.abs(tipOffset(el));
+            const margin = parseFloat(getComputedStyle(el).marginLeft);
+            expect(margin, 'margin covers the protrusion').to.be.at.least(needed - 0.5);
+            // And is not wasteful about it, or tags drift apart for no visible reason.
+            expect(margin, 'margin is not far beyond it').to.be.at.most(needed + 3);
         });
     });
 

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -191,6 +191,13 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
     color: var(--muted);
     text-decoration: none;
     font-size: 13px;
+    /*
+     * A tab is a NavLink in the app's nav bars but a <button> on Inventory and in the
+     * gallery, and a button carries the UA's own `buttonface` background -- rgb(239,239,239).
+     * Only the active tab set a background, so every inactive one was a near-white block in
+     * dark, night and amber.  The bar's own surface has to show through instead.
+     */
+    background: transparent;
     border: 1px solid transparent;
     /* Sits on the bar's own rule, so the active tab can erase it and read as
        connected to the panel below. */
@@ -554,27 +561,101 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 
 /* ----------------------------------------------------------------- Labels */
 
+/*
+ * Sized to Semantic's label (12px text, ~7px of vertical padding), which these replaced.
+ * The first pass came out at 11.5px with 3px of padding and read as noticeably smaller than
+ * what users had before -- a tag is a hit target as well as a word.
+ */
 .wrolpi-label {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 3px 9px;
-    font-size: 11.5px;
+    padding: 5px 10px;
+    font-size: 12.5px;
     font-weight: 500;
     line-height: 1.3;
     background: var(--label-color);
-    color: var(--btn-text);
+    /*
+     * `--label-text` is set per-tag by Tags.js, which calculates black or light text against
+     * the user's chosen fill.  The fallback covers every label whose fill is a theme token.
+     * It is a variable rather than an inline `color` so that a theme which discards the fill
+     * can also discard the text colour calculated for it.
+     */
+    color: var(--label-text, var(--btn-text));
     border: 1px solid transparent;
 }
 
-/* White and black labels would vanish into the surface they sit on. */
+/* ------------------------------------------------------------------- Tags */
+/*
+ * A tag is a label with a physical shape: a pointed left edge and an eyelet, like a tag
+ * tied to a garment.  The point is a square rotated 45 degrees behind the left edge -- its
+ * right half sits under the body in the same colour and merges, leaving the left half
+ * showing as the point.  At 20px a side its diagonal is 28px, which is the body's height,
+ * so the two edges of the point meet the body exactly at its corners.
+ *
+ * The eyelet is drawn in `currentColor`, so it reads as a hole punched through the tag on
+ * any surface, filled or outlined, without needing to know what is behind it.
+ */
+
+.wrolpi-tag {
+    position: relative;
+    /* Room for the point, which is drawn outside the body. */
+    margin-left: 15px;
+    /* Tags wrap, and a wrapped row was sitting on the row above it. */
+    margin-bottom: 5px;
+    /*
+     * The point is centred on the left edge, so its inner half covers the body's first 10px
+     * -- and a positioned pseudo-element paints above the parent's text, not behind it, so
+     * without this the first letter is hidden under the point.  Semantic's tag label carried
+     * the same asymmetry (`padding-left: 1.5em`) for the same reason.
+     */
+    padding-left: 13px;
+}
+
+.wrolpi-tag::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 100%;
+    width: 20px;
+    height: 20px;
+    transform: translate(50%, -50%) rotate(45deg);
+    background: var(--label-color);
+}
+
+/*
+ * The eyelet sits in the point, where a real tag's hole is -- inside the body it reads as a
+ * bullet in front of the word.  It is outside the element's own box, over the ::before, and
+ * paints on top of it by being the later pseudo-element.
+ */
+.wrolpi-tag::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -7px;
+    width: 5px;
+    height: 5px;
+    margin-top: -2.5px;
+    border-radius: 50%;
+    background: currentColor;
+    /* A hole, not a dot: it should read as absence rather than as a bullet. */
+    opacity: 0.45;
+}
+
+/*
+ * White and black labels would vanish into the surface they sit on.  They set the text
+ * colour through `--label-text` rather than `color` for the same reason the per-tag colour
+ * does: setting `color` here outranked the base rule, so amber -- which replaces every fill
+ * with its own and has no `color` rule of its own -- was left painting `--white` on `--text`,
+ * light orange on orange.
+ */
 .wrolpi-label-white {
-    color: var(--black);
+    --label-text: var(--black);
     border-color: var(--border);
 }
 
 .wrolpi-label-black {
-    color: var(--white);
+    --label-text: var(--white);
     border-color: var(--border);
 }
 
@@ -586,6 +667,21 @@ html[data-theme="night"] .wrolpi-label {
     background: transparent;
     color: var(--label-color);
     border-color: var(--label-color);
+}
+
+/*
+ * Night draws the tag as an outline, so the point has to be two strokes rather than a solid
+ * diamond, and the body's own left border has to go -- otherwise a line closes across the
+ * base of the point and it reads as a chip with a triangle stuck to it.
+ */
+html[data-theme="night"] .wrolpi-tag {
+    border-left-color: transparent;
+}
+
+html[data-theme="night"] .wrolpi-tag::before {
+    background: transparent;
+    border-left: 1px solid var(--label-color);
+    border-bottom: 1px solid var(--label-color);
 }
 
 /* ---------------------------------------------------------------- Headers */
@@ -659,6 +755,17 @@ html[data-theme="night"] .wrolpi-label {
 html[data-theme="night"] .wrolpi-label,
 html[data-theme="amber"] .wrolpi-label {
     --label-color: var(--text) !important;
+    /*
+     * The per-tag text colour goes with the fill it was calculated against.  Tags.js works
+     * out black-or-light from the user's chosen hex, and once that hex is discarded the
+     * answer is not just useless but wrong: amber was painting `#dddddd` on `#ff9500`, about
+     * 1.9:1 and a neutral grey in a theme whose whole point is that nothing else is.  Night,
+     * which is an outline over a near-black page, was painting that black text on nothing.
+     *
+     * There is no contrast to calculate here, which is why this is a token and not a second
+     * version of `contrastingColor`: the fill is the theme's own, so the answer is fixed.
+     */
+    --label-text: var(--btn-text) !important;
 }
 
 /* --------------------------------------------------------------- Messages */

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -599,8 +599,11 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 
 .wrolpi-tag {
     position: relative;
-    /* Room for the point, which is drawn outside the body. */
-    margin-left: 15px;
+    /*
+     * Room for the point, which is drawn outside the body: half its diagonal (14.1px) plus
+     * the 1px it is nudged left, rounded up.
+     */
+    margin-left: 16px;
     /* Tags wrap, and a wrapped row was sitting on the row above it. */
     margin-bottom: 5px;
     /*
@@ -619,7 +622,15 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     right: 100%;
     width: 20px;
     height: 20px;
-    transform: translate(50%, -50%) rotate(45deg);
+    /*
+     * Nudged 1px left of where `right: 100%` puts it.  That property positions against the
+     * containing block's *padding* box, and the body carries a 1px border, so a square centred
+     * there sits a pixel inside the visible left edge -- and the point read as set slightly
+     * into the tag rather than growing out of it.  This is exactly that border: 2px opened a
+     * visible gap on the inner side, because the point's edges then meet the body's left edge
+     * short of its corners and leave the difference showing.
+     */
+    transform: translate(calc(50% - 1px), -50%) rotate(45deg);
     background: var(--label-color);
 }
 

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -573,6 +573,32 @@ describe('Label', () => {
     });
 });
 
+describe('Label as a tag', () => {
+    it('is a plain chip unless asked to be a tag', () => {
+        // The same component carries the count badges in the Tags table -- file, zim, channel
+        // and domain counts -- and a pointed left edge on a number reads as an arrow.
+        const {container} = renderUI(<Label color='blue'>1,432</Label>);
+
+        expect(container.querySelector('.wrolpi-label')).toBeInTheDocument();
+        expect(container.querySelector('.wrolpi-tag')).not.toBeInTheDocument();
+    });
+
+    it('takes the tag shape when asked', () => {
+        const {container} = renderUI(<Label tag color='blue'>Water</Label>);
+
+        expect(container.querySelector('.wrolpi-tag')).toBeInTheDocument();
+    });
+
+    it('leaves the text colour to the stylesheet', () => {
+        // Every label routes its text colour through `--label-text` so that night and amber,
+        // which replace the fill with their own, can replace the text colour with it.  An
+        // inline `color` could not be overridden by either.
+        const {container} = renderUI(<Label tag color='blue'>Water</Label>);
+
+        expect(container.querySelector('.wrolpi-label').style.color).toBe('');
+    });
+});
+
 describe('Table', () => {
     it('renders a Semantic-shaped compound table', () => {
         renderUI(<Table>

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -599,6 +599,65 @@ describe('Label as a tag', () => {
     });
 });
 
+describe('nothing paints a label\'s text with an inline colour', () => {
+    /*
+     * A source guard, because this defect appeared at three separate call sites and fixing the
+     * first one did not fix the others.
+     *
+     * A label's text colour has to travel through `--label-text`.  An inline `color` is a
+     * declaration no stylesheet rule can outrank, so night -- which turns a label into an
+     * outline over a near-black page -- keeps whatever was calculated for the fill it just
+     * discarded.  A bright fill leaves black text on near-black: the tag reads as an empty
+     * outline, and nothing fails.
+     *
+     * The three were the tag chip, the tag edit preview (the very preview of the colour being
+     * chosen), and the Flasher's chip badges.  The stylesheet comment explaining the night and
+     * amber override already named the Flasher, and it was still missed.
+     */
+
+    const sourceFiles = (directory) => fs.readdirSync(directory, {withFileTypes: true})
+        .flatMap(entry => {
+            const full = path.join(directory, entry.name);
+            if (entry.isDirectory()) {
+                return entry.name === 'node_modules' ? [] : sourceFiles(full);
+            }
+            if (!/\.(js|tsx)$/.test(entry.name) || /\.test\.|\.cy\./.test(entry.name)) {
+                return [];
+            }
+            return [[full, fs.readFileSync(full, 'utf8')]];
+        });
+
+    it('sets --label-text instead, everywhere', () => {
+        const src = path.join(__dirname, '..', '..');
+        const offenders = [];
+
+        for (const [file, source] of sourceFiles(src)) {
+            const stripped = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+            let from = 0;
+            while (true) {
+                const at = stripped.indexOf('wrolpi-label', from);
+                if (at === -1) break;
+                from = at + 1;
+
+                // The style object belonging to this element, if it has one nearby.
+                const styleAt = stripped.indexOf('style={{', at);
+                if (styleAt === -1 || styleAt - at > 200) continue;
+                const styleEnd = stripped.indexOf('}}', styleAt);
+                if (styleEnd === -1) continue;
+                const styleObject = stripped.slice(styleAt, styleEnd);
+
+                // A bare `color:` -- not `--label-color`, and not `backgroundColor` and friends,
+                // which are camelCase and so do not match a lowercase `color:`.
+                if (/(?:^|[^-\w])color\s*:/.test(styleObject)) {
+                    offenders.push(`${path.relative(src, file)}: ${styleObject.slice(0, 90)}`);
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+});
+
 describe('Table', () => {
     it('renders a Semantic-shaped compound table', () => {
         renderUI(<Table>


### PR DESCRIPTION
Four asks, three cosmetic and one that turned out to be a real legibility bug.

## They look like tags now

A pointed left edge and an eyelet, like a tag tied to a garment. The point is a square rotated 45° behind the left edge, sized so its diagonal equals the body height and its two edges meet the body exactly at the corners — the same geometry Semantic used (14px protrusion against their 13.2px).

Only where something actually **is** a tag. `Label` also carries the count badges in the Tags table — file, zim, channel, domain counts — and a point on a number reads as an arrow, so the shape sits behind a `tag` prop that `NameToTagLabel` opts into.

## They were smaller than before

You were right: 11.5px text with 3px of vertical padding, against Semantic's 12px and ~7px. Now 12.5px and 5px, which also keeps a tag a reasonable thing to tap.

## Bottom margin

Wrapped rows were sitting on the row above. Tags now carry a bottom margin, plus a left margin for the point to occupy — without it the point prints over whatever is to its left.

## The text colour was unreadable in night and wrong in amber

`Tags.js` calculates black-or-light against the colour the user chose per tag, and wrote the answer to **`color` inline** — a declaration no stylesheet rule can outrank. Measured:

| theme | fill | text | contrast |
|---|---|---|---|
| night | transparent (outline) over `#0a0000` | `#000000`, calculated for a near-white fill | **1.1:1** |
| amber | `#ff9500` | `#dddddd` | **1.9:1** |

In night a near-white tag was legible only by its border. In amber `#dddddd` is also a neutral grey, in the one theme whose whole point is that no other hue reaches the eye.

**There is no second contrast function to write**, which is what this looked like it needed. Once a theme has discarded the user's colour there is nothing left to calculate against — the fill is the theme's own, so the answer is fixed. The fix is to stop hard-coding `color` so the theme can decide: the calculated value goes into `--label-text`, and night and amber override it alongside the fill they already override.

`.wrolpi-label-white` / `-black` moved to the same variable. Setting `color` there outranked the base rule, so amber was painting `--white` on `--text` — light orange on orange.

### `contrastingColor` was picking the worse of its two options

It compared a brightness figure to a threshold of 120, and that figure weighted the **gamma-encoded** bytes without linearising them. So Semantic's blue `#2185d0` got light text at **2.9:1** where dark text gives **5.3:1**. Every mid-tone blue, teal and purple a user might pick sat in that band. It now measures the WCAG contrast ratio of both candidates and returns the better one — no threshold needed. `luma()` is gone; it had no other caller.

## Also, unrelated (second commit, drop it if you'd rather)

**An inactive tab was a near-white block in dark, night and amber.** A tab is a `NavLink` in the app's nav bars but a `<button>` on the Inventory page and in the gallery, and a button carries the UA's `buttonface` background — `rgb(239, 239, 239)`. Only `.wrolpi-tab-active` set a background. Invisible in light; a bright patch in the other three. One line, tested in all four themes.

## Testing

- jest: **1009 passing**, 58 suites. 12 new.
- `ui-layout.cy.js`: **47 passing**, 22 new.
- `npm run build` clean.
- Checked by eye in all four themes.

**`Tags.test.js` is new**, and covers the chip that nothing covered: every other spec takes `NameToTagLabel` from `tagsContextFixture`, which stubs it as a function returning the name. That is precisely how a tag could be unreadable without a single test noticing. Two of its five were verified red against the inline `color`.

**`cy.contrastRatio()`** measures text against the surface *actually* behind it, walking up to the first ancestor that paints something — a transparent tag has no background of its own, so a naive check reads `rgba(0,0,0,0)` and concludes anything is legible. Twelve cases: three tag colours across four themes, at WCAG AA. Plus a teeth test asserting the old inline-`color` version still measures **below 1.5:1**, so the check is provably able to fail.

The gallery had label swatches in theme colours and **no user-coloured tag**, which is why none of this was visible in it. It has eleven now, spanning the range where the black-or-light decision flips.

Pre-existing and unrelated: `Tags.cy.js`, `Channels.cy.js`, `Download.cy.js`, `Inventory.cy.js` fail with the same 11 Semantic-era selector errors as before, confirmed identical at the base commit.