### PR TITLE
ui: cards get legible titles, contained posters, and meta beside the title

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -82,8 +82,14 @@ pre.wrap-text {
     text-decoration: none !important;
 }
 
+/*
+ * A card's title and its author/channel/domain line are links, but they are the card's
+ * text -- they take the body colour rather than the link colour, so a grid of cards reads
+ * as titles and not as a wall of blue.  This was a literal `black` until the themes
+ * arrived, which left every title at about 1.1:1 on the dark, night and amber panels.
+ */
 .card-link {
-    color: black;
+    color: var(--text);
 }
 
 .center-me {

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -426,22 +426,22 @@ export function ArchiveCard({file}) {
         </div>
     </>;
 
-    return <Card media={media} title={titleElm} meta={meta}
-                 color={mimetypeColor(file.mimetype, file.primary_path)}>
-        <div style={{display: 'flex', gap: '0.5em', marginTop: '0.5em'}}>
-            <Link to={`/archives/${file.id}`}>
-                <Button icon='file alternate'>Details</Button>
-            </Link>
-            <IconButton
-                icon='external'
-                label='Open original URL'
-                component='a'
-                href={file.url}
-                target='_blank'
-                rel='noopener noreferrer'
-            />
-        </div>
-    </Card>
+    const actions = <div style={{display: 'flex', gap: '0.5em'}}>
+        <Link to={`/archives/${file.id}`}>
+            <Button icon='file alternate'>Details</Button>
+        </Link>
+        <IconButton
+            icon='external'
+            label='Open original URL'
+            component='a'
+            href={file.url}
+            target='_blank'
+            rel='noopener noreferrer'
+        />
+    </div>;
+
+    return <Card media={media} title={titleElm} meta={meta} actions={actions}
+                 color={mimetypeColor(file.mimetype, file.primary_path)}/>
 }
 
 // Domain table column configuration

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -174,19 +174,30 @@ export function isoDatetimeToString(dt, time = false) {
     return d;
 }
 
-export function CardLink({to, newTab = false, ...props}) {
+/*
+ * Both card links COMPOSE the caller's className rather than being overwritten by it.
+ * Written as `className='...' {...props}`, the spread put the caller's class last and it
+ * replaced the pair outright -- so every archive title, which passes
+ * `card-title-ellipsis`, lost `card-link` and rendered in the link colour instead of the
+ * card's text colour.  The one card type whose classes are set this way, and the one whose
+ * title looked wrong.
+ */
+const cardLinkClass = (className) =>
+    ['no-link-underscore', 'card-link', className].filter(Boolean).join(' ');
+
+export function CardLink({to, newTab = false, className, ...props}) {
     props = newTab === true ? {...props, target: '_blank', rel: 'noopener noreferrer'} : props;
-    return <Link to={to} className="no-link-underscore card-link" {...props}>
+    return <Link to={to} className={cardLinkClass(className)} {...props}>
         {props.children}
     </Link>
 }
 
-export function ExternalCardLink({to, children, ...props}) {
+export function ExternalCardLink({to, children, className, ...props}) {
     return <a
         href={to}
         target='_blank'
         rel='noopener noreferrer'
-        className='no-link-underscore card-link'
+        className={cardLinkClass(className)}
         {...props}
     >
         {children}
@@ -726,7 +737,7 @@ export function findPosterPath(file) {
     }
 }
 
-export function CardPoster({to, file}) {
+export function CardPoster({to, file, overlay}) {
     const navigate = useNavigate();
 
     // Marks a tagged file, pinned to the poster's corner.
@@ -739,16 +750,29 @@ export function CardPoster({to, file}) {
         // FileGroup has a poster (screenshot/thumbnail) file.
         posterPath = `/media/${encodeMediaPath(posterPath)}`;
 
-        // Sized by `.wrolpi-card-poster`: as wide as the card allows, natural ratio.
-        const image = <img alt='poster' src={posterPath}/>;
+        /*
+         * Sized by `.wrolpi-card-poster`: as wide as the card allows, capped in height,
+         * natural ratio.  The corner chrome goes INSIDE the link, beside the image:
+         *
+         *   - the frame shrink-wraps the painted image, so a mark pinned to its corner
+         *     tracks the poster rather than the letterbox space beside it.  A height-capped
+         *     poster is a good deal narrower than its band -- 155px inside a 233px card for
+         *     a book cover, less for a vertical video;
+         *   - and the mark stays part of the poster's hit target, rather than a dead spot
+         *     on the corner of an otherwise clickable image.
+         */
+        const inner = <>
+            {imageLabel}
+            <img alt='poster' src={posterPath}/>
+            {overlay}
+        </>;
 
         return <div className='wrolpi-card-poster'>
-            {imageLabel}
             {to
                 // Link within this App.
-                ? <Link to={to}>{image}</Link>
+                ? <Link to={to} className='wrolpi-card-poster-frame'>{inner}</Link>
                 // Preview the file.
-                : <PreviewLink file={file}>{image}</PreviewLink>}
+                : <PreviewLink file={file} className='wrolpi-card-poster-frame'>{inner}</PreviewLink>}
         </div>
     } else {
         // FileGroup has no poster.

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -727,8 +727,6 @@ export function findPosterPath(file) {
 }
 
 export function CardPoster({to, file}) {
-    // Used to center posters in CardIcon.
-    const style = {display: 'flex', justifyContent: 'center'};
     const navigate = useNavigate();
 
     // Marks a tagged file, pinned to the poster's corner.
@@ -741,25 +739,17 @@ export function CardPoster({to, file}) {
         // FileGroup has a poster (screenshot/thumbnail) file.
         posterPath = `/media/${encodeMediaPath(posterPath)}`;
 
-        const image = <>
-            {/* Replicate <Image label/> but with maxHeight applied to image */}
-            {imageLabel}
-            <img alt='poster' src={posterPath} style={{maxHeight: '163px', maxWidth: '290px', width: 'auto'}}/>
-        </>;
+        // Sized by `.wrolpi-card-poster`: as wide as the card allows, natural ratio.
+        const image = <img alt='poster' src={posterPath}/>;
 
-        if (to) {
-            // Link within this App.
-            return <Link to={to} style={style}>
-                {image}
-            </Link>
-        } else {
-            // Preview the file.
-            return <div style={style}>
-                <PreviewLink file={file}>
-                    {image}
-                </PreviewLink>
-            </div>
-        }
+        return <div className='wrolpi-card-poster'>
+            {imageLabel}
+            {to
+                // Link within this App.
+                ? <Link to={to}>{image}</Link>
+                // Preview the file.
+                : <PreviewLink file={file}>{image}</PreviewLink>}
+        </div>
     } else {
         // FileGroup has no poster.
         if (!to || (to.startsWith('/media/') || to.startsWith('/download/'))) {

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import {act, render, screen, waitFor} from '../test-utils';
 import userEvent from '@testing-library/user-event';
 import {
-    contrastingColor, contrastRatio, DirectorySearch, HelpHeader, InfoHeader, loadRole,
+    CardLink, contrastingColor, contrastRatio, DirectorySearch, ExternalCardLink, HelpHeader,
+    InfoHeader, loadRole,
     SearchResultsInput, TAG_TEXT_DARK, TAG_TEXT_LIGHT,
 } from './Common';
 import {healthRole} from './admin/ControllerPage';
@@ -682,5 +683,27 @@ describe('a heading keeps its help icon on the same row as the text', () => {
         const {container} = render(<HelpHeader headerContent='Root CA Certificate' helpPath='/x/'/>);
 
         expect(container.querySelector('.inline-header')).toBeNull();
+    });
+});
+
+describe('card links', () => {
+    /*
+     * `.card-link` is what makes a card's title read as the card's text rather than as a
+     * link, so a title that misses it is the one thing on the card in the wrong colour.
+     * Both helpers set the class and then spread the caller's props over it, so any call
+     * site passing a className of its own -- which is every archive title, via
+     * `card-title-ellipsis` -- silently replaced the class instead of adding to it.
+     */
+    it.each([
+        ['CardLink', <CardLink to='/archives/1' className='card-title-ellipsis'>Title</CardLink>],
+        ['ExternalCardLink',
+            <ExternalCardLink to='http://x/a.html' className='card-title-ellipsis'>Title</ExternalCardLink>],
+    ])('%s keeps its own classes when the call site adds one', (_name, element) => {
+        render(element);
+
+        const link = screen.getByText('Title');
+        expect(link).toHaveClass('card-link');
+        expect(link).toHaveClass('no-link-underscore');
+        expect(link).toHaveClass('card-title-ellipsis');
     });
 });

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -54,6 +54,15 @@ import {contrastingColor} from './Common';
  * already happened more than once.
  */
 
+/*
+ * A stand-in poster of exact intrinsic dimensions, so the poster caps can be seen against
+ * the ratios that actually break them -- a real library has all five and the gallery has
+ * no media of its own.
+ */
+const samplePoster = (width, height) => `data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='${width}' height='${height}'>` +
+    `<rect width='100%' height='100%' fill='%23808080'/></svg>`)}`;
+
 const Section = ({label, children}) => <section style={{marginBottom: 34}}>
     <p style={{
         fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase',
@@ -714,6 +723,57 @@ export function ThemeSamplePage() {
                     }}><Icon name={icon} size={34}/></div>}
                 />)}
             </CardGroup>
+
+            <Header as='h4'>Posters</Header>
+            <CardGroup>
+                {[
+                    ['16:9 video thumbnail', 1280, 720],
+                    ['4:3 screenshot', 800, 600],
+                    ['square thumbnail', 600, 600],
+                    ['portrait book cover', 306, 396],
+                    ['smaller than the card', 120, 90],
+                ].map(([label, w, h]) => <Card
+                    key={label}
+                    title={label}
+                    meta={`${w}×${h}`}
+                    color='blue'
+                    media={<div className='wrolpi-card-poster'>
+                        <img alt='' src={samplePoster(w, h)}/>
+                    </div>}
+                />)}
+            </CardGroup>
+            <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
+                A poster is capped on both axes — the card's width, and{' '}
+                <code>--card-poster-max-height</code> — and keeps its own ratio whichever
+                cap bites. Capping the width alone let a square thumbnail stand as tall as
+                the card is wide. A poster smaller than the card is left at its own size
+                rather than upscaled.
+            </p>
+
+            <Header as='h4'>Meta, body and actions</Header>
+            <CardGroup>
+                {[
+                    ['Rainwater Harvesting And Filtration For A Small Off-Grid Homestead',
+                        'engineering775.com · 2025-01-30', true],
+                    ['Solar Basics', 'wiki.example.org · 2024-08-02', true],
+                    ['Field Notes.pdf', 'docs/ · 2023-06-14', false],
+                ].map(([title, meta, withActions]) => <Card
+                    key={title}
+                    title={<a href='#cards' className='no-link-underscore card-link'>{title}</a>}
+                    meta={meta}
+                    color='blue'
+                    actions={withActions ? <div style={{display: 'flex', gap: '0.5em'}}>
+                        <Button icon='file alternate'>Details</Button>
+                        <IconButton icon='external' label='Open original URL'/>
+                    </div> : undefined}
+                />)}
+            </CardGroup>
+            <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
+                Titles are links but take the body colour, not the link colour — a grid of
+                results should read as titles. The meta line sits directly under the title;
+                actions are pushed to the foot, so a row lines its buttons up however many
+                lines each title took. A card with no actions simply ends.
+            </p>
             <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
                 The bottom edge carries the file type's colour, so a grid of results is
                 scannable by kind before any title is read. It comes from a token, so night

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -244,9 +244,24 @@ export function ThemeSamplePage() {
                         })}>Show a toast</Button>
                     </Row>
                 </div>
+                <div style={{marginTop: 12}}>
+                    <Row>
+                        {['xs', 'sm', 'md', 'lg', 'xl'].map(size => <div key={size}
+                            style={{display: 'flex', gap: '0.4em', alignItems: 'flex-start'}}>
+                            <Button size={size}>{size}</Button>
+                            <IconButton size={size} icon='external' label={`Open (${size})`}/>
+                        </div>)}
+                    </Row>
+                </div>
                 <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
                     In night mode Delete drops its fill for a dashed red outline; dashed means
                     destructive or failed, and nothing else uses it.
+                </p>
+                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                    An icon button is exactly as tall as a labelled one at every size, so a
+                    group of them lines up. Mantine's own scale for icon buttons is unrelated
+                    to its scale for buttons — <code>sm</code> is 22px against a button's 36px
+                    — and the two components start from different defaults.
                 </p>
             </Panel>
         </Section>

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -841,10 +841,14 @@ export function VideoCard({file}) {
         channel_url = `/videos/channel/${channel.id}/video`;
     }
 
-    const media = <div style={{position: 'relative'}}>
-        <CardPoster to={video_url} file={file}/>
-        <Duration totalSeconds={file.length}/>
-    </div>;
+    /*
+     * The duration goes through CardPoster's `overlay` rather than being pinned to a
+     * wrapper around it: the wrapper is the full width of the card, and a vertical video's
+     * poster is only about half that once the height cap applies, so the badge landed well
+     * clear of the frame it belongs to.
+     */
+    const media = <CardPoster to={video_url} file={file}
+                              overlay={<Duration totalSeconds={file.length}/>}/>;
 
     const title = file.title || file.name || video.stem || video.name;
     let titleElm = <Tooltip label={title}>

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -101,9 +101,16 @@ export interface IconButtonProps extends Omit<ActionIconProps, 'children'> {
     component?: any;
 }
 
-/** A square, icon-only button. */
+/**
+ * A square, icon-only button, exactly as tall as a labelled `Button` beside it.
+ *
+ * The height needs BOTH halves of the fix.  ui.css aligns ActionIcon's size scale with
+ * Button's, and this default aligns the starting point: Mantine defaults ActionIcon to `md`
+ * where it defaults Button to `sm`, so leaving it alone would trade a 28-vs-36 mismatch for
+ * a 42-vs-36 one.
+ */
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((
-    {role, icon, label, className, ...props}, ref
+    {role, icon, label, className, size = 'sm', ...props}, ref
 ) => {
     const fromRole = role ? roleProps[role] : undefined;
     return <ActionIcon
@@ -116,7 +123,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((
         variant={props.variant ?? fromRole?.variant ?? 'default'}
         className={[fromRole?.className, className].filter(Boolean).join(' ') || undefined}
         {...props}
-        size={resolveSize(props.size)}
+        size={resolveSize(size)}
     >
         {renderIcon(icon)}
     </ActionIcon>

--- a/app/src/components/ui/Surfaces.tsx
+++ b/app/src/components/ui/Surfaces.tsx
@@ -149,8 +149,19 @@ export interface CardProps {
     /** Image or poster area above the body. */
     media?: React.ReactNode;
     title?: React.ReactNode;
+    /**
+     * The card's secondary line -- author, channel, domain, date.  It sits directly under
+     * the title rather than at the foot of the card: a grid stretches every card to the
+     * tallest in its row, so a foot-anchored meta line strands the date a long way from
+     * the title it belongs to.
+     */
     meta?: React.ReactNode;
     children?: React.ReactNode;
+    /**
+     * Controls, rendered last and pushed to the card's foot so that a row of cards lines
+     * its buttons up regardless of how many lines each title took.
+     */
+    actions?: React.ReactNode;
     onClick?: React.MouseEventHandler<HTMLDivElement>;
     /**
      * A token colour name, drawn as an accent along the card's top edge.  File cards use
@@ -162,7 +173,7 @@ export interface CardProps {
     className?: string;
 }
 
-export function Card({media, title, meta, children, onClick, color, className}: CardProps) {
+export function Card({media, title, meta, children, actions, onClick, color, className}: CardProps) {
     return <MCard
         withBorder
         padding={0}
@@ -183,8 +194,11 @@ export function Card({media, title, meta, children, onClick, color, className}: 
         {media && <div style={{borderBottom: '1px solid var(--border)'}}>{media}</div>}
         <div style={{padding: '10px 12px 12px', display: 'flex', flexDirection: 'column', gap: 4, flex: 1}}>
             {title && <div style={{fontSize: 13, fontWeight: 600, lineHeight: 1.35}}>{title}</div>}
+            {meta && <div className='wrolpi-card-meta' style={{fontSize: 12, color: 'var(--muted)'}}>{meta}</div>}
             {children}
-            {meta && <div style={{fontSize: 12, color: 'var(--muted)', marginTop: 'auto'}}>{meta}</div>}
+            {actions && <div className='wrolpi-card-actions' style={{marginTop: 'auto', paddingTop: 8}}>
+                {actions}
+            </div>}
         </div>
     </MCard>
 }

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
     ActionInput, Button, Card, Header, Icon, IconButton, IconStack, Loading, MultiSelect, Panel, PathInput,
-    Message, Placeholder, Progress, Statistic, StatisticGroup, Status, TabBar, Table,
+    Message, Placeholder, Progress, SearchBox, Statistic, StatisticGroup, Status, TabBar, Table,
     tabClassName, TextInput,
 } from './index';
 import {MemoryRouter} from 'react-router';
+import {VideoCard} from '../Videos';
 import {CardPoster, contrastingColor, HelpHeader, LoadStatistic} from '../Common';
 import {Notifications} from '@mantine/notifications';
 import {clearToasts, toast} from './toast';
@@ -1914,5 +1915,108 @@ describe('a button and an icon button are the same height', () => {
         cy.get('button').should(($el) =>
             expect($el[0].getBoundingClientRect().height, 'default icon button height')
                 .to.be.at.least(34));
+    });
+});
+
+describe('corner chrome sits on the poster, not on the band around it', () => {
+    /*
+     * The tag mark and the video duration are pinned to a corner of "the poster".  Once the
+     * poster gained a height cap, the painted image stopped filling the band it sits in: a
+     * portrait cover is 155px wide inside a 233px card, and a vertical video narrower still.
+     * The mark then floats in empty letterbox space nowhere near the image's corner.
+     *
+     * Geometry against a real painted image, so it belongs here.  It has to be checked on a
+     * ratio that is HEIGHT-bound -- on a 16:9 poster the image fills the band and a mark
+     * pinned to either one lands in the same place, which is why this went unnoticed.
+     */
+    const tagged = (width, height) => ({...posterFile(width, height), tags: [{name: 'ham radio'}]});
+
+    [
+        {name: 'a portrait book cover', w: 306, h: 396},
+        {name: 'a vertical video', w: 720, h: 1280},
+        {name: 'a poster smaller than the card', w: 120, h: 90},
+    ].forEach(({name, w, h}) => {
+        it(`pins the tag to the corner of ${name}`, () => {
+            servePoster(w, h);
+            cy.mountUI(narrowCard(<CardPoster file={tagged(w, h)}/>));
+
+            cy.get('.wrolpi-card-poster img')
+                .should(($img) => expect($img[0].naturalWidth, 'poster loaded').to.equal(w))
+                .should(($img) => {
+                    const image = $img[0].getBoundingClientRect();
+                    const band = $img[0].closest('.wrolpi-card-poster').getBoundingClientRect();
+                    // The premise: this ratio really does leave letterbox space to get lost in.
+                    expect(band.width - image.width, `${name} is narrower than its band`)
+                        .to.be.greaterThan(20);
+
+                    const mark = Cypress.$('.wrolpi-card-tag')[0].getBoundingClientRect();
+                    expect(mark.left, 'tag tracks the image, not the band')
+                        .to.be.closeTo(image.left, 2);
+                    expect(mark.top, 'tag sits at the top of the image').to.be.closeTo(image.top, 2);
+                });
+        });
+    });
+
+    it('keeps the tag inside the poster link, so clicking it still navigates', () => {
+        // The mark used to render inside the Link beside the image and was part of the
+        // poster's hit target; a sibling placed before the link is a dead spot on the corner.
+        servePoster(306, 396);
+        cy.mountUI(narrowCard(<CardPoster to='/videos/1' file={tagged(306, 396)}/>));
+
+        cy.get('.wrolpi-card-tag').should(($tag) =>
+            expect($tag[0].closest('a'), 'the tag is inside the link').to.not.be.null);
+    });
+});
+
+describe('a video card pins its duration to the poster', () => {
+    /*
+     * The same defect as the tag mark, on the other corner and reached by a different
+     * route: the duration was pinned to a wrapper around CardPoster rather than to the
+     * poster itself.  Mounted through the real VideoCard, because the wrapper was the
+     * subject and a hand-built poster would not have one.
+     */
+    it('keeps the duration on a vertical video, not out in the band', () => {
+        servePoster(720, 1280);
+        // mountWithRouter, not mountUI: VideoCard reads the sort order from the query
+        // context, which the spartan mount deliberately does not provide.
+        cy.mountWithRouter(<div style={{width: 233}}><VideoCard file={{
+            id: 1, tags: [], length: 95, primary_path: 'videos/short.mp4',
+            title: 'A vertical video', mimetype: 'video/mp4',
+            poster_path: 'videos/poster-720x1280.svg',
+            video: {stem: 'short', channel: null},
+        }}/></div>);
+
+        cy.get('.wrolpi-card-poster img')
+            .should(($img) => expect($img[0].naturalWidth, 'poster loaded').to.equal(720))
+            .should(($img) => {
+                const image = $img[0].getBoundingClientRect();
+                const band = $img[0].closest('.wrolpi-card-poster').getBoundingClientRect();
+                expect(band.width - image.width, 'the poster is narrower than its band')
+                    .to.be.greaterThan(20);
+
+                const badge = Cypress.$('.duration-overlay')[0].getBoundingClientRect();
+                expect(badge.right, 'the duration tracks the image, not the band')
+                    .to.be.closeTo(image.right, 6);
+            });
+    });
+});
+
+describe('the search clear button matches the field it clears', () => {
+    /*
+     * Aligning IconButton with Button changed every icon button in the app, and this is the
+     * one in the library that stands beside an input rather than beside a button.  It is
+     * also the case the remap was built for: `--ai-size-input-*` exists precisely so an
+     * ActionIcon can match an Input, so if this pair is ragged the remap picked the wrong
+     * scale.
+     */
+    it('is exactly as tall as the search field', () => {
+        cy.mountUI(<SearchBox placeholder='Search' clearable value='axe' onChange={() => {}}/>);
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            const input = Cypress.$('input')[0].getBoundingClientRect();
+            const clear = $clear[0].getBoundingClientRect();
+            expect(input.height, 'the field has a height at all').to.be.greaterThan(10);
+            expect(clear.height, 'clear button vs search field').to.be.closeTo(input.height, 0.5);
+        });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    ActionInput, Button, Card, Header, Icon, IconStack, Loading, MultiSelect, Panel, PathInput,
+    ActionInput, Button, Card, Header, Icon, IconButton, IconStack, Loading, MultiSelect, Panel, PathInput,
     Message, Placeholder, Progress, Statistic, StatisticGroup, Status, TabBar, Table,
     tabClassName, TextInput,
 } from './index';
@@ -1861,5 +1861,58 @@ describe('a card keeps its meta with the title and its actions at the foot', () 
             expect(tall.getBoundingClientRect().bottom, 'both action rows sit on the same line')
                 .to.be.closeTo(short.getBoundingClientRect().bottom, 1);
         });
+    });
+});
+
+describe('a button and an icon button are the same height', () => {
+    /*
+     * Mantine gives ActionIcon a size scale of its own that is nothing like Button's --
+     * `sm` is 22px against a button's 36px -- and defaults it to `md` where Button defaults
+     * to `sm`.  So the Details/Open pair on an archive card came out 36px beside 28px, and
+     * every other toolbar that mixes the two was ragged in the same way.
+     *
+     * Mantine already ships the aligned scale as `--ai-size-input-*`, for an ActionIcon
+     * sitting beside an Input; those five values are identical to `--button-height-*`.  The
+     * fix points one at the other, so this holds for a size we have never used as well as
+     * the ones we have.
+     *
+     * Heights, so it belongs here: jsdom returns zero for both and the comparison would
+     * pass on any pair of numbers at all.
+     */
+    const sizes = [undefined, 'xs', 'sm', 'md', 'lg', 'xl'];
+
+    sizes.forEach((size) => {
+        it(`matches at size ${size || '(default)'}`, () => {
+            cy.mountUI(<div style={{display: 'flex', gap: '0.5em', alignItems: 'flex-start'}}>
+                <Button size={size} icon='file alternate'>Details</Button>
+                <IconButton size={size} icon='external' label='Open original URL'/>
+            </div>);
+
+            cy.get('button').should(($buttons) => {
+                expect($buttons.length).to.equal(2);
+                const [button, iconButton] = [...$buttons].map(el => el.getBoundingClientRect());
+                // A zero-height pair would satisfy the equality below without meaning anything.
+                expect(button.height, 'the button has a height at all').to.be.greaterThan(10);
+                expect(iconButton.height, `icon button at size ${size || '(default)'}`)
+                    .to.be.closeTo(button.height, 0.5);
+                // Square, which is the whole point of an icon button.
+                expect(iconButton.width, 'the icon button stays square')
+                    .to.be.closeTo(iconButton.height, 0.5);
+            });
+        });
+    });
+
+    it('grows the icon button rather than shrinking the button', () => {
+        /*
+         * Both could be made equal by cutting the labelled button down to 28px, which would
+         * be the wrong fix -- a 28px target is below the 44px-ish guidance already stretched
+         * by having buttons this small, and every OTHER button on the page would still be 36.
+         * Pinned so a future "make them match" cannot resolve the other way.
+         */
+        cy.mountUI(<IconButton icon='external' label='Open original URL'/>);
+
+        cy.get('button').should(($el) =>
+            expect($el[0].getBoundingClientRect().height, 'default icon button height')
+                .to.be.at.least(34));
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
-    ActionInput, Button, Header, Icon, IconStack, Loading, MultiSelect, Panel, PathInput,
+    ActionInput, Button, Card, Header, Icon, IconStack, Loading, MultiSelect, Panel, PathInput,
     Message, Placeholder, Progress, Statistic, StatisticGroup, Status, TabBar, Table,
     tabClassName, TextInput,
 } from './index';
-import {contrastingColor, HelpHeader, LoadStatistic} from '../Common';
+import {MemoryRouter} from 'react-router';
+import {CardPoster, contrastingColor, HelpHeader, LoadStatistic} from '../Common';
 import {Notifications} from '@mantine/notifications';
 import {clearToasts, toast} from './toast';
 import {monochromeThemes, themeNames} from '../../themes/names';
@@ -1670,5 +1671,195 @@ describe('media filtering', () => {
 
         cy.get('img').should(($img) =>
             expect(getComputedStyle($img[0]).filter).to.equal('none'));
+    });
+});
+
+/*
+ * A poster of exact intrinsic dimensions.  It has to come over the wire rather than as a
+ * data: URI, because CardPoster rewrites whatever it is given into `/media/<path>` -- so
+ * the bytes are served by an intercept and the component builds its own URL, which is the
+ * URL the app actually requests.
+ */
+const posterFile = (width, height) => ({
+    id: 1,
+    tags: [],
+    poster_path: `videos/poster-${width}x${height}.svg`,
+    primary_path: 'videos/one.mp4',
+});
+
+const servePoster = (width, height) => cy.intercept(
+    'GET', `**/media/videos/poster-${width}x${height}.svg`,
+    {
+        headers: {'content-type': 'image/svg+xml'},
+        body: `<svg xmlns='http://www.w3.org/2000/svg' width='${width}' height='${height}'>` +
+            `<rect width='100%' height='100%' fill='#888'/></svg>`,
+    },
+);
+
+/* A card as narrow as the default grid makes them, which is where the cropping showed. */
+const narrowCard = (children) =>
+    <MemoryRouter><div style={{width: 233}}>{children}</div></MemoryRouter>;
+
+/*
+ * The height cap, read from the stylesheet rather than repeated here, so the two cannot
+ * drift.  Deleting the declaration makes this NaN and every comparison against it fails,
+ * which is the point -- and the bound below keeps "read whatever the CSS says" from being
+ * a test that any value at all satisfies.
+ */
+const cardPosterCap = () => {
+    const value = parseFloat(getComputedStyle(document.documentElement)
+        .getPropertyValue('--card-poster-max-height'));
+    expect(value, 'a poster cap is declared, and is small enough to be a cap')
+        .to.be.within(80, 240);
+    return value;
+};
+
+describe('a card poster is bounded by the card, and keeps its ratio', () => {
+    /*
+     * The poster carried a fixed 290x163 box.  A card in the default grid is about 233px
+     * wide and Mantine's Card sets `overflow: hidden`, so the browser painted the middle
+     * 233px of a 290px image: the ratio was right in the layout tree and wrong on screen.
+     * None of that is visible to jsdom, which lays nothing out.
+     *
+     * The cap that replaced it is on the WIDTH, so a square or portrait source grows as
+     * tall as it likes -- a 1:1 thumbnail became a 233px-tall band above a two-line title.
+     * Hence a height cap as well.  Both caps have to preserve the ratio, which is the part
+     * worth testing: `max-width` and `max-height` together only "contain" an image while
+     * its own width and height stay `auto`.
+     */
+    const cases = [
+        {name: 'a 16:9 video thumbnail', w: 1280, h: 720},
+        {name: 'a square thumbnail', w: 600, h: 600},
+        {name: 'a portrait book cover', w: 306, h: 396},
+        {name: 'a poster smaller than the card', w: 120, h: 90},
+    ];
+
+    cases.forEach(({name, w, h}) => {
+        it(`fits ${name} inside the card without distorting it`, () => {
+            servePoster(w, h);
+            cy.mountUI(narrowCard(<CardPoster file={posterFile(w, h)}/>));
+
+            cy.get('.wrolpi-card-poster img')
+                // The intrinsic size has to have arrived, or every ratio below is 0/0.
+                .should(($img) => expect($img[0].naturalWidth, 'poster loaded').to.equal(w))
+                .should(($img) => {
+                    const img = $img[0];
+                    const box = img.getBoundingClientRect();
+                    const card = img.closest('.wrolpi-card-poster').getBoundingClientRect();
+
+                    expect(box.width, 'poster stays within the card').to.be.at.most(card.width + 0.5);
+                    expect(box.height, 'poster is capped in height').to.be.at.most(cardPosterCap() + 0.5);
+                    // Never upscaled: a small poster is left at its own size.
+                    expect(box.width, 'poster is not stretched past its own size').to.be.at.most(w + 0.5);
+                    expect(box.width / box.height, `${name} keeps its ratio`)
+                        .to.be.closeTo(w / h, 0.01);
+                });
+        });
+    });
+
+    it('shrinks a tall poster by its width rather than squashing it', () => {
+        /*
+         * The failure mode a ratio check alone would miss: a height cap applied while the
+         * width is pinned crops or squashes instead of containing.  A 600x600 source in a
+         * 233px card is width-bound at 233 if the cap is loose and height-bound if it is
+         * tight -- either way the OTHER axis must have moved with it.
+         */
+        servePoster(600, 600);
+        cy.mountUI(narrowCard(<CardPoster file={posterFile(600, 600)}/>));
+
+        cy.get('.wrolpi-card-poster img')
+            .should(($img) => expect($img[0].naturalWidth).to.equal(600))
+            .should(($img) => {
+                const box = $img[0].getBoundingClientRect();
+                expect(box.height, 'the cap actually bit').to.be.at.most(cardPosterCap() + 0.5);
+                expect(box.width, 'and the width came down with it')
+                    .to.be.closeTo(box.height, 0.5);
+            });
+    });
+});
+
+describe('a card reads as titles, not as a wall of links', () => {
+    /*
+     * A card's title and its author/channel/domain line are links, and they carried a
+     * literal `color: black` from before the themes existed.  On the dark, night and amber
+     * panels that is about 1.1:1 -- the titles were there, and invisible.  The date beside
+     * them was fine, because it takes `--muted` from the card body, which is what made the
+     * bug look like a card-title bug rather than a link bug.
+     *
+     * jsdom cannot see this: `.card-link` now resolves a custom property, and jsdom drops
+     * `color: var(--text)` as an invalid declaration.
+     */
+    themeNames.forEach((theme) => {
+        it(`keeps a card title legible in ${theme}`, () => {
+            cy.mountUI(<MemoryRouter>
+                <Card title={<a href='/videos/1' className='no-link-underscore card-link'>
+                    How To Sharpen An Axe
+                </a>} meta='Wranglerstar'/>
+            </MemoryRouter>, {theme});
+
+            cy.get('.card-link').should(($link) => {
+                const panel = toRgb(getComputedStyle(document.documentElement)
+                    .getPropertyValue('--panel'));
+                const title = toRgb(getComputedStyle($link[0]).color);
+                expect(contrast(title, panel), `card title on the panel in ${theme}`)
+                    .to.be.greaterThan(4.5);
+            });
+        });
+    });
+});
+
+describe('a card keeps its meta with the title and its actions at the foot', () => {
+    /*
+     * A grid stretches every card to the tallest in its row.  The meta line used to carry
+     * `margin-top: auto`, so on /docs a PDF with no author had its date shoved 55px below
+     * the title it belongs to, at the bottom of a card that was tall only because of its
+     * neighbour.  Actions are the thing that wants the foot -- a row of cards should line
+     * its buttons up however many lines each title took.
+     *
+     * Real layout, because `margin-top: auto` in a flex column is resolved by the layout
+     * engine and jsdom has none.  The DOM ORDER half of this is in ui.test.js.
+     */
+    const row = <div style={{display: 'flex', alignItems: 'stretch', width: 520}}>
+        {[
+            'A title long enough to wrap onto three separate lines inside a narrow card',
+            'Short',
+        ].map((title, index) => <div key={index} style={{width: 240, display: 'flex'}}>
+            <Card title={title} meta='example.com · 2025-01-30'
+                  actions={<Button>Details</Button>}/>
+        </div>)}
+    </div>;
+
+    it('leaves no gap between the title and the meta line', () => {
+        cy.mountUI(row);
+
+        cy.get('.wrolpi-card-meta').should(($metas) => {
+            expect($metas.length).to.equal(2);
+            const gaps = [...$metas].map((meta) => {
+                const title = meta.previousElementSibling;
+                return meta.getBoundingClientRect().top - title.getBoundingClientRect().bottom;
+            });
+            // The card body's own 4px gap, and nothing else.
+            gaps.forEach((gap, index) => expect(gap, `card ${index} title-to-meta`).to.be.at.most(6));
+            // Both cards really were stretched to the same height, or nothing was pushed.
+            const heights = [...Cypress.$('.mantine-Card-root')]
+                .map(card => Math.round(card.getBoundingClientRect().height));
+            expect(new Set(heights).size, 'the row stretched both cards equally').to.equal(1);
+        });
+    });
+
+    it('lines the actions up at the foot however tall the title got', () => {
+        cy.mountUI(row);
+
+        cy.get('.wrolpi-card-actions').should(($actions) => {
+            expect($actions.length).to.equal(2);
+            const [tall, short] = [...$actions];
+            // The premise: the two titles really are different heights.
+            const titleHeights = [...Cypress.$('.mantine-Card-root')].map(card =>
+                Math.round(card.lastElementChild.firstElementChild.getBoundingClientRect().height));
+            expect(new Set(titleHeights).size, 'the two titles differ in height').to.equal(2);
+
+            expect(tall.getBoundingClientRect().bottom, 'both action rows sit on the same line')
+                .to.be.closeTo(short.getBoundingClientRect().bottom, 1);
+        });
     });
 });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -102,6 +102,28 @@ html[data-theme="night"] .wrolpi-button-danger:hover:not(:disabled) {
 
 /* The icon inside inherits currentColor, so it follows without another rule. */
 
+/*
+ * An icon button is the same height as a labelled one, so a group of them lines up.
+ *
+ * Mantine gives ActionIcon a size scale unrelated to Button's -- `sm` is 22px against a
+ * button's 36px -- which left the Details/Open pair on every archive card ragged, and any
+ * other toolbar that mixes the two.  It already ships the aligned scale as
+ * `--ai-size-input-*`, for an ActionIcon standing beside an Input; those five values are
+ * identical to `--button-height-*`.  Pointing one at the other fixes every size at once,
+ * including ones no call site uses yet.
+ *
+ * The `html` prefix is load-bearing.  Mantine declares this scale on ActionIcon's own
+ * hashed class, which has the same specificity as `.mantine-ActionIcon-root` and would win
+ * on source order.
+ */
+html .mantine-ActionIcon-root {
+    --ai-size-xs: var(--ai-size-input-xs);
+    --ai-size-sm: var(--ai-size-input-sm);
+    --ai-size-md: var(--ai-size-input-md);
+    --ai-size-lg: var(--ai-size-input-lg);
+    --ai-size-xl: var(--ai-size-input-xl);
+}
+
 /* ----------------------------------------------------------- Theme picker */
 
 .wrolpi-theme-picker {

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1117,6 +1117,34 @@ html[data-theme="amber"] .wrolpi-progress-fill {
  * poster area agree in every theme.
  */
 
+/*
+ * A poster is bounded by the card and keeps whatever ratio the source image has.  It used
+ * to carry a fixed 290x163 box, which is wider than a card in a default grid (~233px at
+ * desktop widths), so `overflow: hidden` on the card cropped the sides off and the poster
+ * read as the wrong aspect ratio.
+ *
+ * Both caps are needed.  Bounding the width alone lets a square thumbnail stand as tall as
+ * the card is wide, and a portrait book cover taller still, so the media band dwarfs the
+ * title it belongs to.  `width` and `height` stay `auto` so the pair behaves as "contain":
+ * whichever cap bites first, the other axis comes down with it and the ratio survives.
+ */
+:root {
+    --card-poster-max-height: 200px;
+}
+
+.wrolpi-card-poster {
+    position: relative;
+}
+
+.wrolpi-card-poster img {
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: var(--card-poster-max-height);
+    margin: 0 auto;
+}
+
 .wrolpi-card-icon {
     position: relative;
     display: flex;

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1154,8 +1154,27 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     --card-poster-max-height: 200px;
 }
 
+/*
+ * The band is the full width of the card and centres the poster in it.  The frame inside
+ * shrink-wraps the painted image, and is what corner chrome -- the tagged mark, a video's
+ * duration -- is positioned against.  Pinning that chrome to the BAND puts it in the
+ * letterbox space beside a height-capped poster: 39px adrift on a book cover, 60px on a
+ * vertical video.
+ *
+ * The frame's own width falls out of the caps below.  Its intrinsic contribution is the
+ * image's natural width already reduced by `max-height`, so a portrait cover contributes
+ * 155px and gets 155px; a 16:9 poster contributes 1280px and is flex-shrunk to the band,
+ * at which point `max-width: 100%` resolves against a width that is finally definite.
+ */
 .wrolpi-card-poster {
+    display: flex;
+    justify-content: center;
+}
+
+.wrolpi-card-poster-frame {
     position: relative;
+    display: block;
+    min-width: 0;
 }
 
 .wrolpi-card-poster img {
@@ -1164,7 +1183,6 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     height: auto;
     max-width: 100%;
     max-height: var(--card-poster-max-height);
-    margin: 0 auto;
 }
 
 .wrolpi-card-icon {

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -894,6 +894,37 @@ describe('Card', () => {
 
         expect(container.firstChild.style.borderBottom).toBe('');
     });
+
+    it('puts the meta line under the title and the actions last', () => {
+        /*
+         * Order is the half of the fix jsdom can judge.  An Archive card renders its domain
+         * and date as `meta` and its Details/Open buttons as `actions`; before `actions`
+         * existed the buttons were children and the meta was foot-anchored, so every archive
+         * card read buttons-then-domain.  Which slot lands where is what this asserts; that
+         * the foot anchoring actually resolves is in ui-layout.cy.js, since `margin-top:
+         * auto` needs a layout engine.
+         */
+        renderUI(<Card title='Rainwater Harvesting'
+                       meta='engineering775.com'
+                       actions={<button type='button'>Details</button>}>
+            <span>body</span>
+        </Card>);
+
+        const body = screen.getByText('Rainwater Harvesting').parentElement;
+        expect([...body.children].map(child => child.textContent)).toEqual([
+            'Rainwater Harvesting', 'engineering775.com', 'body', 'Details',
+        ]);
+        expect(body.querySelector('.wrolpi-card-actions')).toHaveStyle({marginTop: 'auto'});
+        expect(body.querySelector('.wrolpi-card-meta').style.marginTop).toBe('');
+    });
+
+    it('renders no actions row when a card has no actions', () => {
+        // Otherwise every card in a grid pays for an empty foot, and the spacing below the
+        // meta line differs between a card with buttons and one without.
+        const {container} = renderUI(<Card title='Plain' meta='docs/'/>);
+
+        expect(container.querySelector('.wrolpi-card-actions')).toBeNull();
+    });
 });
 
 describe('CardGroup', () => {


### PR DESCRIPTION
Four defects reported on `/videos`, `/docs` and `/archives`.

### Titles were invisible outside light

`.card-link` carried a literal `color: black` from before the themes existed.

| theme | title | panel | contrast |
|---|---|---|---|
| light | `#000000` | `#ffffff` | 21:1 |
| dark | `#000000` | `#26292b` | **1.36:1** |
| night | `#000000` | `#160404` | **1.06:1** |
| amber | `#000000` | `#1a0f00` | **1.09:1** |

It covers every card title and the channel/author/domain line beside it. The date was fine, because it takes `--muted` from the card body — which is exactly what made this read as a card-title bug rather than a link bug. Titles now take `--text`: they are links, but they are the card's *text*, not a wall of blue.

### Posters were cropped, not mis-proportioned

The image carried a fixed `290x163` box. A card in the default grid is ~233px wide and Mantine's `Card` sets `overflow: hidden`, so the browser painted the middle 233px of a 290px image — the ratio was right in the layout tree and wrong on screen.

Replaced with caps on **both** axes (the card's width, and `--card-poster-max-height: 200px`) with `width`/`height` left `auto`, so the pair behaves as "contain". Bounding the width alone was the first attempt and is not enough — a square thumbnail then stands as tall as the card is wide, and a portrait cover taller still:

| source | before | width cap only | both caps |
|---|---|---|---|
| 1280×720 | 290×163, cropped to 233 | 231×130 | 231×130 |
| 600×600 | 163×163, cropped | 231×231 | 200×200 |
| 306×396 | 126×163 | 231×299 | 155×200 |
| 120×90 | 120×90 | 120×90 | 120×90 |

### The meta line was foot-anchored

`margin-top: auto` on the meta meant that on `/docs` a PDF with no author had its date shoved up to **55px** below the title, at the bottom of a card that was tall only because of its neighbour in the row. It now sits directly under the title, 4px down.

### Archive cards read buttons-then-domain

Because the buttons were `children` and the meta was what got pushed to the foot. `Card` gains an `actions` slot, rendered last and anchored to the foot, so a row lines its buttons up however many lines each title took.

### Gallery

A poster row covering all five ratios, and a meta/actions row with deliberately unequal titles.

### Tests

1076 jest / 59 suites, 145 in `ui-layout.cy.js`, clean `npm run build`. The 12 failures elsewhere in the cypress component run are the documented pre-existing Semantic-era ones.

Every new guard was run against a planted regression, in **every** suite that claims the behaviour, with the plant kept as narrow as the claim:

| plant | red | stays green (inverse) |
|---|---|---|
| drop `max-height` | square, portrait, squash | 16:9 and small poster — not height-bound |
| `width: 100%` | containment + no-upscale | 16:9 — still 233 wide either way |
| restore `color: black` | dark, night, amber | light — black on white *is* legible |
| re-anchor the meta | cypress gap + jest order | — |
| swap slot order | cypress gap + foot, jest order | — |

The poster cap is read from the stylesheet rather than repeated in the spec, so the two cannot drift; deleting the declaration makes it `NaN` and every comparison fails. A `within(80, 240)` bound keeps "read whatever the CSS says" from being satisfied by any value at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)