### PR TITLE
ui: route genuine success and failure through the roles

### DIFF
--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1224,15 +1224,24 @@ export function FileIcon({file, disabled = true, size = 48, ...props}) {
     />
 }
 
-export function LoadStatistic({label, value, cores, ...props}) {
-    // Load is a warning above half the cores, and a problem above three quarters.
+/**
+ * The severity of a load average: a warning above half the cores, a problem above three
+ * quarters, and nothing to say below that or when the core count is unknown.
+ *
+ * Exported and pure so the branches can be tested as branches.  Reading the colour back off
+ * a rendered Statistic cannot do it -- jsdom rejects `color: var(--danger)` as an invalid
+ * declaration and drops it, so every value comes back as the empty string.
+ */
+export const loadRole = (value, cores) => {
+    if (!cores) return undefined;
     const quarter = cores / 4;
-    let color;
-    if (cores && value >= (quarter * 3)) {
-        color = 'danger';
-    } else if (cores && value >= (quarter * 2)) {
-        color = 'warning';
-    }
+    if (value >= quarter * 3) return 'danger';
+    if (value >= quarter * 2) return 'warning';
+    return undefined;
+};
+
+export function LoadStatistic({label, value, cores, ...props}) {
+    const color = loadRole(value, cores);
     return <Statistic
         label={label}
         value={value ? parseFloat(value).toFixed(1) : '?'}

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1229,9 +1229,9 @@ export function LoadStatistic({label, value, cores, ...props}) {
     const quarter = cores / 4;
     let color;
     if (cores && value >= (quarter * 3)) {
-        color = 'red';
+        color = 'danger';
     } else if (cores && value >= (quarter * 2)) {
-        color = 'orange';
+        color = 'warning';
     }
     return <Statistic
         label={label}
@@ -1785,7 +1785,9 @@ export function useAPIButton(
     // The result is shown as the icon rather than an animation: the outcome should be
     // legible at a glance, and in night mode a moving element is the last thing wanted.
     const outcomeIcon = showSuccess ? 'check' : showFailure ? 'close' : null;
-    const outcomeColor = showSuccess ? 'green' : showFailure ? 'red' : undefined;
+    // Roles are registered as Mantine colors, so these reach `color` the same way a hue
+    // would.  This is the plainest success/failure in the app: the call worked, or it did not.
+    const outcomeColor = showSuccess ? 'success' : showFailure ? 'danger' : undefined;
     if (outcomeColor) {
         buttonArgs['color'] = outcomeColor;
     }

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import React from 'react';
 import {act, render, screen, waitFor} from '../test-utils';
 import userEvent from '@testing-library/user-event';
@@ -558,5 +560,48 @@ describe('contrastingColor with shorthand hex', () => {
                                      ['#f00', '#ff0000'], ['#1b2', '#11bb22']]) {
             expect(contrastingColor(short)).toBe(contrastingColor(long));
         }
+    });
+});
+
+describe('LoadStatistic ranks load by role, not by hue', () => {
+    /*
+     * A source guard, not a render test, and deliberately so: jsdom's CSS parser REJECTS
+     * `color: var(--danger)` as an invalid declaration and drops it, so every inline colour
+     * reads back as the empty string here.  A render test would pass whatever the component
+     * did -- the first version of this asserted `''` for the below-threshold cases and would
+     * have gone on passing with the hues restored.
+     *
+     * What is painted is asserted in ui-layout.cy.js, in a browser, at the thresholds.
+     */
+    it('names roles rather than hues at both thresholds', () => {
+        const source = fs.readFileSync(path.join(__dirname, 'Common.js'), 'utf8');
+        const helper = source.slice(
+            source.indexOf('export function LoadStatistic'),
+            source.indexOf('export function', source.indexOf('export function LoadStatistic') + 10));
+
+        expect(helper).toContain("color = 'danger'");
+        expect(helper).toContain("color = 'warning'");
+        expect(helper.match(/'(red|green|amber|yellow|orange)'/)).toBeNull();
+    });
+});
+
+describe('a drive\'s SMART assessment is a severity, not a colour', () => {
+    /*
+     * A source guard: `getHealthColor` is module-private, and exporting it only so a test
+     * can reach it would be shaping the code around the test.  What matters is that the
+     * helper stays on the ramp -- all four branches or none, since a helper where PASS and
+     * FAIL rank but WARN is an unranked hue is worse than either choice.
+     */
+    it('maps every branch to a role', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, 'admin', 'ControllerPage.js'), 'utf8');
+        const helper = source.slice(
+            source.indexOf('const getHealthColor'),
+            source.indexOf('};', source.indexOf('const getHealthColor')));
+
+        expect(helper).toContain("'var(--success)'");
+        expect(helper).toContain("'var(--warning)'");
+        expect(helper).toContain("'var(--danger)'");
+        expect(helper.match(/var\(--(red|green|amber|yellow|orange)\)/)).toBeNull();
     });
 });

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -1,11 +1,11 @@
-import fs from 'fs';
-import path from 'path';
 import React from 'react';
 import {act, render, screen, waitFor} from '../test-utils';
 import userEvent from '@testing-library/user-event';
 import {
-    contrastingColor, contrastRatio, DirectorySearch, SearchResultsInput, TAG_TEXT_DARK, TAG_TEXT_LIGHT,
+    contrastingColor, contrastRatio, DirectorySearch, loadRole, SearchResultsInput,
+    TAG_TEXT_DARK, TAG_TEXT_LIGHT,
 } from './Common';
+import {healthRole} from './admin/ControllerPage';
 
 // Mock debounce to make tests run faster
 jest.mock('lodash/debounce', () => jest.fn(fn => {
@@ -563,45 +563,62 @@ describe('contrastingColor with shorthand hex', () => {
     });
 });
 
-describe('LoadStatistic ranks load by role, not by hue', () => {
+describe('loadRole', () => {
     /*
-     * A source guard, not a render test, and deliberately so: jsdom's CSS parser REJECTS
-     * `color: var(--danger)` as an invalid declaration and drops it, so every inline colour
-     * reads back as the empty string here.  A render test would pass whatever the component
-     * did -- the first version of this asserted `''` for the below-threshold cases and would
-     * have gone on passing with the hues restored.
+     * The branches, tested as branches.  This used to be a source guard scraping the
+     * function body out of Common.js, because the obvious render test cannot work: jsdom
+     * REJECTS `color: var(--danger)` as an invalid declaration and drops it, so every inline
+     * colour reads back as the empty string and the assertions passed for that reason alone.
+     * Pulling the mapping out as a pure function is the honest fix.
      *
-     * What is painted is asserted in ui-layout.cy.js, in a browser, at the thresholds.
+     * Thresholds are halves and three quarters of the core count, so each is asserted either
+     * side of its boundary rather than at one comfortable value.
      */
-    it('names roles rather than hues at both thresholds', () => {
-        const source = fs.readFileSync(path.join(__dirname, 'Common.js'), 'utf8');
-        const helper = source.slice(
-            source.indexOf('export function LoadStatistic'),
-            source.indexOf('export function', source.indexOf('export function LoadStatistic') + 10));
+    it('says nothing about a load below half the cores', () => {
+        expect(loadRole(1.9, 4)).toBeUndefined();
+        expect(loadRole(0, 4)).toBeUndefined();
+    });
 
-        expect(helper).toContain("color = 'danger'");
-        expect(helper).toContain("color = 'warning'");
-        expect(helper.match(/'(red|green|amber|yellow|orange)'/)).toBeNull();
+    it('warns from half the cores', () => {
+        expect(loadRole(2.0, 4)).toBe('warning');
+        expect(loadRole(2.9, 4)).toBe('warning');
+    });
+
+    it('calls it danger from three quarters', () => {
+        expect(loadRole(3.0, 4)).toBe('danger');
+        expect(loadRole(99, 4)).toBe('danger');
+    });
+
+    it('says nothing when the core count is unknown', () => {
+        // Both thresholds are guarded on `cores`.  Without it every load would read as fine,
+        // which is the safe direction, but worth pinning so it stays deliberate.
+        expect(loadRole(12, undefined)).toBeUndefined();
+        expect(loadRole(12, 0)).toBeUndefined();
+    });
+
+    it('never returns a hue', () => {
+        // The regression this exists for: `orange` is byte-identical to `--text` in night,
+        // so a warning load rendered as an ordinary uncoloured number.
+        [loadRole(1, 4), loadRole(2.5, 4), loadRole(4, 4)].filter(Boolean).forEach(role =>
+            expect(role).not.toMatch(/^(red|green|amber|yellow|orange|blue)$/));
     });
 });
 
-describe('a drive\'s SMART assessment is a severity, not a colour', () => {
-    /*
-     * A source guard: `getHealthColor` is module-private, and exporting it only so a test
-     * can reach it would be shaping the code around the test.  What matters is that the
-     * helper stays on the ramp -- all four branches or none, since a helper where PASS and
-     * FAIL rank but WARN is an unranked hue is worse than either choice.
-     */
-    it('maps every branch to a role', () => {
-        const source = fs.readFileSync(
-            path.join(__dirname, 'admin', 'ControllerPage.js'), 'utf8');
-        const helper = source.slice(
-            source.indexOf('const getHealthColor'),
-            source.indexOf('};', source.indexOf('const getHealthColor')));
+describe('healthRole', () => {
+    it('maps every SMART assessment to a severity', () => {
+        expect(healthRole('PASS')).toBe('success');
+        expect(healthRole('WARN')).toBe('warning');
+        expect(healthRole('FAIL')).toBe('danger');
+    });
 
-        expect(helper).toContain("'var(--success)'");
-        expect(helper).toContain("'var(--warning)'");
-        expect(helper).toContain("'var(--danger)'");
-        expect(helper.match(/var\(--(red|green|amber|yellow|orange)\)/)).toBeNull();
+    it('is not case sensitive, because the value comes from smartctl', () => {
+        expect(healthRole('pass')).toBe('success');
+        expect(healthRole('Fail')).toBe('danger');
+    });
+
+    it('treats a missing or unrecognised assessment as unknown, not as healthy', () => {
+        // Reporting an unreadable drive as PASS would be the dangerous direction.
+        [undefined, null, '', 'SOMETHING_ELSE'].forEach(value =>
+            expect(healthRole(value)).toBe('neutral'));
     });
 });

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -979,10 +979,12 @@ function RefreshStepItem({phase, isActive, isCompleted, isDisabled, description}
     return <div style={{
         display: 'flex', alignItems: 'center', gap: 8, flex: '1 1 160px', padding: '0.5em 0.75em',
         opacity: isDisabled ? 0.5 : 1,
-        borderBottom: isActive ? '2px solid var(--blue)' : '2px solid transparent',
+        borderBottom: isActive ? '2px solid var(--info)' : '2px solid transparent',
     }}>
+        {/* The same three roles Status maps complete/active/pending onto.  Not the Status
+            component itself: these rows carry a per-phase glyph, which is the point of them. */}
         <Icon name={phase.icon} size='large'
-              style={{color: isCompleted ? 'var(--green)' : isActive ? 'var(--blue)' : 'var(--muted)'}}/>
+              style={{color: isCompleted ? 'var(--success)' : isActive ? 'var(--info)' : 'var(--neutral)'}}/>
         <div>
             <div style={{fontWeight: 600, fontSize: 13}}>{phase.title}</div>
             <div style={{fontSize: 12, color: 'var(--muted)'}}>{isActive || isCompleted ? description : ''}</div>
@@ -1033,7 +1035,7 @@ function RefreshProgressBar({status, operation_total, operation_processed, opera
 
     // Show error state
     if (status === 'error' && error) {
-        return <Progress percent={100} color='red' label={`Error: ${error}`}/>;
+        return <Progress percent={100} color='danger' label={`Error: ${error}`}/>;
     }
 
     let label = `${phaseLabel}`;

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -909,7 +909,7 @@ export function FlasherPage() {
                                         </span>
                                         {chipMismatch &&
                                             <span style={{marginLeft: '0.5em'}}>
-                                                <Label color='red' icon='warning sign'>
+                                                <Label color='warning' icon='warning sign'>
                                                     Built for {chipIdName(fileChipId)}, not{' '}
                                                     {chipIdName(deviceChipId)}
                                                 </Label>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -197,7 +197,7 @@ export function ThemeSamplePage() {
             <StatisticGroup>
                 <Statistic value='0.4' label='1 Min. Load'/>
                 <Statistic value='2.6' label='5 Min. Load' color='orange'/>
-                <Statistic value='4.1' label='15 Min. Load' color='red'/>
+                <Statistic value='4.1' label='15 Min. Load' color='danger'/>
                 <Statistic value='48' label='Temp C°'/>
             </StatisticGroup>
         </Section>
@@ -700,7 +700,7 @@ export function ThemeSamplePage() {
 
         <Section label='Danger zone'>
             <Panel danger>
-                <h2 style={{color: 'var(--red)', fontSize: 14, margin: '0 0 4px'}}>Danger zone</h2>
+                <h2 style={{color: 'var(--danger)', fontSize: 14, margin: '0 0 4px'}}>Danger zone</h2>
                 <p style={{color: 'var(--muted)', fontSize: 13, margin: '0 0 12px'}}>
                     These actions are destructive and cannot be undone.
                 </p>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -196,7 +196,7 @@ export function ThemeSamplePage() {
             <Header as='h5' style={{marginTop: 24}}>Coloured readings, as Status draws them</Header>
             <StatisticGroup>
                 <Statistic value='0.4' label='1 Min. Load'/>
-                <Statistic value='2.6' label='5 Min. Load' color='orange'/>
+                <Statistic value='2.6' label='5 Min. Load' color='warning'/>
                 <Statistic value='4.1' label='15 Min. Load' color='danger'/>
                 <Statistic value='48' label='Temp C°'/>
             </StatisticGroup>

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -614,13 +614,16 @@ function CookiesSettingsSection() {
         fetchStatus();
     };
 
-    // Status is encoded by color like any other status label; no filled "success/warning"
-    // words map directly to a token, so the wrapper picks the token color explicitly.
+    // The two states that mean something take roles; the two that are just "nothing to
+    // report" stay --muted, which is dimmer than --neutral in night and amber and so keeps
+    // the least important states at the bottom.
     const getStatusLabel = () => {
         if (loading) return <span style={{color: 'var(--muted)'}}>Loading...</span>;
         if (!status.cookies_exist) return <span style={{color: 'var(--muted)'}}>No cookies stored</span>;
-        if (status.cookies_unlocked) return <span style={{color: 'var(--green)'}}>Unlocked</span>;
-        return <span style={{color: 'var(--amber)'}}>Locked</span>;
+        if (status.cookies_unlocked) return <span style={{color: 'var(--success)'}}>Unlocked</span>;
+        // Locked is not an error the user made, but cookie-requiring downloads fail until
+        // somebody enters the password after a reboot -- that is attention, not failure.
+        return <span style={{color: 'var(--warning)'}}>Locked</span>;
     };
 
     return <Panel>

--- a/app/src/components/admin/Configs.js
+++ b/app/src/components/admin/Configs.js
@@ -7,7 +7,7 @@ function WarningIcon({ok}) {
     // null is empty, true is valid, false is invalid.
     const content = ok === true ? 'Valid and can be imported.' : ok === false ? 'Invalid, can be overwritten.' : 'Empty config, can be overwritten.';
     return <Tooltip label={content}>
-        <span style={{color: ok === true ? 'var(--violet)' : ok === false ? 'var(--red)' : 'var(--muted)'}}>
+        <span style={{color: ok === true ? 'var(--success)' : ok === false ? 'var(--danger)' : 'var(--neutral)'}}>
             <Icon name={ok === false ? 'close' : 'check'} label={content}/>
         </span>
     </Tooltip>
@@ -82,7 +82,7 @@ function BackupDateRow({date, previews, previewsLoaded, onSelect}) {
 
     const noChanges = <span style={{color: 'var(--muted)', fontStyle: 'italic'}}>No changes</span>;
     const previewFailed = <Tooltip label='Failed to load preview'>
-        <span style={{color: 'var(--red)'}}><Icon name='warning sign' label='Failed to load preview'/></span>
+        <span style={{color: 'var(--danger)'}}><Icon name='warning sign' label='Failed to load preview'/></span>
     </Tooltip>;
 
     let mergeCell;

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -606,12 +606,16 @@ function ServicesSection() {
 
 // Helper to get health status color from SMART assessment
 const getHealthColor = (assessment) => {
-    if (!assessment) return 'var(--muted)';
+    // Roles, not hues: a drive's assessment is a severity and has to rank as one.  All
+    // four branches together -- a helper where PASS and FAIL rank but WARN is an
+    // unranked hue is worse than either choice, and in night `--amber` is byte-identical
+    // to `--yellow` so WARN would stop sitting between them.
+    if (!assessment) return 'var(--neutral)';
     const upper = assessment.toUpperCase();
-    if (upper === 'PASS') return 'var(--green)';
-    if (upper === 'WARN') return 'var(--amber)';
-    if (upper === 'FAIL') return 'var(--red)';
-    return 'var(--muted)';
+    if (upper === 'PASS') return 'var(--success)';
+    if (upper === 'WARN') return 'var(--warning)';
+    if (upper === 'FAIL') return 'var(--danger)';
+    return 'var(--neutral)';
 };
 
 // Helper to format power-on hours
@@ -829,7 +833,9 @@ function MountModal({disk, open, onClose, onMount}) {
                     <p>
                         Found <strong>{entries}</strong> ({formatBytes(shadowed.size_bytes)}) at the mount target.
                     </p>
-                    <p style={{color: 'var(--red)'}}>
+                    {/* A caution about a consequence, not a failure -- the destructive
+                        weight is already carried by the confirm button below. */}
+                    <p style={{color: 'var(--warning)'}}>
                         Those files will continue to consume space on the underlying filesystem
                         (typically the SD card on a Raspberry Pi) and can fill it up.
                     </p>

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -605,18 +605,32 @@ function ServicesSection() {
 
 
 // Helper to get health status color from SMART assessment
-const getHealthColor = (assessment) => {
-    // Roles, not hues: a drive's assessment is a severity and has to rank as one.  All
-    // four branches together -- a helper where PASS and FAIL rank but WARN is an
-    // unranked hue is worse than either choice, and in night `--amber` is byte-identical
-    // to `--yellow` so WARN would stop sitting between them.
-    if (!assessment) return 'var(--neutral)';
-    const upper = assessment.toUpperCase();
-    if (upper === 'PASS') return 'var(--success)';
-    if (upper === 'WARN') return 'var(--warning)';
-    if (upper === 'FAIL') return 'var(--danger)';
-    return 'var(--neutral)';
+/**
+ * The severity of a SMART assessment.
+ *
+ * Roles, not hues: a drive's health is a severity and has to rank as one.  All four
+ * branches together -- a helper where PASS and FAIL rank but WARN is an unranked hue is
+ * worse than either choice, and in night `--amber` is byte-identical to `--yellow`, so WARN
+ * would stop sitting between them.
+ *
+ * Exported and pure so the mapping can be tested as a mapping rather than scraped out of
+ * the source, which is what this needed before it was separated from the CSS wrapper.
+ */
+export const healthRole = (assessment) => {
+    if (!assessment) return 'neutral';
+    switch (assessment.toUpperCase()) {
+        case 'PASS':
+            return 'success';
+        case 'WARN':
+            return 'warning';
+        case 'FAIL':
+            return 'danger';
+        default:
+            return 'neutral';
+    }
 };
+
+const getHealthColor = (assessment) => `var(--${healthRole(assessment)})`;
 
 // Helper to format power-on hours
 const formatPowerOnHours = (hours) => {

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -238,7 +238,7 @@ function RecurringDownloadRow({download, fetchDownloads, onDelete}) {
         </Modal.Actions>
     </Modal>;
 
-    const errorTrigger = <IconButton icon='exclamation triangle' label='Download error' color='orange'
+    const errorTrigger = <IconButton icon='exclamation triangle' label='Download error' color='danger'
                                      onClick={handleErrorOpen}/>;
 
     const hideEdit = downloader === Downloaders.MapCatalog || downloader === Downloaders.MapExtract;
@@ -453,7 +453,7 @@ function OnceDownloadRow({download, fetchDownloads, isSelected, onSelect}) {
 
     if (error && !download.progress) {
         completedAtCell = (
-            <IconButton icon='exclamation triangle' label='Download error' color='red'
+            <IconButton icon='exclamation triangle' label='Download error' color='danger'
                         onClick={() => setErrorModalOpen(true)}/>
         )
         errorModal = <Modal

--- a/app/src/components/inventory/InventoryItemsMobile.js
+++ b/app/src/components/inventory/InventoryItemsMobile.js
@@ -49,7 +49,7 @@ export function InventoryItemsMobile({fields, items}) {
                             {columns.map((f, idx) => <Table.Cell key={f.key}>
                                 {idx === 0 && expired &&
                                     <Icon name='warning sign' label='Expired'
-                                          style={{color: 'var(--red)', marginRight: '0.4em'}}/>}
+                                          style={{color: 'var(--danger)', marginRight: '0.4em'}}/>}
                                 {formatValue(item, f)}
                             </Table.Cell>)}
                         </Table.Row>;

--- a/app/src/components/inventory/InventoryTable.js
+++ b/app/src/components/inventory/InventoryTable.js
@@ -235,7 +235,7 @@ export function InventoryTable({slug, fields, items, locations, catalog, search,
                         <Table.Cell>
                             <Checkbox checked={selected.has(item.id)} onChange={() => toggleSelected(item.id)}/>
                             {expired && <Icon name='warning sign' label='Expired'
-                                              style={{color: 'var(--red)', marginLeft: '0.4em'}}/>}
+                                              style={{color: 'var(--danger)', marginLeft: '0.4em'}}/>}
                         </Table.Cell>
                         {sortedFields.map(f => <Table.Cell key={f.key}>
                             {editing

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -333,6 +333,56 @@ describe('semantic roles read as severity in every theme', () => {
     });
 });
 
+describe('a load reading ranks itself in the monochrome themes', () => {
+    /*
+     * LoadStatistic is the Status page's CPU load, and the clearest payoff of the roles
+     * outside the library: it used to be `orange` above half the cores and `red` above three
+     * quarters, and in night `--orange` is byte-identical to `--text`, so a machine under
+     * load rendered its warning as an ordinary uncoloured number.
+     *
+     * Only a browser can see this.  jsdom rejects `color: var(--warning)` as invalid and
+     * drops it, so the inline colour reads back empty whatever the component did.
+     */
+    monochromeThemes.forEach((theme) => {
+        it(`separates fine, warning and danger loads in ${theme}`, () => {
+            cy.mountUI(
+                <Panel>
+                    <Statistic value='1.9' label='fine' cores={4} color={undefined}/>
+                    <Statistic value='2.6' label='warning' color='warning'/>
+                    <Statistic value='4.1' label='danger' color='danger'/>
+                </Panel>,
+                {theme},
+            );
+
+            cy.get('.wrolpi-statistic-value').should(($values) => {
+                const [fine, warning, danger] = [...$values]
+                    .map(el => toRgb(getComputedStyle(el).color));
+                const panel = toRgb(getComputedStyle(
+                    Cypress.$('.wrolpi-panel')[0]).backgroundColor);
+
+                expect(new Set([fine, warning, danger]).size, 'three distinct readings').to.equal(3);
+                expect(contrast(danger, panel), 'danger is louder than warning')
+                    .to.be.greaterThan(contrast(warning, panel));
+                expect(contrast(danger, panel), 'danger is louder than a plain reading')
+                    .to.be.greaterThan(contrast(fine, panel));
+
+                /*
+                 * NOT asserted: that warning outranks a plain reading.  It does not, and that
+                 * is a live question rather than an oversight -- an uncoloured value inherits
+                 * `--text`, which in night is 4.98:1 against 4.91:1 for `--warning`.  So a
+                 * machine under load is marginally QUIETER than one that is fine.
+                 *
+                 * Lifting warning above text is a palette change, not a call-site one: on a
+                 * dark panel the only way up is lightness, and night's danger would desaturate
+                 * from #ff3e3e to about #ff5d5d -- trading the theme's "red only" character
+                 * for loudness.  Worth a deliberate decision, so it is flagged rather than
+                 * quietly made here.
+                 */
+            });
+        });
+    });
+});
+
 describe('a table header is a surface, not just bold text', () => {
     themeNames.forEach((theme) => {
         it(`separates the header from every body row in ${theme}`, () => {

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -4,7 +4,7 @@ import {
     Message, Placeholder, Statistic, StatisticGroup, Status, TabBar, Table, tabClassName,
     TextInput,
 } from './index';
-import {contrastingColor} from '../Common';
+import {contrastingColor, LoadStatistic} from '../Common';
 import {Notifications} from '@mantine/notifications';
 import {clearToasts, toast} from './toast';
 import {monochromeThemes, themeNames} from '../../themes/names';
@@ -335,26 +335,31 @@ describe('semantic roles read as severity in every theme', () => {
 
 describe('a load reading ranks itself in the monochrome themes', () => {
     /*
-     * LoadStatistic is the Status page's CPU load, and the clearest payoff of the roles
-     * outside the library: it used to be `orange` above half the cores and `red` above three
-     * quarters, and in night `--orange` is byte-identical to `--text`, so a machine under
-     * load rendered its warning as an ordinary uncoloured number.
+     * The real `LoadStatistic`, at the real thresholds -- NOT a hand-built `Statistic` with
+     * the roles typed in.  The first version of this did that, and it would have stayed green
+     * with `LoadStatistic` reverted to `orange`/`red`: it proved only that role tokens resolve
+     * distinctly, which the roles suite above already covers.
      *
-     * Only a browser can see this.  jsdom rejects `color: var(--warning)` as invalid and
-     * drops it, so the inline colour reads back empty whatever the component did.
+     * This is the Status page's CPU load, and the clearest payoff of the roles outside the
+     * library: `orange` above half the cores was byte-identical to `--text` in night, so a
+     * machine under load rendered its warning as an ordinary uncoloured number.
+     *
+     * Only a browser can see it.  jsdom rejects `color: var(--warning)` as invalid and drops
+     * it, so the inline colour reads back empty whatever the component did.
      */
     monochromeThemes.forEach((theme) => {
         it(`separates fine, warning and danger loads in ${theme}`, () => {
             cy.mountUI(
                 <Panel>
-                    <Statistic value='1.9' label='fine' cores={4} color={undefined}/>
-                    <Statistic value='2.6' label='warning' color='warning'/>
-                    <Statistic value='4.1' label='danger' color='danger'/>
+                    <LoadStatistic label='1 Min. Load' value={1.9} cores={4}/>
+                    <LoadStatistic label='5 Min. Load' value={2.6} cores={4}/>
+                    <LoadStatistic label='15 Min. Load' value={4.1} cores={4}/>
                 </Panel>,
                 {theme},
             );
 
             cy.get('.wrolpi-statistic-value').should(($values) => {
+                expect($values.length, 'three readings').to.equal(3);
                 const [fine, warning, danger] = [...$values]
                     .map(el => toRgb(getComputedStyle(el).color));
                 const panel = toRgb(getComputedStyle(


### PR DESCRIPTION
Sixteen call sites, chosen by reading each one rather than grepping for a hue. I had four sub-agents judge them independently against one rule: **convert only what genuinely means success or failure**; identification, category and decoration stay hue-named.

## Converted

| Site | Was | Now |
|---|---|---|
| SMART drive health — all four branches | green/amber/red/muted | success/warning/danger/neutral |
| Config validity: valid / invalid / empty | violet/red/muted | success/danger/neutral |
| "Failed to load preview" | red | danger |
| Both "Download error" triggers | orange **and** red | danger |
| Expired inventory items (desktop + mobile) | red | danger |
| Refresh phases: complete / active / not reached | green/blue/muted | success/info/neutral |
| Refresh Progress in its error state | red | danger |
| Cookie status: Unlocked / Locked | green/amber | success/warning |
| Flasher chip-mismatch label | red | warning |
| CPU load thresholds (`LoadStatistic`) | orange/red | warning/danger |
| `useAPIButton` outcome | green/red | success/danger |
| Gallery "Danger zone" + load readings | red/orange | danger/warning |

## Left alone, deliberately

- **The file browser toolbar** — every action has its own colour so they can be told apart, and delete already uses `role='danger'`. Your ruling.
- **Diff add/remove** in the config and inventory import previews. Adding is not a success and removing is not a failure — in Overwrite mode the removals are precisely what the user asked for, and painting them `danger` would report their intended action as broken. One agent also measured that in night `--green`/`--red` are *further apart* than `--success`/`--danger`, so converting would make the add/remove distinction harder to see, not easier.
- Seasons in `DatesSelector`, the uploader star and favourite heart, `TagIcon`, downloader category buttons, "Recommended to Keep".

## Three sites were actually wrong

- Both **"Download error"** triggers guard on the *same condition* and open the *same modal*, but one was `orange` and the other `red`. And `orange` is the worst possible choice — byte-identical to `--text` in night, so that error button was indistinguishable from an ordinary control.
- **Config validity** drew its valid state in `--violet`. No user parses lavender as "valid".
- **`LoadStatistic`** — the thing users actually watch on the Status page — rendered its warning threshold in that same invisible orange.

## Two notes on the tests

**My first `LoadStatistic` test was vacuous.** It rendered the component and asserted the inline colour — but jsdom *rejects* `color: var(--danger)` as an invalid declaration and drops it, so every colour reads back as the empty string. Two of the four assertions passed for that reason alone and would have kept passing with the hues restored. It is a source guard now, with the painted result asserted in a browser.

**That browser test then found something real, which I have not fixed.** An uncoloured reading inherits `--text`, which in night is **4.98:1** against `--warning`'s **4.91:1** — so a machine under load is marginally *quieter* than one that is fine.

The fix is a palette change, not a call-site one. On a dark panel the only way up is lightness, and night's danger would desaturate from `#ff3e3e` to about `#ff5d5d` — trading the theme's "red only" character for loudness. That is your call, so the test documents it and asserts what does hold (three distinct readings; danger louder than both) rather than my quietly making it.

## Verified

- jest **1058 passing** / 59 suites
- `ui-layout.cy.js` **113 passing** (was 111)
- `npm run build` clean
- every conversion checked red against a planted reversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)