### PR TITLE
ui: toasts — top right, readable titles, the clickable one restored, and 24 tests

### DIFF
--- a/app/cypress/support/component.js
+++ b/app/cypress/support/component.js
@@ -19,12 +19,16 @@ import '../../src/index.css';
 import '../../src/themes/fonts.css';
 import '../../src/themes/tokens.css';
 import '@mantine/core/styles.css';
+// App.js loads this too.  Without it a Notification renders unstyled here, so a toast had no
+// surface and no title colour of Mantine's -- and its contrast test could not fail.
+import '@mantine/notifications/styles.css';
 // react-router v7 ships these directly; `react-router-dom` is not installed.
 import {MemoryRouter, Route, Routes} from "react-router";
 import {QueryProvider} from "../../src/hooks/customHooks";
 import {TagsProvider} from "../../src/Tags";
 import {MantineProvider} from "@mantine/core";
 import {cssVariablesResolver, mantineTheme} from "../../src/themes/mantine";
+import {isDarkTheme} from "../../src/themes/names";
 import {MediaFilterDefs} from "../../src/themes/MediaFilterDefs";
 import React from "react";
 
@@ -75,6 +79,13 @@ Cypress.Commands.add('mountWithRouter', (component, options) => {
  * `theme` stamps data-theme the way ThemeProvider does; `mediaFilter` stamps
  * data-media-filter and mounts the SVG filter definitions, since a filter referenced but
  * never defined silently does nothing.
+ *
+ * `forceColorScheme` matters as much as the token table, and was missing.  Mantine keys its
+ * own rules on data-mantine-color-scheme, which ThemeProvider sets from the theme -- night and
+ * amber ride on dark.  Without it every theme rendered against Mantine's LIGHT scheme here, so
+ * a per-theme test could pass on a page that was broken in the app: the toast title, which
+ * Mantine paints with `--mantine-color-white` in dark scheme only, resolved correctly by
+ * accident and its contrast test could not fail.
  */
 Cypress.Commands.add('mountUI', (component, options = {}) => {
     const {theme = 'light', mediaFilter, ...mountOptions} = options;
@@ -85,7 +96,11 @@ Cypress.Commands.add('mountUI', (component, options = {}) => {
     else delete html.dataset.mediaFilter;
 
     return cy.mount(
-        <MantineProvider theme={mantineTheme} cssVariablesResolver={cssVariablesResolver}>
+        <MantineProvider
+            theme={mantineTheme}
+            cssVariablesResolver={cssVariablesResolver}
+            forceColorScheme={isDarkTheme(theme) ? 'dark' : 'light'}
+        >
             {mediaFilter ? <MediaFilterDefs/> : null}
             {component}
         </MantineProvider>,

--- a/app/src/components/Theme.tsx
+++ b/app/src/components/Theme.tsx
@@ -215,7 +215,12 @@ export function ThemeProvider({children, ...props}: ThemeProviderProps) {
             cssVariablesResolver={cssVariablesResolver}
             forceColorScheme={dark ? 'dark' : 'light'}
         >
-            <Notifications position='bottom-right' limit={5}/>
+            {/*
+              * Top right.  Bottom right put toasts over the sticky footer on the file browser
+              * and over the player controls on a video, which are the two places a background
+              * task is most likely to report while the user is doing something else.
+              */}
+            <Notifications position='top-right' limit={5}/>
             {children}
         </MantineProvider>
     </ThemeContext.Provider>

--- a/app/src/components/ThemeProvider.test.js
+++ b/app/src/components/ThemeProvider.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import React, {useContext} from 'react';
-import {act, render, screen} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ThemeContext} from '../contexts/contexts';
 import {
@@ -16,6 +16,7 @@ import {
     themeSessionKey,
 } from './Theme';
 import {mediaFilterSessionKey, resolveMediaFilter, themeMediaFilter} from '../themes/names';
+import {clearToasts, toast} from './ui';
 
 // Lets a test drive `prefers-color-scheme` and assert on what the provider applied.
 let prefersDark = false;
@@ -300,5 +301,71 @@ describe('theme helpers', () => {
         expect(isDarkTheme(darkTheme)).toBe(true);
         expect(isDarkTheme(nightTheme)).toBe(true);
         expect(isDarkTheme(amberTheme)).toBe(true);
+    });
+});
+
+describe('the toast container ThemeProvider mounts', () => {
+    /*
+     * Observing the wiring rather than re-stating it.
+     *
+     * `toast.test.js` and `ui-layout.cy.js` each mount their own `<Notifications>` with the
+     * position and limit they expect, so neither would notice if this file moved the container
+     * back, changed its limit, or dropped it altogether -- and a missing container while
+     * thirteen call sites keep firing is the failure that has already shipped once.  Those
+     * suites test `toast()`; this tests that the app has somewhere to put what it produces.
+     */
+
+    beforeEach(() => {
+        prefersDark = false;
+        localStorage.clear();
+        mockMatchMedia();
+    });
+
+    afterEach(() => act(() => clearToasts()));
+
+    const notifications = () =>
+        document.querySelectorAll('[class*="mantine-Notification-root"]');
+
+    it('shows a toast raised by a call site', async () => {
+        // The regression that already shipped: no container, thirteen call sites still firing,
+        // nothing thrown and nothing shown.
+        renderProvider();
+
+        act(() => toast({title: 'Refresh started'}));
+
+        expect(await screen.findByText('Refresh started')).toBeInTheDocument();
+    });
+
+    it('puts it in the top right', async () => {
+        /*
+         * Asserted through a real toast rather than by finding a container.  Mantine renders an
+         * empty container for every position it supports, so querying for one returns whichever
+         * comes first in the DOM -- `top-center` -- whatever the provider was configured with.
+         */
+        renderProvider();
+
+        act(() => toast({title: 'Somewhere'}));
+        const notification = await screen.findByText('Somewhere');
+
+        expect(notification.closest('[class*="mantine-Notifications-root"]'))
+            .toHaveAttribute('data-position', 'top-right');
+    });
+
+    it('shows five at once and queues the rest', async () => {
+        /*
+         * The user-visible behaviour, not the prop: Mantine's own default limit is also 5, so
+         * this stays green if `limit={5}` is deleted from the provider.  It is here to catch a
+         * limit being *raised* -- a background task that reports twenty times should not bury
+         * the page -- rather than to prove the prop is present.
+         */
+        renderProvider();
+
+        act(() => {
+            for (let i = 1; i <= 7; i += 1) {
+                toast({title: `Toast ${i}`});
+            }
+        });
+
+        await waitFor(() => expect(notifications()).toHaveLength(5));
     });
 });

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -33,6 +33,7 @@ import {
     ThemePicker,
     Toggle,
     Tooltip,
+    clearToasts,
     toast,
 } from './ui';
 import {semanticColorNames} from '../themes/mantine';
@@ -60,6 +61,10 @@ const Section = ({label, children}) => <section style={{marginBottom: 34}}>
 const Row = ({children}) => <div style={{display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center'}}>
     {children}
 </div>;
+
+// Numbers the stacked toasts so it is obvious which press produced which, and that a second
+// press adds a toast rather than replacing the first.  Module scope, so it survives re-renders.
+let toastCounter = 0;
 
 export function ThemeSamplePage() {
     const {theme} = useContext(ThemeContext);
@@ -208,6 +213,77 @@ export function ThemeSamplePage() {
                 <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
                     In night mode Delete drops its fill for a dashed red outline; dashed means
                     destructive or failed, and nothing else uses it.
+                </p>
+            </Panel>
+        </Section>
+
+        <Section label='Toasts'>
+            <Panel>
+                {/*
+                  * `toast` has thirteen call sites and no test, and it has already failed once
+                  * app-wide: App.js dropped Semantic's toast container while seven pages were
+                  * still importing the old helper, and every notification silently vanished.
+                  * A toast is also the one component you cannot see by loading a page -- it has
+                  * to be provoked -- which is why it needs buttons here rather than a sample.
+                  */}
+                <Row>
+                    <Button role='primary' onClick={() => toast({
+                        type: 'info', title: 'Refresh started',
+                        description: 'Indexing the media directory.',
+                    })}>Info</Button>
+                    <Button role='save' onClick={() => toast({
+                        type: 'success', title: 'Saved',
+                        description: 'Channel settings written to config/channels.yaml.',
+                    })}>Success</Button>
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'warning', title: 'Daily download limit reached',
+                        description: 'Downloads will resume tomorrow at 00:00.',
+                    })}>Warning</Button>
+                    <Button role='danger' onClick={() => toast({
+                        type: 'error', title: 'Download failed',
+                        description: 'HTTP 403 from the remote server after 3 attempts.',
+                    })}>Error</Button>
+                </Row>
+
+                <Row>
+                    {/* Click this repeatedly: each press is a separate toast, and the
+                        container holds five at once. */}
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'info', title: `Stacked toast ${++toastCounter}`,
+                        description: 'Press again before this one expires.',
+                    })}>Stack one more</Button>
+                    <Button role='cancel' onClick={() => {
+                        // All five at once, to see the container at its limit.
+                        for (let i = 1; i <= 5; i += 1) {
+                            toast({
+                                type: 'info', title: `Toast ${i} of 5`,
+                                description: 'Filling the container to its limit.',
+                            });
+                        }
+                    }}>Fill the stack</Button>
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'error', title: 'This one stays',
+                        description: 'time: 0 means it waits to be dismissed. Close it yourself.',
+                        time: 0,
+                    })}>Never expires</Button>
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'warning',
+                        description: 'No title, only a description — some call sites send just this.',
+                    })}>No title</Button>
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'error', title: 'A long one, to see how it wraps',
+                        description: 'Failed to fetch https://example.com/a/very/long/path/that/'
+                            + 'keeps/going/for/a/while.html: the remote server closed the '
+                            + 'connection after sending part of the response body.',
+                    })}>Long text</Button>
+                    <Button role='danger' onClick={() => clearToasts()}>Clear all</Button>
+                </Row>
+
+                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                    Bottom right, five at a time, five seconds each unless the caller says
+                    otherwise. Check each type in all four themes: night has no second hue to
+                    spend, so info, success, warning and error cannot be told apart by colour
+                    there.
                 </p>
             </Panel>
         </Section>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -276,6 +276,14 @@ export function ThemeSamplePage() {
                             + 'keeps/going/for/a/while.html: the remote server closed the '
                             + 'connection after sending part of the response body.',
                     })}>Long text</Button>
+                    {/* Events.js sends three of these, each opening a URL.  Click the toast
+                        body, or Tab to it and press Enter; the dismiss button does not follow. */}
+                    <Button role='cancel' onClick={() => toast({
+                        type: 'info', title: 'Screenshot Generated',
+                        description: 'Click here to view it.',
+                        time: 10000,
+                        onClick: () => toast({type: 'success', title: 'Followed the toast'}),
+                    })}>Clickable</Button>
                     <Button role='danger' onClick={() => clearToasts()}>Clear all</Button>
                 </Row>
 

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -288,7 +288,7 @@ export function ThemeSamplePage() {
                 </Row>
 
                 <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
-                    Bottom right, five at a time, five seconds each unless the caller says
+                    Top right, five at a time, five seconds each unless the caller says
                     otherwise. Check each type in all four themes: night has no second hue to
                     spend, so info, success, warning and error cannot be told apart by colour
                     there.

--- a/app/src/components/ui/toast.test.js
+++ b/app/src/components/ui/toast.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MantineProvider} from '@mantine/core';
 import {Notifications} from '@mantine/notifications';
 import {cssVariablesResolver, mantineTheme} from '../../themes/mantine';
+import {notificationsStore} from '@mantine/notifications';
 import {clearToasts, toast} from './toast';
 
 /*
@@ -111,9 +112,10 @@ describe('toast', () => {
         showToast({type: 'error', title: 'Download failed'});
 
         await waitFor(() => expect(visibleToasts()).toHaveLength(1));
-        // Mantine writes the resolved colour onto the element as a custom property.
-        const notification = visibleToasts()[0];
-        expect(notification.getAttribute('style')).toContain('red');
+        // The whole custom property, not a substring: `toContain('red')` would also be
+        // satisfied by any other declaration that happens to carry those three letters.
+        expect(visibleToasts()[0].getAttribute('style'))
+            .toMatch(/--notification-color:\s*var\(--mantine-color-red-/);
     });
 
     it('gives each type a colour of its own', async () => {
@@ -142,7 +144,8 @@ describe('toast', () => {
         showToast({title: 'Refresh started'});
 
         await waitFor(() => expect(visibleToasts()).toHaveLength(1));
-        expect(visibleToasts()[0].getAttribute('style')).toContain('blue');
+        expect(visibleToasts()[0].getAttribute('style'))
+            .toMatch(/--notification-color:\s*var\(--mantine-color-blue-/);
     });
 
     it('survives being called with nothing at all', () => {
@@ -203,6 +206,20 @@ describe('a toast that can be clicked', () => {
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 
+    it('can also be activated with Space', async () => {
+        // `toast.ts` handles Enter and Space; only Enter was covered, so dropping the Space
+        // branch -- or switching to `event.code` -- would have stayed green.
+        const onClick = jest.fn();
+        withToasts();
+
+        showToast({title: 'Screenshot Generated', onClick});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        visibleToasts()[0].focus();
+        await userEvent.keyboard(' ');
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
     it('looks clickable only when it is', async () => {
         withToasts();
 
@@ -244,15 +261,38 @@ describe('how long a toast stays up', () => {
         await waitFor(() => expect(screen.queryByText('Saved')).not.toBeInTheDocument());
     });
 
-    it('is still up a moment after being shown, when no time is given', async () => {
-        // The default is five seconds, which is not worth waiting for; what is worth asserting
-        // is that a caller who names no time does not get a toast that vanishes instantly.
+    /*
+     * The dismissal deadline `toast()` hands Mantine, read back off its store.
+     *
+     * Waiting is no good for this.  Sleeping 150ms and finding the toast still there catches
+     * "vanishes on the next tick" and nothing else -- it passes just as happily for a 200ms
+     * default, a 1000ms one, `false`, or Mantine's own container default of 4000ms.  Waiting
+     * the full five seconds instead would put five seconds into every run.  The store holds
+     * exactly what was passed, which is the thing worth asserting.
+     */
+    const autoCloseOf = (options) => {
+        showToast(options);
+        const [notification] = notificationsStore.getState().notifications;
+        return notification.autoClose;
+    };
+
+    it('gives a toast five seconds when the caller names no time', () => {
         withToasts();
-        showToast({title: 'Refresh started'});
 
-        await new Promise(resolve => setTimeout(resolve, 150));
+        expect(autoCloseOf({title: 'Refresh started'})).toBe(5000);
+    });
 
-        expect(screen.getByText('Refresh started')).toBeInTheDocument();
+    it('passes a time the caller chose straight through', () => {
+        withToasts();
+
+        expect(autoCloseOf({title: 'Brief', time: 250})).toBe(250);
+    });
+
+    it('turns time 0 into no deadline at all', () => {
+        // Not 0.  Mantine reads a number as a delay, so a literal 0 dismisses on the next tick.
+        withToasts();
+
+        expect(autoCloseOf({title: 'Download failed', time: 0})).toBe(false);
     });
 
     it('stays until dismissed when the caller asks for time 0', async () => {

--- a/app/src/components/ui/toast.test.js
+++ b/app/src/components/ui/toast.test.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import {MantineProvider} from '@mantine/core';
+import {Notifications} from '@mantine/notifications';
+import {cssVariablesResolver, mantineTheme} from '../../themes/mantine';
+import {clearToasts, toast} from './toast';
+
+/*
+ * Tests for toasts.
+ *
+ * `toast` has thirteen call sites and had no test at all, having already failed once in the
+ * way that is hardest to notice: App.js dropped Semantic's toast container while seven pages
+ * were still importing the old helper, so every notification in the app silently went
+ * nowhere.  Nothing threw, and nothing looked wrong until somebody expected a message.
+ *
+ * The container is mounted here the way ThemeProvider mounts it, because a toast with no
+ * container is exactly the failure worth covering.
+ */
+
+const withToasts = () => render(
+    <MantineProvider theme={mantineTheme} cssVariablesResolver={cssVariablesResolver}>
+        <Notifications position='top-right' limit={5}/>
+    </MantineProvider>
+);
+
+const showToast = (options) => act(() => {
+    toast(options);
+});
+
+const visibleToasts = () =>
+    document.querySelectorAll('[class*="mantine-Notification-root"]');
+
+afterEach(() => {
+    act(() => clearToasts());
+});
+
+describe('toast', () => {
+    it('shows a title and its description', async () => {
+        withToasts();
+
+        showToast({type: 'success', title: 'Saved', description: 'Channel settings written.'});
+
+        expect(await screen.findByText('Saved')).toBeInTheDocument();
+        expect(screen.getByText('Channel settings written.')).toBeInTheDocument();
+    });
+
+    it('shows a description on its own', async () => {
+        // Several call sites send no title.
+        withToasts();
+
+        showToast({description: 'Nothing to download.'});
+
+        expect(await screen.findByText('Nothing to download.')).toBeInTheDocument();
+    });
+
+    it('stacks, rather than replacing what is already up', async () => {
+        /*
+         * The behaviour that matters when a background task reports repeatedly -- three
+         * downloads finishing should be three messages, not one that keeps being overwritten.
+         * Mantine replaces a notification when it is given an `id` it has already seen, so
+         * this would break the moment somebody added one to dedupe.
+         */
+        withToasts();
+
+        showToast({title: 'First'});
+        showToast({title: 'Second'});
+        showToast({title: 'Third'});
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(3));
+        expect(screen.getByText('First')).toBeInTheDocument();
+        expect(screen.getByText('Third')).toBeInTheDocument();
+    });
+
+    it('stacks two identical toasts as two', async () => {
+        // Same title and description twice over: still two messages.
+        withToasts();
+
+        showToast({title: 'Download failed', description: 'HTTP 403'});
+        showToast({title: 'Download failed', description: 'HTTP 403'});
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(2));
+    });
+
+    it('holds no more than the container allows', async () => {
+        // Five at once, so the sixth waits rather than the stack growing without limit.
+        withToasts();
+
+        for (let i = 1; i <= 7; i += 1) {
+            showToast({title: `Toast ${i}`});
+        }
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(5));
+    });
+
+    it('clears everything on request', async () => {
+        // Used when navigating away from a failed action, so its errors do not follow you.
+        withToasts();
+        showToast({title: 'One'});
+        showToast({title: 'Two'});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(2));
+
+        act(() => clearToasts());
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(0));
+    });
+
+    it('carries the colour its type maps to', async () => {
+        withToasts();
+
+        showToast({type: 'error', title: 'Download failed'});
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        // Mantine writes the resolved colour onto the element as a custom property.
+        const notification = visibleToasts()[0];
+        expect(notification.getAttribute('style')).toContain('red');
+    });
+
+    it('gives each type a colour of its own', async () => {
+        /*
+         * Four types that must not collapse into one in light and dark.  Night and amber are
+         * the deliberate exception -- they have no second hue to spend -- but that is decided
+         * by the token tables, not here, and here they have to differ.
+         */
+        withToasts();
+
+        const colours = new Set();
+        for (const type of ['info', 'success', 'warning', 'error']) {
+            showToast({type, title: `A ${type}`});
+        }
+        await waitFor(() => expect(visibleToasts()).toHaveLength(4));
+        for (const notification of visibleToasts()) {
+            colours.add((notification.getAttribute('style') || '').match(/--notification-color:[^;]*/)?.[0]);
+        }
+
+        expect(colours.size).toBe(4);
+    });
+
+    it('defaults to info when given no type', async () => {
+        withToasts();
+
+        showToast({title: 'Refresh started'});
+
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        expect(visibleToasts()[0].getAttribute('style')).toContain('blue');
+    });
+
+    it('survives being called with nothing at all', () => {
+        // Defensive: a call site building options from an API response can end up with none.
+        withToasts();
+
+        expect(() => showToast()).not.toThrow();
+    });
+});
+
+describe('how long a toast stays up', () => {
+    /*
+     * Real timers, with short durations chosen by the caller.
+     *
+     * Fake timers do not work here.  Hiding a notification runs an exit transition -- a timer
+     * plus a state update plus a transition end -- and advancing the clock, even awaited inside
+     * `act`, never gets the element removed from the DOM.  Both the assertion and its control
+     * then read the same whatever the code does, which is a test that cannot fail.  It read
+     * green against a deliberately planted `autoClose: 0` before this was rewritten.
+     */
+
+    it('goes away on its own', async () => {
+        withToasts();
+        showToast({title: 'Saved', time: 60});
+
+        await waitFor(() => expect(screen.queryByText('Saved')).not.toBeInTheDocument());
+    });
+
+    it('is still up a moment after being shown, when no time is given', async () => {
+        // The default is five seconds, which is not worth waiting for; what is worth asserting
+        // is that a caller who names no time does not get a toast that vanishes instantly.
+        withToasts();
+        showToast({title: 'Refresh started'});
+
+        await new Promise(resolve => setTimeout(resolve, 150));
+
+        expect(screen.getByText('Refresh started')).toBeInTheDocument();
+    });
+
+    it('stays until dismissed when the caller asks for time 0', async () => {
+        /*
+         * Semantic treated `time: 0` as "stay up".  Mantine wants `autoClose: false`: its
+         * `getAutoClose` returns any number as given, and the container then calls
+         * `setTimeout(hide, 0)` -- so passing the 0 straight through dismisses the toast on the
+         * next tick.  Call sites use 0 for errors the user must actually see, so getting this
+         * backwards would throw away precisely the messages that matter most.
+         *
+         * A toast that expires normally goes up alongside it as a control.  Waiting for that one
+         * to disappear proves dismissal is working, which is what makes the survivor a fact
+         * about `time: 0` rather than about how long the test happened to wait.
+         */
+        withToasts();
+        showToast({title: 'Expires normally', time: 60});
+        showToast({title: 'Download failed', time: 0});
+
+        await waitFor(() => expect(screen.queryByText('Expires normally')).not.toBeInTheDocument());
+
+        expect(screen.getByText('Download failed')).toBeInTheDocument();
+    });
+});

--- a/app/src/components/ui/toast.test.js
+++ b/app/src/components/ui/toast.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {MantineProvider} from '@mantine/core';
 import {Notifications} from '@mantine/notifications';
 import {cssVariablesResolver, mantineTheme} from '../../themes/mantine';
@@ -149,6 +150,79 @@ describe('toast', () => {
         withToasts();
 
         expect(() => showToast()).not.toThrow();
+    });
+});
+
+describe('a toast that can be clicked', () => {
+    /*
+     * Semantic's toast took an `onClick` in its options and made the whole toast activate it.
+     * `Events.js` still passes one -- it did before the migration and was never changed -- for
+     * three events that each open a URL: a shared page pushed from the browser extension, a
+     * finished archive upload, and a generated screenshot.  The migrated helper destructured
+     * four keys and dropped the rest, so all three became dead toasts.  The first of them
+     * renders the description "Click here to view the shared page", which it was not.
+     */
+
+    it('runs the handler when the toast is clicked', async () => {
+        const onClick = jest.fn();
+        withToasts();
+
+        showToast({title: 'Archive Uploaded', description: 'example.com', onClick});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        await userEvent.click(screen.getByText('Archive Uploaded'));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not run the handler when the toast is dismissed', async () => {
+        // The close button sits inside the toast, so its click reaches the root too.  Dismissing
+        // a notification is not the same as following it, and for these three that difference is
+        // a page navigation the user did not ask for.
+        const onClick = jest.fn();
+        withToasts();
+
+        showToast({title: 'Archive Uploaded', onClick});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        await userEvent.click(screen.getByRole('button', {name: 'Dismiss notification'}));
+
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('can be reached and activated from the keyboard', async () => {
+        // WROLPi runs on devices with a keyboard and no mouse.  A toast that only a pointer can
+        // follow is a feature half the deployments cannot use.
+        const onClick = jest.fn();
+        withToasts();
+
+        showToast({title: 'Screenshot Generated', onClick});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+        visibleToasts()[0].focus();
+        expect(visibleToasts()[0]).toHaveFocus();
+        await userEvent.keyboard('{Enter}');
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('looks clickable only when it is', async () => {
+        withToasts();
+
+        showToast({title: 'Plain'});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+
+        const plain = visibleToasts()[0];
+        expect(plain.style.cursor).not.toBe('pointer');
+        expect(plain).not.toHaveAttribute('tabindex');
+    });
+
+    it('marks a clickable toast as clickable', async () => {
+        const onClick = jest.fn();
+        withToasts();
+
+        showToast({title: 'Follow me', onClick});
+        await waitFor(() => expect(visibleToasts()).toHaveLength(1));
+
+        expect(visibleToasts()[0].style.cursor).toBe('pointer');
+        expect(visibleToasts()[0]).toHaveAttribute('tabindex', '0');
     });
 });
 

--- a/app/src/components/ui/toast.ts
+++ b/app/src/components/ui/toast.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {notifications} from '@mantine/notifications';
 
 /*
@@ -16,6 +17,12 @@ export interface ToastOptions {
     description?: string;
     /** Milliseconds before auto-dismiss.  0 keeps it until dismissed. */
     time?: number;
+    /**
+     * Makes the whole toast activate this — Semantic's behaviour, which `Events.js` still
+     * relies on for the three events that carry a URL: a page shared from the browser
+     * extension, a finished archive upload, and a generated screenshot.
+     */
+    onClick?: () => void;
 }
 
 const toastColors: Record<ToastType, string> = {
@@ -25,14 +32,47 @@ const toastColors: Record<ToastType, string> = {
     error: 'red',
 };
 
-export function toast({type = 'info', title, description, time = 5000}: ToastOptions = {}) {
+/**
+ * The props that make a toast followable.
+ *
+ * `tabIndex` and the key handler are not decoration: WROLPi runs on devices with a keyboard
+ * and no mouse, and a toast only a pointer can follow is a feature half the deployments
+ * cannot use.  There is deliberately no `role` — a `button` or `link` role may not contain
+ * interactive content, and the dismiss button lives inside.
+ */
+const followable = (onClick: () => void) => ({
+    style: {cursor: 'pointer'},
+    tabIndex: 0,
+    onClick: (event: React.MouseEvent) => {
+        // The dismiss button is inside the toast, so its click reaches here too.  Closing a
+        // notification is not following it, and for these three that would be a navigation
+        // the user did not ask for.
+        if ((event.target as HTMLElement).closest('button')) {
+            return;
+        }
+        onClick();
+    },
+    onKeyDown: (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+        }
+    },
+});
+
+export function toast({type = 'info', title, description, time = 5000, onClick}: ToastOptions = {}) {
     notifications.show({
         title,
         message: description,
         color: toastColors[type],
-        // Semantic treated 0 as "stay up"; Mantine wants false for that.
+        // Semantic treated 0 as "stay up"; Mantine wants false for that.  Its `getAutoClose`
+        // returns any number as given and the container then calls `setTimeout(hide, 0)`, so
+        // passing the 0 through dismisses the toast on the next tick.
         autoClose: time === 0 ? false : time,
         withBorder: true,
+        // Mantine leaves its close button unnamed, which a screen reader reads as "button".
+        closeButtonProps: {'aria-label': 'Dismiss notification'},
+        ...(onClick ? followable(onClick) : {}),
     });
 }
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -3,7 +3,16 @@ import {
     ActionInput, Button, Header, PathInput, Statistic, StatisticGroup, TabBar, tabClassName, TextInput,
 } from './index';
 import {contrastingColor} from '../Common';
+import {Notifications} from '@mantine/notifications';
+import {toast} from './toast';
 import {themeNames} from '../../themes/names';
+
+/* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
+const hexToRgb = (hex) => {
+    const value = hex.replace('#', '');
+    const [r, g, b] = [0, 2, 4].map(i => parseInt(value.slice(i, i + 2), 16));
+    return `rgb(${r}, ${g}, ${b})`;
+};
 
 /*
  * Layout and theming assertions for the component library, run in a real browser.
@@ -539,6 +548,73 @@ describe('tabs', () => {
             cy.contains('button', 'Channels').should(($tab) =>
                 expect(getComputedStyle($tab[0]).backgroundColor, 'inactive tab is transparent')
                     .to.equal('rgba(0, 0, 0, 0)'));
+        });
+    });
+});
+
+describe('a toast is readable in every theme', () => {
+    /*
+     * Mantine paints a dark-scheme notification title with `--mantine-color-white`, and the
+     * bridge aliases that to `--btn-text` -- the text drawn on a filled button, which is
+     * near-black in dark, night and amber.  The title measured about 1.1:1 against the toast's
+     * own surface: present, and invisible.
+     *
+     * Only a browser can catch that.  jsdom resolves no `var()`, so the title's colour there is
+     * the literal string `var(--mantine-color-white)` and every contrast check passes.
+     */
+
+    /*
+     * Mounts once, with the theme, and raises a toast.  Mounting a second time to raise it --
+     * which is how this was first written -- resets the theme to the default, so all four
+     * per-theme cases silently ran in light and none of them could fail.
+     */
+    const showToast = (theme) => {
+        cy.mountUI(<>
+            <Notifications position='top-right' limit={5}/>
+            <button type='button' onClick={() => toast({
+                type: 'error', title: 'Download failed',
+                description: 'HTTP 403 from the remote server after 3 attempts.',
+            })}>Raise one</button>
+        </>, {theme});
+        cy.contains('button', 'Raise one').click();
+        cy.get('[class*="mantine-Notification-root"]').should('exist');
+    };
+
+    themeNames.forEach((theme) => {
+        it(`reads its title and message in ${theme}`, () => {
+            showToast(theme);
+
+            // WCAG AA for both.  The description is the message itself, so it is held to the
+            // same bar as the title rather than treated as decoration.
+            cy.contrastRatio('[class*="mantine-Notification-title"]').should('be.at.least', 4.5);
+            cy.contrastRatio('[class*="mantine-Notification-description"]').should('be.at.least', 4.5);
+        });
+    });
+
+    it('keeps the title more prominent than the message', () => {
+        /*
+         * Night and amber drop the description's muting, because `--muted` on a panel is 2.0:1
+         * in night.  Weight has to carry the hierarchy once colour cannot.
+         */
+        showToast('night');
+
+        cy.get('[class*="mantine-Notification-title"]').then(($title) => {
+            cy.get('[class*="mantine-Notification-description"]').should(($description) => {
+                const weight = (el) => parseInt(getComputedStyle(el).fontWeight, 10);
+                expect(weight($title[0]), 'title weight')
+                    .to.be.greaterThan(weight($description[0]));
+            });
+        });
+    });
+
+    it('takes its surface from the theme, not from Mantine', () => {
+        // A toast is a panel.  Left to Mantine it would be `--mantine-color-body`, which is not
+        // one of our tokens and does not follow night or amber.
+        showToast('night');
+
+        cy.get('[class*="mantine-Notification-root"]').should(($toast) => {
+            const panel = getComputedStyle(document.documentElement).getPropertyValue('--panel').trim();
+            expect(getComputedStyle($toast[0]).backgroundColor).to.equal(hexToRgb(panel));
         });
     });
 });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -779,6 +779,54 @@ html[data-theme="amber"] .wrolpi-label {
     --label-text: var(--btn-text) !important;
 }
 
+/* ----------------------------------------------------------------- Toasts */
+/*
+ * Notifications take their colours from our tokens rather than from Mantine's colour scheme.
+ *
+ * Mantine paints a dark-scheme notification title with `--mantine-color-white`, and the
+ * bridge aliases that to `--btn-text` -- deliberately, because it is the text drawn on a
+ * filled button, which is near-black in dark, night and amber.  So the title came out at
+ * rgb(28, 31, 33) on a rgb(38, 41, 43) surface: about 1.1:1, present and invisible.  Fixing
+ * the alias is not an option; it is correct for the buttons it exists for.
+ *
+ * The `html` prefix is only there to outrank Mantine's single-class rules.  One set of values
+ * covers every theme, because the tokens are what differ.
+ */
+
+html .mantine-Notification-root {
+    background-color: var(--panel);
+    border-color: var(--border);
+}
+
+html .mantine-Notification-title {
+    color: var(--text);
+}
+
+html .mantine-Notification-description {
+    color: var(--muted);
+}
+
+/*
+ * The description is the message itself, so it has to be read, and `--muted` is too dim to
+ * read on a panel in the two monochrome themes -- 2.0:1 in night, 3.1:1 in amber, against
+ * 5.1:1 and 5.7:1 in dark and light.  Those two drop the muting and let the title's weight
+ * carry the hierarchy instead, which is the same brightness-over-hue trade the rest of night
+ * makes.
+ */
+html[data-theme="night"] .mantine-Notification-description,
+html[data-theme="amber"] .mantine-Notification-description {
+    color: var(--text);
+}
+
+html .mantine-Notification-closeButton {
+    color: var(--muted);
+}
+
+html .mantine-Notification-closeButton:hover {
+    background-color: var(--head);
+    color: var(--text);
+}
+
 /* --------------------------------------------------------------- Messages */
 
 .wrolpi-message {


### PR DESCRIPTION
`toast` had thirteen call sites and no test. It has already failed once app-wide — `App.js` dropped Semantic's container while seven pages still imported the old helper, and every notification silently went nowhere.

## Title was unreadable in dark, night and amber

Mantine's dark-scheme notification title is `color: var(--mantine-color-white)`, and the bridge aliases that to `--btn-text` — deliberately, because it is the text drawn on a filled button, which is near-black in those three themes. Measured: **`rgb(28,31,33)` on `rgb(38,41,43)`, about 1.1:1.** Present and invisible.

Fixing the alias isn't an option; it's correct for the buttons it exists for. So notifications take their surface, border and text from our tokens instead. After: **14.9 / 11.9 / 5.0 / 8.6** to one.

I also caught a regression I introduced doing it: I set the description to `--muted`, which is **2.0:1 in night** and 3.1 in amber. The description is the message, so night and amber drop the muting and let the title's weight (500 vs 400) carry the hierarchy.

Mantine writes its rule through `:where(...)`, which has zero specificity, so an `html`-prefixed single-class override outranks it.

## Moved to the top right

Bottom right put toasts over the file browser's sticky footer and a video's player controls — the two places a background task is most likely to report while the user is doing something else.

**One thing for review:** at scroll-top the first toast overlaps the nav bar. The nav is `position: static`, so it scrolls away and the overlap only exists at the top of a page. Left as-is rather than guessing at an offset — say if you want the container pushed clear of the header.

## The clickable toast was dropped by the migration

Semantic's `toast` took an `onClick` in its options and made the whole toast activate it. The migrated helper destructured four keys and dropped the rest, silently. `Events.js` still passes one — it did before the migration and was never changed — for the three events that arrive with a URL:

| event | what it announced |
|---|---|
| `user_notify_message` | a page shared from the browser extension |
| `upload_archive` | a finished archive upload |
| `screenshot_generated` | a generated screenshot |

The first renders the description **"Click here to view the shared page"**, which it was not. All three used to `window.open(url, '_self')`.

`onClick` is passed through again, with a pointer cursor. Two additions beyond parity:

- **Dismissing does not follow it.** The close button is inside the toast, so its click reaches the root; without a guard, closing an upload toast would navigate you away.
- **It is reachable from the keyboard**, which it never was even under Semantic. WROLPi runs on devices with a keyboard and no mouse. No ARIA `role` — `button` and `link` may not contain interactive content, and the dismiss button is in there.

Mantine also leaves that dismiss button unnamed, so a screen reader read it as "button". It has a label now, which is how the dismiss-doesn't-follow test finds it.

## Gallery

A Toasts section: one button per type, one that stacks a numbered toast per press, one that fills the container to its limit of five, one that never expires, one with no title, one long enough to wrap, one clickable, and clear-all. A toast is the one component that cannot be seen by loading a page.

## Testing

- jest: **1032 passing**, 59 suites. 18 new in `toast.test.js`.
- `ui-layout.cy.js`: **54 passing**, 6 new.
- `npm run build` clean. Checked by eye in all four themes, and the clickable toast verified in a real browser rather than against a spy.

**Eleven of the new tests were verified red against planted defects** — a shared `id` (which makes Mantine replace instead of stack), one colour for every type, `autoClose` taking the 0 literally, and the notification overrides removed.

### Four test-authoring corrections, all mine

Worth reading, because three of them are the kind that leave a green suite over a broken page:

1. **`cy.mountUI` never set `forceColorScheme`**, so every theme rendered against Mantine's *light* scheme. Any per-theme browser test could pass on a page that was broken in the app. This is the same harness the tag-contrast tests use.
2. **The support file never imported `@mantine/notifications/styles.css`**, which `App.js` does — so a Notification rendered unstyled and had no Mantine colour to be wrong about.
3. **The spec's own helper mounted twice**, and the second mount reset the theme to the default. All four per-theme cases ran in light.
4. **The `time: 0` test passed against a planted `autoClose: 0` twice.** Fake timers never complete the exit transition, so the element stays in the DOM regardless — first a synchronous assertion, then a control that could not fail either. It now uses real timers and waits for a normally-expiring toast to disappear first, so dismissal is demonstrably working before the survivor is asserted.

Mantine does treat a literal `0` as "close immediately" (`getAutoClose` returns the number, then `setTimeout(hide, 0)`), so that guard in `toast.ts` is load-bearing.

Pre-existing and unrelated: `Tags.cy.js`, `Channels.cy.js`, `Download.cy.js`, `Inventory.cy.js` fail with the same 11 Semantic-era selector errors, unchanged by this branch.

## Follow-up

In night and amber all four toast types are the same colour — deliberate per the token tables, but it means an error toast reads like an info toast. Belongs with the semantic-role-token pass (`--good`/`--warning`/`--bad`), along with the `--orange` problem.

`--muted` measuring 2.0:1 on a panel in night is not only a toast issue: statistic labels and inactive tabs use it too. Left alone here.