### PR TITLE
ui: progress bars get room for their label, and keep their band inside

### DIFF
--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -376,6 +376,55 @@ export function ThemeSamplePage() {
             </Panel>
         </Section>
 
+        <Section label='Progress'>
+            <Panel>
+                {/*
+                  The label sits on BOTH halves of the bar, so every one of these is really a
+                  contrast test: the text has to read over the fill and over the track, in all
+                  four themes.  That is why light brightens the fill rather than using the raw
+                  token, and why night and amber drop it to --muted instead of a hue.
+                */}
+                <div style={{maxWidth: 460}}>
+                    <Progress percent={0}/>
+                    <Progress percent={8}/>
+                    <Progress percent={37}/>
+                    <Progress percent={62}/>
+                    <Progress percent={94}/>
+                    <Progress percent={100}/>
+                </div>
+
+                <Header as='h5'>Its own label instead of the percentage</Header>
+                <div style={{maxWidth: 460}}>
+                    <Progress percent={41} label='2.1 GB / 5.3 GB'/>
+                    <Progress percent={73} label='CPU Usage (16 cores)'/>
+                    <Progress percent={12} label='nbd0 read 4.2 MBps'/>
+                </div>
+
+                <Header as='h5'>No label at all, and unknown size</Header>
+                <div style={{maxWidth: 460}}>
+                    <Progress percent={55} showPercent={false}/>
+                    {/* Indeterminate: a band sliding inside the bar, for work whose size is
+                        not known yet.  It must stay within the track -- it used to slide out
+                        past both edges, because nothing clipped it. */}
+                    <Progress indeterminate label='Uploading…'/>
+                    <Progress indeterminate showPercent={false}/>
+                </div>
+
+                <Header as='h5'>Carrying a meaning</Header>
+                <div style={{maxWidth: 460}}>
+                    <Progress percent={64} color='info' label='Downloading'/>
+                    <Progress percent={100} color='success' label='Complete'/>
+                    <Progress percent={80} color='warning' label='Disk 80% full'/>
+                    <Progress percent={100} color='danger' label='Error: HTTP 403'/>
+                </div>
+                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 14, marginBottom: 0}}>
+                    A bar is 22px so its label has room; at 16px the text filled the bar edge to
+                    edge. Check the mid-range ones — 37% and 62% are where the label crosses the
+                    boundary between fill and track, which is the case that has to work.
+                </p>
+            </Panel>
+        </Section>
+
         <Section label='Messages'>
             <div style={{display: 'flex', flexDirection: 'column', gap: 10}}>
                 <Message kind='info' title='Refresh started'>
@@ -683,9 +732,6 @@ export function ThemeSamplePage() {
                 <Row>
                     <Button role='cancel' icon='eye' onClick={() => setModalOpen(true)}>Open a modal</Button>
                 </Row>
-                <div style={{marginTop: 12, maxWidth: 320}}>
-                    <Progress indeterminate label='Uploading…'/>
-                </div>
                 <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
                     Semantic's compound shape is kept — Modal.Header, Modal.Content,
                     Modal.Actions — so the 34 call sites written against it migrate by import.

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -521,17 +521,14 @@ describe('a progress bar has room for the label inside it', () => {
 
         cy.get('.wrolpi-progress').should(($bar) => {
             const box = $bar[0].getBoundingClientRect();
-            const text = $bar[0].querySelector('.wrolpi-progress-text')
-                .firstChild.getBoundingClientRect
-                ? $bar[0].querySelector('.wrolpi-progress-text').getBoundingClientRect()
-                : null;
             expect(box.height, 'bar height').to.be.at.least(20);
+
             // The line box, measured from the text node itself rather than its stretched
             // flex container, which is inset:0 and therefore always the bar's height.
             const range = document.createRange();
             range.selectNodeContents($bar[0].querySelector('.wrolpi-progress-text'));
-            const line = range.getBoundingClientRect();
-            expect(box.height - line.height, 'air around the label').to.be.at.least(4);
+            expect(box.height - range.getBoundingClientRect().height, 'air around the label')
+                .to.be.at.least(4);
         });
     });
 
@@ -551,10 +548,21 @@ describe('a progress bar has room for the label inside it', () => {
         );
 
         cy.get('.wrolpi-progress-text').should(($text) => {
+            const style = getComputedStyle($text[0]);
+            expect(style.whiteSpace, 'label does not wrap').to.equal('nowrap');
+            expect(style.textOverflow, 'and is cut with an ellipsis, not mid-glyph')
+                .to.equal('ellipsis');
+
             const range = document.createRange();
             range.selectNodeContents($text[0]);
-            const lines = range.getClientRects().length;
-            expect(lines, 'the label occupies one line box').to.equal(1);
+            expect(range.getClientRects().length, 'one line box').to.equal(1);
+            /*
+             * And that one line is genuinely wider than the space it has -- otherwise the
+             * test proves nothing, since a label that fits occupies one line either way.
+             * This is the case that used to wrap and get bisected by the clip.
+             */
+            expect(range.getBoundingClientRect().width, 'the label really is too long')
+                .to.be.greaterThan($text[0].getBoundingClientRect().width);
         });
     });
 
@@ -619,11 +627,15 @@ describe('a progress bar has room for the label inside it', () => {
 
     it('keeps the indeterminate band inside the bar', () => {
         /*
-         * The band slides on `margin-left`, from -35% to 100%.  Those are its real layout
-         * positions -- it genuinely does extend past both edges, and `getBoundingClientRect`
-         * reports that whether or not it is visible.  So the assertion is on the clip, plus
-         * the fact that the band escapes without one: together they show the clip is doing
-         * work rather than being decoration.
+         * The band slides on `margin-left` from -35% to 100%, so it genuinely does extend
+         * past both edges and `getBoundingClientRect` reports that whether or not it is
+         * painted.  The clip is what keeps it out of sight.
+         *
+         * The band is PINNED here rather than sampled mid-animation.  Reading a running
+         * animation made this both flaky and, worse, permanently false for anyone with
+         * Reduce Motion turned on: `prefers-reduced-motion` replaces the slide with
+         * `width: 100%` and no negative margin, so the band never leaves the box and an
+         * assertion that it does could not pass on that machine at all.
          */
         cy.mountUI(bar({indeterminate: true, label: 'Uploading…'}), {theme: 'light'});
 
@@ -631,10 +643,42 @@ describe('a progress bar has room for the label inside it', () => {
             expect(getComputedStyle($bar[0]).overflow, 'the bar clips its contents')
                 .to.equal('hidden');
 
+            const fill = $bar[0].querySelector('.wrolpi-progress-fill');
+            // Where the animation's first keyframe puts it, held still.
+            fill.style.animation = 'none';
+            fill.style.width = '35%';
+            fill.style.marginLeft = '-35%';
+
+            const box = $bar[0].getBoundingClientRect();
+            const band = fill.getBoundingClientRect();
+            expect(band.left, 'the band does leave the box, so the clip is load-bearing')
+                .to.be.lessThan(box.left - 1);
+        });
+    });
+
+    it('does not move the band at all when motion is suppressed', () => {
+        /*
+         * The other branch, and the reason the test above pins rather than samples: with
+         * Reduce Motion the bar fills instead of sliding, because motion was the only signal
+         * it had.  A band that never moves must also never leave the box.
+         */
+        cy.mountUI(bar({indeterminate: true}), {theme: 'light'});
+        cy.get('.wrolpi-progress-fill').should('exist');
+
+        cy.document().then((doc) => {
+            const probe = doc.createElement('style');
+            probe.textContent = `
+                .wrolpi-progress-indeterminate .wrolpi-progress-fill {
+                    animation: none; width: 100%; opacity: 0.5;
+                }`;
+            doc.head.appendChild(probe);
+        });
+
+        cy.get('.wrolpi-progress-indeterminate').should(($bar) => {
             const box = $bar[0].getBoundingClientRect();
             const band = $bar[0].querySelector('.wrolpi-progress-fill').getBoundingClientRect();
-            expect(band.left < box.left - 1 || band.right > box.right + 1,
-                'the band does leave the box, so the clip is load-bearing').to.equal(true);
+            expect(band.left, 'band starts at the bar').to.be.closeTo(box.left, 2);
+            expect(band.right, 'band ends at the bar').to.be.closeTo(box.right, 2);
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
     ActionInput, Button, Header, Icon, IconStack, Loading, MultiSelect, Panel, PathInput,
-    Message, Placeholder, Statistic, StatisticGroup, Status, TabBar, Table, tabClassName,
-    TextInput,
+    Message, Placeholder, Progress, Statistic, StatisticGroup, Status, TabBar, Table,
+    tabClassName, TextInput,
 } from './index';
 import {contrastingColor, HelpHeader, LoadStatistic} from '../Common';
 import {Notifications} from '@mantine/notifications';
@@ -505,6 +505,136 @@ describe('a heading opens a section rather than closing the last one', () => {
         cy.get('.wrolpi-header').should(($header) => {
             expect(getComputedStyle($header[0]).marginTop, 'first child has no top margin')
                 .to.equal('0px');
+        });
+    });
+});
+
+describe('a progress bar has room for the label inside it', () => {
+    const bar = (props) => <Panel><Progress {...props}/></Panel>;
+
+    it('leaves air above and below the text', () => {
+        /*
+         * The Status page draws 44 of these.  At 16px tall the 11px bold label left about
+         * half a pixel of air, which is legible only if you already know what it says.
+         */
+        cy.mountUI(bar({percent: 62, label: 'CPU Usage (16 cores)'}), {theme: 'light'});
+
+        cy.get('.wrolpi-progress').should(($bar) => {
+            const box = $bar[0].getBoundingClientRect();
+            const text = $bar[0].querySelector('.wrolpi-progress-text')
+                .firstChild.getBoundingClientRect
+                ? $bar[0].querySelector('.wrolpi-progress-text').getBoundingClientRect()
+                : null;
+            expect(box.height, 'bar height').to.be.at.least(20);
+            // The line box, measured from the text node itself rather than its stretched
+            // flex container, which is inset:0 and therefore always the bar's height.
+            const range = document.createRange();
+            range.selectNodeContents($bar[0].querySelector('.wrolpi-progress-text'));
+            const line = range.getBoundingClientRect();
+            expect(box.height - line.height, 'air around the label').to.be.at.least(4);
+        });
+    });
+
+    it('keeps a long label on one line', () => {
+        /*
+         * `white-space: nowrap` on the label.  The first version of this asserted the bar did
+         * not get wider -- which it cannot: the label is `position: absolute; inset: 0`, so it
+         * takes no part in its parent's width and the claim was unfalsifiable.  What a long
+         * label really does is wrap to a second line inside a 22px bar and get cut in half by
+         * the clip, so that is what is measured.
+         */
+        cy.mountUI(
+            <div style={{width: 200}}>
+                <Progress percent={40} label='nbd0 read 128.4 MBps sustained over 5 minutes'/>
+            </div>,
+            {theme: 'light'},
+        );
+
+        cy.get('.wrolpi-progress-text').should(($text) => {
+            const range = document.createRange();
+            range.selectNodeContents($text[0]);
+            const lines = range.getClientRects().length;
+            expect(lines, 'the label occupies one line box').to.equal(1);
+        });
+    });
+
+    it('separates bars that are stacked directly on one another', () => {
+        // The Status page's CPU and RAM bars are bare siblings in a Panel and were touching.
+        cy.mountUI(
+            <Panel>
+                <Progress percent={20} label='CPU Usage'/>
+                <Progress percent={70} label='RAM Usage'/>
+            </Panel>,
+            {theme: 'light'},
+        );
+
+        cy.get('.wrolpi-progress').should(($bars) => {
+            const [first, second] = [...$bars].map(b => b.getBoundingClientRect());
+            expect(second.top - first.bottom, 'gap between stacked bars').to.be.at.least(6);
+        });
+    });
+
+    it('adds no gap to a bar its container already spaces', () => {
+        /*
+         * The other half, and the reason for `* +` rather than a blanket margin: the drive
+         * bandwidth bars each sit alone in a Grid column, which supplies the gutters.  A
+         * blanket margin would add a second one on top.
+         */
+        cy.mountUI(
+            <Panel>
+                <div><Progress percent={20} label='nbd0 read'/></div>
+                <div><Progress percent={30} label='nbd0 write'/></div>
+            </Panel>,
+            {theme: 'light'},
+        );
+
+        cy.get('.wrolpi-progress').should(($bars) => {
+            [...$bars].forEach((bar, index) =>
+                expect(getComputedStyle(bar).marginTop, `bar ${index} is an only child`)
+                    .to.equal('0px'));
+        });
+    });
+
+    themeNames.forEach((theme) => {
+        it(`reads its label against the track in ${theme}`, () => {
+            /*
+             * The label spans the whole bar, so it sits on the fill AND on the track.  This
+             * asserts the track half only, and that is deliberate: over the FILL it measures
+             * 5.49 in light but 2.35 / 2.48 / 2.74 in dark, night and amber -- below any
+             * legibility floor.  Fixing that needs a per-half text colour, which is a design
+             * decision rather than a bug fix, so it is reported rather than quietly asserted
+             * at a threshold low enough to pass.  See the note in ui.css.
+             */
+            cy.mountUI(bar({percent: 20, label: 'CPU Usage'}), {theme});
+
+            cy.get('.wrolpi-progress').should(($bar) => {
+                const text = toRgb(getComputedStyle(
+                    $bar[0].querySelector('.wrolpi-progress-text')).color);
+                const track = toRgb(getComputedStyle($bar[0]).backgroundColor);
+                expect(contrast(text, track), 'label against the empty part of the bar')
+                    .to.be.at.least(4.5);
+            });
+        });
+    });
+
+    it('keeps the indeterminate band inside the bar', () => {
+        /*
+         * The band slides on `margin-left`, from -35% to 100%.  Those are its real layout
+         * positions -- it genuinely does extend past both edges, and `getBoundingClientRect`
+         * reports that whether or not it is visible.  So the assertion is on the clip, plus
+         * the fact that the band escapes without one: together they show the clip is doing
+         * work rather than being decoration.
+         */
+        cy.mountUI(bar({indeterminate: true, label: 'Uploading…'}), {theme: 'light'});
+
+        cy.get('.wrolpi-progress-indeterminate').should(($bar) => {
+            expect(getComputedStyle($bar[0]).overflow, 'the bar clips its contents')
+                .to.equal('hidden');
+
+            const box = $bar[0].getBoundingClientRect();
+            const band = $bar[0].querySelector('.wrolpi-progress-fill').getBoundingClientRect();
+            expect(band.left < box.left - 1 || band.right > box.right + 1,
+                'the band does leave the box, so the clip is load-bearing').to.equal(true);
         });
     });
 });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1057,10 +1057,17 @@ html .mantine-Notification-closeButton:hover {
     font-weight: 700;
     color: var(--text);
     font-variant-numeric: tabular-nums;
-    /* A long label must not push the bar wider than the column it was given. */
+    /*
+     * A long label is a real case, not a hypothetical: uploads label with a filename
+     * (Upload.js, FileBrowser.js) and a failed refresh labels with the error string.
+     * Without `nowrap` it wraps to a second line inside a 22px bar and the clip bisects
+     * it; with a hard clip and no ellipsis, `Complete: very-long-archive-name.tar.gz`
+     * ends mid-glyph and reads as broken rather than truncated.
+     */
     padding: 0 6px;
     overflow: hidden;
     white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 /*

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -975,12 +975,35 @@ html .mantine-Notification-closeButton:hover {
 
 /* --------------------------------------------------------------- Progress */
 
+/*
+ * Tall enough for the label inside it.  At 16px a 14px line box left half a pixel of air
+ * above and below the text, which on the Status page is 44 bars of cramped 11px bold --
+ * legible only if you already knew what it said.
+ *
+ * `overflow: hidden` is what keeps the indeterminate band inside the bar.  Without it the
+ * band slides from `margin-left: -35%` to `100%` in full view, so the animation ran from
+ * outside the left edge to outside the right one, painting over whatever sat beside it.
+ */
 .wrolpi-progress {
     position: relative;
-    height: 16px;
+    height: 22px;
     min-width: 120px;
+    overflow: hidden;
     background: var(--bg);
     border: 1px solid var(--border);
+}
+
+/*
+ * Bars stacked directly on top of each other need a gap; bars that a container already
+ * spaces do not.  On the Status page the CPU and RAM bars are bare siblings in a Panel and
+ * were touching, while the drive-bandwidth bars each sit alone in a Grid column and get
+ * their spacing from the Grid.
+ *
+ * `* +` distinguishes those two cases by itself: it fires only when a bar actually follows
+ * something, so an only-child bar in a column is untouched.
+ */
+* + .wrolpi-progress {
+    margin-top: 8px;
 }
 
 .wrolpi-progress-fill {
@@ -1029,15 +1052,29 @@ html .mantine-Notification-closeButton:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 11px;
+    /* 12px rather than 11: these labels carry units and device names, not just a number. */
+    font-size: 12px;
     font-weight: 700;
     color: var(--text);
     font-variant-numeric: tabular-nums;
+    /* A long label must not push the bar wider than the column it was given. */
+    padding: 0 6px;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 /*
  * The percent text sits on both the filled and empty halves of the bar, so the
  * fill has to stay light enough in light mode for dark text to read over it.
+ *
+ * MEASURED, and only light actually clears it.  The label against the fill is
+ * 5.49:1 in light (the brightness filter below is what buys that) but 2.35 in
+ * dark, 2.48 in night and 2.74 in amber; against the empty track it is 5.2-15:1
+ * everywhere.  Reaching AA over the fill needs the label drawn twice, clipped to
+ * the fill boundary, so each half gets its own colour -- and in night not even
+ * that would do it, since `--text` is only ~4:1 against pure black and the fill
+ * is lighter than black by definition.  Left as it is, deliberately, rather than
+ * asserted at a threshold chosen to pass.
  */
 html[data-theme="light"] .wrolpi-progress {
     background: var(--panel);


### PR DESCRIPTION
## Too thin

16px tall with an 11px bold label left about half a pixel of air above and below — and the Status page draws **44 of them**. Now 22px with a 12px label, since these carry device names and units rather than just a number.

## The band escaped the bar

`indeterminate` slides on `margin-left` from `-35%` to `100%` and nothing clipped it, so the animation ran from outside the left edge to outside the right one — exactly as you saw. `overflow: hidden` on the bar.

## Why CPU/RAM touched but bandwidth didn't

It isn't the bars. **CPU and RAM are bare siblings inside a `Panel`** (`{cpuProgress}{memoryUsageProgress}`), and `.wrolpi-progress` had no margin. **Each bandwidth bar sits alone in a `<Grid.Col>`**, so the Mantine `Grid` supplies the gutter.

`* + .wrolpi-progress { margin-top: 8px }` separates those two cases on its own — it only fires when a bar actually follows something, so an only-child bar in a column is untouched. Verified on the live page: 8px between CPU and RAM, **0px on every bandwidth bar**. A blanket margin would have doubled the Grid's gutter, and that's asserted too.

## Gallery

New Progress section: six percentages (including the mid-range ones where the label crosses the fill boundary), custom labels, no label, indeterminate, and the four roles. I removed the demo's own gaps so what it shows is the spacing the component really has.

## Measured, and NOT fixed — your call

Building the gallery turned up something worth your eye. The label spans the whole bar, so it sits on the fill **and** the track:

| theme | over fill | over track |
|---|---|---|
| light | **5.49** ✓ | 14.95 |
| dark | **2.35** ✗ | 13.45 |
| night | **2.48** ✗ | 5.18 |
| amber | **2.74** ✗ | 9.16 |

Light clears it because of the `brightness(1.75)` filter; the other three don't. Reaching AA over the fill needs the label drawn twice and clipped at the fill boundary so each half takes its own colour — and **in night not even that works**: `--text` is only ~4:1 against pure black, and a fill is lighter than black by definition.

I've recorded it in `ui.css` and in the test, which asserts the **track half only** rather than picking a threshold low enough to pass. Say the word if you want the two-copy clip for dark and amber.

## One test was unfalsifiable

"Keeps a long label from widening the bar" **cannot fail** — the label is `position: absolute; inset: 0` and takes no part in its parent's width. What a long label really does is wrap to a second line inside a 22px bar and get cut in half by the new clip. It measures line boxes now.

## Verified

- jest **1074 passing** / 59 suites
- `ui-layout.cy.js` **133 passing** (was 124)
- `npm run build` clean
- five plants, all red: 16px height, clip removed, blanket margin, no `nowrap`, no adjacent margin
- checked all four themes in the gallery and on `/admin/status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)