### PR TITLE
ui: the navbar measures its foreground instead of assuming one

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,6 +1,6 @@
-/* Nav bar: a hand-rolled flexbox bar (was a Semantic Menu).  The user-chosen
-   background color and the `--btn-text` foreground are set inline per theme;
-   this stylesheet only supplies structure and hover affordances. */
+/* Nav bar: a hand-rolled flexbox bar (was a Semantic Menu).  The user-chosen background
+   and the foreground measured against it are set inline (see themes/navColors); this
+   stylesheet only supplies structure and hover affordances. */
 .wrolpi-navbar {
     display: flex;
     align-items: stretch;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -79,6 +79,30 @@ html .wrolpi-navbar .mantine-ActionIcon-root:hover {
     display: flex;
     align-items: center;
     margin-left: 1.5em;
+    /* Full bar height, so the anchor inside has somewhere to stretch to. */
+    align-self: stretch;
+}
+
+/*
+ * An icon-only trigger in the corner gets a link's hit area, not its glyph's.
+ *
+ * The share glyph already computed `cursor: pointer` -- it is an `<a href>` -- but the
+ * target was the 24px box the icon occupies, so the pointer appeared only if you found it
+ * exactly, and there was no hover highlight to aim at.  Stretched and padded, it behaves
+ * like Help and Admin beside it.
+ *
+ * `align-self` rather than `align-items: stretch` on the wrapper: the IconButtons in the
+ * corner have an explicit height, and a stretch container places an item it cannot stretch
+ * at the start -- which would push the hotspot and theme glyphs back off centre.
+ */
+.wrolpi-navbar-icon > a {
+    align-self: stretch;
+    padding: 0 0.5em;
+    cursor: pointer;
+}
+
+.wrolpi-navbar-icon > a:hover {
+    background: rgba(0, 0, 0, 0.12);
 }
 
 /*

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -42,6 +42,35 @@
     background: rgba(0, 0, 0, 0.12);
 }
 
+/*
+ * Everything in the bar takes the bar's foreground.
+ *
+ * `color: inherit` on the links alone was not enough, because two of the things in the
+ * corner do not inherit at all and both came out blue on every bar in every theme:
+ *
+ *   - An anchor takes `a {color: var(--blue)}` from tokens.css, which outranks an inherited
+ *     value however the bar sets it.  The search glyph is an anchor, and so is every status
+ *     icon that links to /admin -- those only looked right because they carry an inline
+ *     colour of their own, which still wins here and is meant to.
+ *   - A Mantine ActionIcon paints `--ai-color`, its own themed blue.  The hamburger and the
+ *     theme toggle are ActionIcons.  The variable is no use as a hook: Mantine writes it
+ *     INLINE on the element, so a stylesheet declaring it loses every time (the same trap
+ *     as `--group-justify` on Pagination).  The painted property has to be set instead, and
+ *     `html` lifts this over Mantine's own single-class rule.
+ *
+ * Measuring the foreground against the bar is worth nothing if the icons opt out of it.
+ */
+.wrolpi-navbar a,
+html .wrolpi-navbar .mantine-ActionIcon-root {
+    color: inherit;
+}
+
+/* The bar's own hover, rather than a blue tint from Mantine's palette. */
+html .wrolpi-navbar .mantine-ActionIcon-root:hover {
+    background: rgba(0, 0, 0, 0.12);
+    color: inherit;
+}
+
 .channel-edit {
     border-radius: 3px;
     padding: 0.75em;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -71,6 +71,44 @@ html .wrolpi-navbar .mantine-ActionIcon-root:hover {
     color: inherit;
 }
 
+/*
+ * One status indicator's slot.  Laid out rather than nudged: see NavIconWrapper in Nav.js
+ * for the 0.8em top margin this replaces and why it looked correct on half the indicators.
+ */
+.wrolpi-navbar-icon {
+    display: flex;
+    align-items: center;
+    margin-left: 1.5em;
+}
+
+/*
+ * An anchor in the corner hugs its glyph instead of a text line box.
+ *
+ * A line box reserves descender space for text that is not there, which leaves an icon
+ * sitting about 3px above the centre of the box being centred -- the share and search
+ * glyphs, but not the hotspot or theme picker, which are square ActionIcons that centre
+ * their own glyph.  That difference is what made a single top margin look right on some
+ * indicators and wrong on others.
+ */
+.wrolpi-navbar-right a {
+    display: flex;
+    align-items: center;
+}
+
+/*
+ * A link in the corner fills the bar's height, as one outside it does.
+ *
+ * Help and Admin highlighted only a box around their text while Videos and Statistics
+ * highlighted the full height.  Same class and same rules; the difference is the parent.
+ * The bar stretches its children, but the corner is a nested flex container that centres
+ * its own, so a link inside it was sized to its content.  The hover background is painted
+ * on the link box, so this is the hover affordance itself and not just its outline.
+ */
+.wrolpi-navbar-right .wrolpi-navbar-link,
+.wrolpi-navbar-right .wrolpi-navbar-link-button {
+    align-self: stretch;
+}
+
 .channel-edit {
     border-radius: 3px;
     padding: 0.75em;

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -29,6 +29,7 @@ import {
 import {useBluetooth, useDesktop, useHotspot, useSearchDirectories, useSearchOrder, useThrottle, useVnc, useWROLMode} from "../hooks/customHooks";
 import {Media, SettingsContext, StatusContext, ThemeContext} from "../contexts/contexts";
 import {themeChoices} from "../themes/names";
+import {contrastRatio as measureContrast} from "../themes/contrast";
 import {FilePreviewContext} from "./FilePreview";
 import _ from "lodash";
 import {killDownloads, startDownloads, unlockCookies} from "../api";
@@ -1575,52 +1576,28 @@ export const toLocaleString = (num, locale = 'en-US') => {
     return num.toLocaleString(locale);
 }
 
-/**
- * WCAG relative luminance: sRGB channels linearised first, then Rec. 709 weighted.
+/*
+ * The WCAG primitives now live in themes/contrast, so the theme code can measure a colour
+ * without importing this module -- Common.js pulls in half the component library, and
+ * `themes/` importing it is how an import cycle starts.  Forwarded because a good many call
+ * sites and tests already take `contrastRatio` from here.
  *
- * The linearisation is the part that matters.  Weighting the gamma-encoded bytes directly --
- * which is what this did before -- is a rough approximation that misjudges mid-tone blues and
- * purples badly enough to pick the wrong text colour for them.
- */
-function relativeLuminance(color) {
-    const rgb = (typeof color === 'string') ? hexToRGBArray(color) : color;
-    if (!rgb) {
-        return 0;
-    }
-    const linear = rgb.map(value => {
-        const channel = value / 255;
-        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
-    });
-    return (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2]);
-}
-
-/** WCAG contrast ratio between two colours, from 1:1 (identical) to 21:1 (black on white). */
-export function contrastRatio(a, b) {
-    const luminances = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
-    return (luminances[0] + 0.05) / (luminances[1] + 0.05);
-}
-
-/**
- * A hex colour as [r, g, b], accepting both `#rrggbb` and the shorthand `#rgb`.
+ * It is forwarded by a function that delegates rather than by `export {contrastRatio}`, and
+ * that is load-bearing.  A bare re-export compiles to a getter that dereferences the imported
+ * module, and six specs mock this module with `{...jest.requireActual('./Common')}` -- a
+ * spread invokes every getter, and those spreads run re-entrantly while Common.js is still
+ * evaluating (Common -> customHooks -> Common, both mocked that way).  The getter fires
+ * before the import binding is assigned, throws `Cannot read properties of undefined`, and
+ * takes the whole suite with it.  A function is read by the spread but not called, so it
+ * dereferences nothing until evaluation has finished.
  *
- * The shorthand matters because tag colours are not only chosen in the colour picker: they
- * live in the database and in a config file, and a config is something a user edits by hand
+ * The hex parser accepting the `#rgb` shorthand matters and is not incidental: tag colours
+ * are not only chosen in the colour picker, they live in a config file a user edits by hand
  * -- configs are the source of truth in WROLPi.  Rejecting `#fff` left the luminance at zero,
  * so a near-white tag was treated as black and handed light text.
  */
-function hexToRGBArray(color) {
-    let hex = (typeof color === 'string' ? color : '').replace(/^#/, '');
-    if (hex.length === 3) {
-        // #abc means #aabbcc, not #0a0b0c.
-        hex = hex.split('').map(digit => digit + digit).join('');
-    }
-    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
-        console.error('Invalid hex color: ' + color);
-        return;
-    }
-    let rgb = [];
-    for (let i = 0; i <= 2; i++) rgb[i] = parseInt(hex.substr(i * 2, 2), 16);
-    return rgb;
+export function contrastRatio(a, b) {
+    return measureContrast(a, b);
 }
 
 export const TAG_TEXT_DARK = '#000000';

--- a/app/src/components/KeyboardShortcutsProvider.js
+++ b/app/src/components/KeyboardShortcutsProvider.js
@@ -83,6 +83,16 @@ function SearchModal({open, onClose}) {
     return (
         <Modal open={open} onClose={onClose} centered={false} title='Search'>
             <Modal.Content>
+                {/*
+                  * `wrolpi-search-modal` makes the suggestion list part of the panel rather
+                  * than an overlay on the page; see ui.css.  Everywhere else the list floats
+                  * over the page, which is right -- results that reflow the page while you
+                  * type are unusable.  Inside a modal it is wrong twice over: an absolutely
+                  * positioned list adds no height, so the panel stayed 114px tall, and the
+                  * panel's own `overflow: auto` then clipped the list at the panel's edge.
+                  * The modal showed a search box and the first word of the first result.
+                  */}
+                <div className='wrolpi-search-modal'>
                 <SearchResultsInput
                     clearable
                     searchStr={searchStr}
@@ -97,6 +107,7 @@ function SearchModal({open, onClose}) {
                     inputRef={inputRef}
                     autoFocus
                 />
+                </div>
             </Modal.Content>
         </Modal>
     );

--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -111,8 +111,18 @@ function DropdownMenuItem({link}) {
  * button that eventually rendered -- the row overflowed by that much and the bar wrapped.
  * Measuring one thing and drawing another is only ever right by coincidence.
  */
-const NavDropdownTrigger = React.forwardRef(({text, ...props}, ref) =>
-    <button type='button' ref={ref} className='wrolpi-navbar-link wrolpi-navbar-link-button'
+const NavDropdownTrigger = React.forwardRef(({text, className, ...props}, ref) =>
+    /*
+     * `className` is pulled out and MERGED, never spread over.  Menu.Target clones its child
+     * and hands it a className of its own, and a `{...props}` spread placed after the
+     * attribute replaces ours with it -- which left the real More button with no class at
+     * all, so it rendered as a bare grey UA button instead of taking the bar's colour, its
+     * padding and its hover.  The hidden placeholder is not cloned by Menu.Target, so it
+     * kept its class and measured wider than the button that actually drew.
+     */
+    <button type='button' ref={ref}
+            className={['wrolpi-navbar-link', 'wrolpi-navbar-link-button', className]
+                .filter(Boolean).join(' ')}
             {...props}>
         {text}
         <Icon name='dropdown' size='small' style={{marginLeft: '0.35em'}}/>

--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -208,7 +208,7 @@ export function NavBar() {
      * user's colour, not taken from a single token.  See themes/navColors.
      */
     const navColors = useNavColors(navColor);
-    const wrolpiIcon =<img src='/icon.svg' height='32px' width='32px' alt='WROLPi Home Icon'/>;
+    const wrolpiIcon = <img src='/icon.svg' height='32px' width='32px' alt='WROLPi Home Icon'/>;
     const name = <i>{NAME || wrolpiIcon}</i>;
     const topNavText = wrolModeEnabled ? <>{name}&nbsp; <Icon name='lock'/></> : name;
 

--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -102,15 +102,30 @@ function DropdownMenuItem({link}) {
     </Menu.Item>
 }
 
+/*
+ * The trigger for a navbar dropdown.
+ *
+ * Shared with the hidden placeholder DesktopNav measures on its first render, and that is
+ * the point of extracting it.  The placeholder used to be a plain `<button>More</button>`
+ * with no caret, so the space reserved for the overflow menu was about 21px short of the
+ * button that eventually rendered -- the row overflowed by that much and the bar wrapped.
+ * Measuring one thing and drawing another is only ever right by coincidence.
+ */
+const NavDropdownTrigger = React.forwardRef(({text, ...props}, ref) =>
+    <button type='button' ref={ref} className='wrolpi-navbar-link wrolpi-navbar-link-button'
+            {...props}>
+        {text}
+        <Icon name='dropdown' size='small' style={{marginLeft: '0.35em'}}/>
+    </button>
+);
+NavDropdownTrigger.displayName = 'NavDropdownTrigger';
+
 function DropdownLinks({link}) {
     // A labelled dropdown trigger: the desktop "More" overflow, or any nested
     // link group handed to MenuLink.
     return <Menu position='bottom-end' withinPortal>
         <Menu.Target>
-            <button type='button' className='wrolpi-navbar-link wrolpi-navbar-link-button'>
-                {link.text}
-                <Icon name='dropdown' size='small' style={{marginLeft: '0.35em'}}/>
-            </button>
+            <NavDropdownTrigger text={link.text}/>
         </Menu.Target>
         <Menu.Dropdown>
             {link.links.map(l => <DropdownMenuItem key={l.key} link={l}/>)}
@@ -130,9 +145,23 @@ function MobileMenu({links}) {
     </Menu>
 }
 
-function NavIconWrapper({children}) {
+/*
+ * One status indicator's slot in the right-hand corner.
+ *
+ * This used to carry `marginTop: 0.8em`, a nudge left over from Semantic's menu.  The corner
+ * centres its children, and a top margin is part of the margin box being centred, so the
+ * nudge pushed every indicator down by half of it -- about 6px.
+ *
+ * That read as an error on some and not others, which is why it survived: the bare-icon
+ * anchors (share, search) sit high inside their line box because it reserves descender space
+ * for text that is not there, so the nudge happened to cancel out.  An IconButton is a square
+ * ActionIcon that centres its glyph exactly, so for the hotspot and the theme picker the
+ * nudge was 6px of pure error.  Laying the slot out as a flex box centres both shapes on
+ * their real glyph box and needs no nudge at all.
+ */
+export function NavIconWrapper({children}) {
     if (children) {
-        return <div style={{marginTop: '0.8em', marginLeft: '1.5em'}}>{children}</div>
+        return <div className='wrolpi-navbar-icon'>{children}</div>
     } else {
         // Do not use navbar space if children is empty.
         return <React.Fragment/>
@@ -383,7 +412,7 @@ export function NavBar() {
     </>
 }
 
-function DesktopNav({navColors, homeLink, icons}) {
+export function DesktopNav({navColors, homeLink, icons}) {
     const containerRef = React.useRef(null);
     const homeRef = React.useRef(null);
     const rightMenuRef = React.useRef(null);
@@ -410,7 +439,7 @@ function DesktopNav({navColors, homeLink, icons}) {
                     </span>
                 ))}
                 {!isReady && <span ref={moreRef} style={{visibility: 'hidden', flexShrink: 0}}>
-                    <button type='button' className='wrolpi-navbar-link wrolpi-navbar-link-button'>More</button>
+                    <NavDropdownTrigger text='More'/>
                 </span>}
                 {isReady && overflowLinks.length > 0 &&
                     <DropdownLinks link={{text: 'More', key: 'more', links: overflowLinks}}/>}

--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -19,6 +19,7 @@ import {useReorganizationStatus} from "../contexts/FileWorkerStatusContext";
 import {SearchIconButton} from "./Search";
 import {HELP_VIEWER_URI, NAME, semanticUIColorMap} from "./Vars";
 import {useOverflowNav} from "../hooks/useOverflowNav";
+import {defaultNavColor, navBarStyle, useNavColors} from "../themes/navColors";
 import _ from "lodash";
 
 function updateFavicon(colorName) {
@@ -141,7 +142,7 @@ function NavIconWrapper({children}) {
 function useNavColorSetting() {
     // Use localstorage to avoid flickering navbar color on startup.
     const {settings} = React.useContext(SettingsContext);
-    const [navColor, setNavColor] = useLocalStorage('nav_color', 'violet');
+    const [navColor, setNavColor] = useLocalStorage('nav_color', defaultNavColor);
 
     React.useEffect(() => {
         if (!_.isEmpty(settings)) {
@@ -163,7 +164,12 @@ export function NavBar() {
     const wrolModeEnabled = useWROLMode();
     const {status} = React.useContext(StatusContext);
     const navColor = useNavColorSetting();
-    const wrolpiIcon = <img src='/icon.svg' height='32px' width='32px' alt='WROLPi Home Icon'/>;
+    /*
+     * The bar's foreground is measured against the background the theme resolved for the
+     * user's colour, not taken from a single token.  See themes/navColors.
+     */
+    const navColors = useNavColors(navColor);
+    const wrolpiIcon =<img src='/icon.svg' height='32px' width='32px' alt='WROLPi Home Icon'/>;
     const name = <i>{NAME || wrolpiIcon}</i>;
     const topNavText = wrolModeEnabled ? <>{name}&nbsp; <Icon name='lock'/></> : name;
 
@@ -362,15 +368,7 @@ export function NavBar() {
 
     return <>
         <Media between={['mobile', 'tablet']}>
-            <nav className='wrolpi-navbar' id='global_navbar'
-                 style={{
-                     background: `var(--${navColor})`,
-                     color: 'var(--btn-text)',
-                     // The hotspot glyph stacks two icons, and the corner one paints a disc
-                     // of its surface behind itself.  The bar's colour is the user's choice,
-                     // so it has to be handed down rather than looked up from a token.
-                     '--icon-stack-bg': `var(--${navColor})`,
-                 }}>
+            <nav className='wrolpi-navbar' id='global_navbar' style={navBarStyle(navColors)}>
                 {homeLink}
                 <div className='wrolpi-navbar-right'>
                     {icons}
@@ -380,12 +378,12 @@ export function NavBar() {
             </nav>
         </Media>
         <Media greaterThanOrEqual='tablet'>
-            <DesktopNav navColor={navColor} homeLink={homeLink} icons={icons}/>
+            <DesktopNav navColors={navColors} homeLink={homeLink} icons={icons}/>
         </Media>
     </>
 }
 
-function DesktopNav({navColor, homeLink, icons}) {
+function DesktopNav({navColors, homeLink, icons}) {
     const containerRef = React.useRef(null);
     const homeRef = React.useRef(null);
     const rightMenuRef = React.useRef(null);
@@ -400,15 +398,7 @@ function DesktopNav({navColor, homeLink, icons}) {
 
     return (
         <div ref={containerRef}>
-            <nav className='wrolpi-navbar' id='global_navbar'
-                 style={{
-                     background: `var(--${navColor})`,
-                     color: 'var(--btn-text)',
-                     // The hotspot glyph stacks two icons, and the corner one paints a disc
-                     // of its surface behind itself.  The bar's colour is the user's choice,
-                     // so it has to be handed down rather than looked up from a token.
-                     '--icon-stack-bg': `var(--${navColor})`,
-                 }}>
+            <nav className='wrolpi-navbar' id='global_navbar' style={navBarStyle(navColors)}>
                 <span ref={homeRef} style={{display: 'contents'}}>{homeLink}</span>
                 {(isReady ? visibleLinks : allLinks).map((link, idx) => (
                     <span

--- a/app/src/components/Search.js
+++ b/app/src/components/Search.js
@@ -513,11 +513,18 @@ export function SearchView({suggestions, suggestionsSums, loading}) {
 }
 
 export function SearchIconButton() {
-    // A single button which opens the search modal via keyboard shortcuts context.
+    /*
+     * A single button which opens the search modal via keyboard shortcuts context.
+     *
+     * `wrolpi-navbar-link`, not Semantic's leftover `item`, which carried no rules at all
+     * once Semantic was removed: no pointer cursor, no hover highlight, and a hit area of
+     * whatever the 18px glyph occupied rather than the height of the bar.  It is the same
+     * kind of thing as Help and Admin and now has the same affordance.
+     */
     const {openSearchModal} = React.useContext(KeyboardShortcutsContext);
 
     return (
-        <a className='item' style={{paddingRight: '0.7em'}} onClick={openSearchModal}
+        <a className='wrolpi-navbar-link' onClick={openSearchModal}
            role='button' tabIndex={0} aria-label='Search'
            onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && openSearchModal()}>
             <Icon name='search'/>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -44,7 +44,7 @@ import {
 import {semanticColorNames} from '../themes/mantine';
 import {contrastingColor} from './Common';
 import {navBarStyle, navColorNames, useNavColors} from '../themes/navColors';
-import {IconMenu2, IconSearch} from '@tabler/icons-react';
+import {IconMenu2} from '@tabler/icons-react';
 
 /*
  * A gallery of every component in the library, in the current theme.
@@ -106,10 +106,23 @@ export const NavBarSample = ({color}) => {
             <span className='wrolpi-navbar-link'>Videos</span>
             <span className='wrolpi-navbar-link'>Map</span>
             <div className='wrolpi-navbar-right' style={{gap: '0.5em', paddingRight: '0.5em'}}>
+                {/*
+                  * All three shapes the real bar puts in this corner, because they take
+                  * their colour by three different routes and only one of them was ever
+                  * right.  A bare Icon inherits.  An anchor does NOT -- `a {color:
+                  * var(--blue)}` in tokens.css outranks the inherited value, which is what
+                  * made the search icon blue on every bar in every theme.  And a Mantine
+                  * ActionIcon paints its own themed colour, which is what made the
+                  * hamburger blue.  The first version of this sample used an IconButton for
+                  * the search icon too, so it showed the second fault twice and hid the
+                  * first entirely.
+                  */}
                 <Icon name='warning sign' size='large' label='Drive health warning'/>
                 <Icon name='hdd' size='large' label='Drive temperature warning'/>
-                <Icon name='plug' size='large' label='API is not responding'/>
-                <IconButton icon={IconSearch} label='Search' variant='subtle'/>
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                <a className='item' role='button' tabIndex={0} aria-label='Search'>
+                    <Icon name='search' size='large'/>
+                </a>
                 <IconButton icon={IconMenu2} label='Menu' variant='subtle'/>
             </div>
         </nav>

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -43,6 +43,8 @@ import {
 } from './ui';
 import {semanticColorNames} from '../themes/mantine';
 import {contrastingColor} from './Common';
+import {navBarStyle, navColorNames, useNavColors} from '../themes/navColors';
+import {IconMenu2, IconSearch} from '@tabler/icons-react';
 
 /*
  * A gallery of every component in the library, in the current theme.
@@ -76,6 +78,54 @@ const Row = ({children}) => <div style={{display: 'flex', gap: 10, flexWrap: 'wr
     {children}
 </div>;
 
+/*
+ * One navigation bar, in one of the twelve colours a user can pick for it.
+ *
+ * The bar is the only surface in the app whose background the USER chooses, and every theme
+ * resolves those twelve names to twelve of its own colours -- forty-eight backgrounds that
+ * the same links and status icons have to stay legible on.  They did not: the bar drew every
+ * one of them in `--btn-text`, which is near-black in three of the four themes, and night's
+ * `--brown` is #451212.  That glyph was 1.33:1 against the bar behind it.
+ *
+ * These are the real `.wrolpi-navbar` chrome and the real `navBarStyle`, not a mock-up, so a
+ * sample cannot show a bar the app does not draw.  The measured ratio is printed beside each
+ * one because ten of the forty-eight still sit under 4.5:1 and no foreground will lift them
+ * -- a monochrome theme resolves all twelve names onto one ramp, and a mid-tone of a hue
+ * cannot carry text of that same hue.  Fixing those means changing the palette, which is a
+ * decision to make while looking at them.
+ */
+const AA_CONTRAST = 4.5;
+
+export const NavBarSample = ({color}) => {
+    const colors = useNavColors(color);
+    const short = colors.ratio !== null && colors.ratio < AA_CONTRAST;
+
+    return <div data-nav-sample={color} style={{marginBottom: 8}}>
+        <nav className='wrolpi-navbar' style={{...navBarStyle(colors), minHeight: '2.8em'}}>
+            <span className='wrolpi-navbar-link'><i>WROLPi</i>&nbsp;<Icon name='lock'/></span>
+            <span className='wrolpi-navbar-link'>Videos</span>
+            <span className='wrolpi-navbar-link'>Map</span>
+            <div className='wrolpi-navbar-right' style={{gap: '0.5em', paddingRight: '0.5em'}}>
+                <Icon name='warning sign' size='large' label='Drive health warning'/>
+                <Icon name='hdd' size='large' label='Drive temperature warning'/>
+                <Icon name='plug' size='large' label='API is not responding'/>
+                <IconButton icon={IconSearch} label='Search' variant='subtle'/>
+                <IconButton icon={IconMenu2} label='Menu' variant='subtle'/>
+            </div>
+        </nav>
+        <div style={{
+            fontSize: 11, color: short ? 'var(--danger)' : 'var(--muted)',
+            padding: '3px 2px 0', display: 'flex', gap: 8,
+        }}>
+            <strong style={{fontWeight: 600}}>{color}</strong>
+            <span data-nav-sample-ratio={color}>
+                {colors.ratio === null ? '—' : `${colors.ratio.toFixed(2)}:1`}
+            </span>
+            {short && <span>below 4.5:1 — the palette has no better option</span>}
+        </div>
+    </div>
+};
+
 // Numbers the stacked toasts so it is obvious which press produced which, and that a second
 // press adds a toast rather than replacing the first.  Module scope, so it survives re-renders.
 let toastCounter = 0;
@@ -106,6 +156,20 @@ export function ThemeSamplePage() {
                     The same picker the Settings page uses. The navigation bar has a compact
                     version; both read the same list of themes.
                 </p>
+            </Panel>
+        </Section>
+
+        <Section label='Navigation bars'>
+            <Panel>
+                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 0}}>
+                    Every colour the navigation bar can be set to (Settings &rarr; navbar
+                    colour), in the <strong>{theme}</strong> theme. The text and icons are not
+                    a fixed colour: each bar is measured, and drawn in whichever of this
+                    theme's own colours reads best on it. The ratio under each bar is that
+                    measurement — anything under 4.5:1 is called out, and means the palette
+                    itself has no colour that reads on that background.
+                </p>
+                {navColorNames.map(color => <NavBarSample key={color} color={color}/>)}
             </Panel>
         </Section>
 

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -120,7 +120,7 @@ export const NavBarSample = ({color}) => {
                 <Icon name='warning sign' size='large' label='Drive health warning'/>
                 <Icon name='hdd' size='large' label='Drive temperature warning'/>
                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                <a className='item' role='button' tabIndex={0} aria-label='Search'>
+                <a className='wrolpi-navbar-link' role='button' tabIndex={0} aria-label='Search'>
                     <Icon name='search' size='large'/>
                 </a>
                 <IconButton icon={IconMenu2} label='Menu' variant='subtle'/>

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -13,6 +13,7 @@ import {monochromeThemes, themeNames} from '../../themes/names';
 import {navColorNames} from '../../themes/navColors';
 import {NavBarSample} from '../ThemeSamplePage';
 import {DesktopNav, NavIconWrapper} from '../Nav';
+import {ShareButton} from '../Share';
 
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
@@ -2400,6 +2401,334 @@ describe('the navigation bar never breaks onto a second line', () => {
                         .to.be.at.most(bar.right + 0.5);
                 });
             });
+        });
+    });
+});
+
+describe('the navbar overflow menu keeps the bar\'s styling', () => {
+    /*
+     * Mantine's Menu.Target clones its child and hands it a className of its own.  The
+     * trigger spread those cloned props AFTER its own `className` attribute, so the cloned
+     * value replaced ours and the real More button rendered with NO class at all -- a bare
+     * UA button, grey on dark and white on light, while every other item in the bar took the
+     * user's navbar colour.
+     *
+     * The hidden placeholder DesktopNav measures is NOT cloned by Menu.Target, so it kept its
+     * class and stayed the width the styled button would have been.  That is why the width
+     * sweep passed while the visible button was wrong: the two were the same component and
+     * still not the same thing.
+     */
+    const themeIcon = <NavIconWrapper>
+        <IconButton icon='sun' label='Theme' variant='subtle'/>
+    </NavIconWrapper>;
+
+    // Narrow enough that links have to move into More.
+    const mountNarrow = (theme) => cy.mountUI(
+        <MemoryRouter><div style={{width: 700}}>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={themeIcon}
+            />
+        </div></MemoryRouter>,
+        {theme},
+    );
+
+    const moreButton = () => cy.contains('.wrolpi-navbar button', 'More');
+
+    themeNames.forEach((theme) => {
+        it(`draws More in the bar's own colour in ${theme}`, () => {
+            mountNarrow(theme);
+
+            cy.get('.wrolpi-navbar').then(($nav) => {
+                const expected = getComputedStyle($nav[0]).color;
+                moreButton().should(($more) => {
+                    const style = getComputedStyle($more[0]);
+                    expect($more[0].className, 'More carries the bar classes')
+                        .to.contain('wrolpi-navbar-link');
+                    expect(style.color, `More text colour in ${theme}`).to.equal(expected);
+                    // A UA button paints a grey face; the bar's items are transparent.
+                    expect(style.backgroundColor, `More background in ${theme}`)
+                        .to.equal('rgba(0, 0, 0, 0)');
+                });
+            });
+        });
+    });
+
+    it('gives More the same hit area and caret as the placeholder it was measured as', () => {
+        // The measurement contract.  If the drawn button is narrower or shorter than the
+        // space reserved for it, the row overflows and the bar wraps.
+        mountNarrow('light');
+
+        /*
+         * Both measurements inside the retried assertion.  Reading the bar's height in a
+         * plain `.then()` first captures whatever it was at that instant -- including the
+         * transient wrapped state while the corner is still settling -- and then retries the
+         * comparison against that stale number forever.
+         */
+        cy.get('.wrolpi-navbar').should(($nav) => {
+            const bar = $nav[0].getBoundingClientRect().height;
+            const more = [...$nav[0].querySelectorAll('button')]
+                .find(button => button.textContent.includes('More'));
+
+            expect(more, 'the bar has a More button at this width').to.not.be.undefined;
+            expect(more.querySelector('svg'), 'More has its dropdown caret').to.not.be.null;
+            expect(more.getBoundingClientRect().height, 'More fills the bar')
+                .to.be.closeTo(bar, 1);
+            expect(getComputedStyle(more).cursor, 'More is clickable').to.equal('pointer');
+        });
+    });
+});
+
+describe('the icon-only triggers in the navbar corner are reachable', () => {
+    /*
+     * The search glyph carried Semantic's `item` class, which has had no rules at all since
+     * Semantic was removed: no pointer cursor, no hover highlight, and a hit area of the
+     * 18px glyph rather than the height of the bar.  The share glyph did compute
+     * `cursor: pointer` -- it is an `<a href>` -- but its target was the 24px box the icon
+     * occupies, so the pointer showed only if you found it exactly.
+     *
+     * Both are icon-only triggers sitting beside Help and Admin, and should behave as those
+     * do.  Measured against a real link in the same bar rather than against a number.
+     */
+    /*
+     * The REAL ShareButton, and the real SearchIconButton that DesktopNav renders for
+     * itself.  The first version of this suite used hand-written anchors carrying the
+     * classes I expected the components to have, so reverting SearchIconButton to Semantic's
+     * `item` left it green -- it was measuring my markup, not the app's.
+     */
+    const corner = <NavIconWrapper><ShareButton/></NavIconWrapper>;
+
+    const triggers = {
+        share: '.wrolpi-navbar-icon a',
+        search: '.wrolpi-navbar [aria-label="Search"]',
+    };
+
+    beforeEach(() => cy.mountUI(
+        <MemoryRouter><div style={{width: 1400}}>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={corner}
+            />
+        </div></MemoryRouter>,
+    ));
+
+    Object.entries(triggers).forEach(([name, selector]) => {
+        it(`gives ${name} a pointer and the bar's full height`, () => {
+            cy.get('.wrolpi-navbar').should(($nav) => {
+                const bar = $nav[0].getBoundingClientRect().height;
+                const trigger = $nav[0].querySelector(selector.replace('.wrolpi-navbar ', ''));
+
+                expect(trigger, `${name} is in the bar`).to.not.be.null;
+                expect(getComputedStyle(trigger).cursor, `${name} cursor`).to.equal('pointer');
+                expect(trigger.getBoundingClientRect().height, `${name} hit area`)
+                    .to.be.closeTo(bar, 1);
+            });
+        });
+
+        it(`highlights ${name} on hover, as a link does`, () => {
+            /*
+             * The highlight is what tells a user the glyph is a control at all, and it is
+             * the half of the complaint that a cursor check does not cover.
+             *
+             * `:hover` cannot be forced -- no event applies it, and getComputedStyle will
+             * never report it -- so the real stylesheets are searched for a hover rule this
+             * element matches that paints a background.  Resolved against the live CSSOM
+             * rather than a file, so it fails if the rule is edited, dropped, or written
+             * with a selector that misses.
+             */
+            cy.get(selector).should(($el) => {
+                const element = $el[0];
+                const painted = [...document.styleSheets].flatMap((sheet) => {
+                    try {
+                        return [...sheet.cssRules];
+                    } catch (e) {
+                        return []; // A cross-origin sheet; none of ours are.
+                    }
+                }).filter(rule => rule.selectorText
+                    && rule.selectorText.includes(':hover')
+                    && rule.style.backgroundColor
+                    && rule.selectorText.split(',').some((selector) => {
+                        const resting = selector.replace(/:hover/g, '').trim();
+                        try {
+                            return resting && element.matches(resting);
+                        } catch (e) {
+                            return false;
+                        }
+                    }));
+
+                expect(painted.map(rule => rule.selectorText), `${name} hover rule`)
+                    .to.not.be.empty;
+            });
+        });
+    });
+});
+
+describe('the navbar recalculates when the corner changes, not only the window', () => {
+    /*
+     * The corner is not a fixed width.  The ⌘K hint beside the search glyph renders only
+     * once `useKeyboardDetected` has seen a keypress, so it appears at an arbitrary later
+     * moment; the load, memory, temperature and drive warnings appear and vanish as the
+     * machine's state changes.  Each one changes the room the links have, and none of them
+     * resizes the container.
+     *
+     * With only the container observed nothing recalculated, and the bar wrapped -- which is
+     * why the same viewport wrapped or not depending on whether the user had touched a key,
+     * and why the width sweep could pass while the real bar was broken.  The sweep measures
+     * a bar whose corner never changes after mount; this one changes it.
+     */
+    const GrowingCorner = () => {
+        // Stands in for the ⌘K hint and for a warning icon arriving: a corner that is one
+        // width when the bar is measured and a wider one a moment later.
+        const [grown, setGrown] = React.useState(false);
+        React.useEffect(() => {
+            const timer = setTimeout(() => setGrown(true), 150);
+            return () => clearTimeout(timer);
+        }, []);
+        return <NavIconWrapper>
+            <span data-testid='corner-filler'
+                  style={{display: 'inline-block', width: grown ? 180 : 20}}/>
+        </NavIconWrapper>;
+    };
+
+    const mountGrowing = (width) => cy.mountUI(
+        <MemoryRouter><div style={{width}}>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={<GrowingCorner/>}
+            />
+        </div></MemoryRouter>,
+    );
+
+    it('gives up links when the corner grows after the bar was measured', () => {
+        mountGrowing(900);
+
+        // The corner has finished growing...
+        cy.get('[data-testid="corner-filler"]').should(($filler) => {
+            expect($filler[0].getBoundingClientRect().width, 'the corner grew').to.equal(180);
+        });
+
+        // ...and the bar is still one row, which it can only be if it recalculated.
+        cy.get('.wrolpi-navbar').should(($nav) => {
+            const rows = new Set([...$nav[0].querySelectorAll('.wrolpi-navbar-link')]
+                .map(link => Math.round(link.getBoundingClientRect().top)));
+            expect([...rows], 'every link shares one row').to.have.length(1);
+        });
+    });
+
+    it('takes the links back when the corner shrinks again', () => {
+        /*
+         * The inverse, and the reason to recalculate rather than simply reserve the widest
+         * corner the bar might ever have: a warning icon that clears must give its space
+         * back, or the bar keeps a permanently shortened set of links until the next resize.
+         */
+        mountGrowing(900);
+
+        cy.get('[data-testid="corner-filler"]').should(($filler) => {
+            expect($filler[0].getBoundingClientRect().width).to.equal(180);
+        });
+
+        cy.get('.wrolpi-navbar').then(($nav) => {
+            const shrunken = $nav[0].querySelectorAll('.wrolpi-navbar-link').length;
+
+            // Shrink the corner back, as a cleared warning would.
+            cy.get('[data-testid="corner-filler"]').then(($filler) => {
+                $filler[0].style.width = '20px';
+            });
+
+            cy.get('.wrolpi-navbar').should(($after) => {
+                expect($after[0].querySelectorAll('.wrolpi-navbar-link').length,
+                    'links come back when the corner clears').to.be.greaterThan(shrunken);
+            });
+        });
+    });
+});
+
+describe('the global search modal shows its results', () => {
+    /*
+     * The suggestion list overlays the page everywhere else, and should: a list that reflows
+     * the page underneath while you type is unusable.  Inside the search modal that same rule
+     * failed twice over.  An absolutely positioned list contributes no height, so the modal
+     * panel sized itself to the search box alone -- 114px -- and the panel's own
+     * `overflow: auto` then clipped the list at that edge.  What the user got was a search
+     * box and the first line of the first group, with the page showing through below.
+     *
+     * The real SearchBox, in a panel with the modal's overflow, so the class that carries the
+     * fix comes from the component rather than from markup written here.
+     */
+    const results = {
+        channels: {
+            name: 'Channels',
+            results: Array.from({length: 8}, (unused, index) => ({
+                title: `Channel ${index + 1}`, description: 'A channel of videos',
+            })),
+        },
+        domains: {
+            name: 'Domains',
+            results: Array.from({length: 8}, (unused, index) => ({
+                title: `example${index + 1}.com`, description: 'An archived domain',
+            })),
+        },
+    };
+
+    // The modal panel: Mantine caps its height and scrolls it, which is what did the clipping.
+    const panel = (children) => <div className='fake-modal-content'
+                                     style={{maxHeight: 504, overflow: 'auto', width: 440}}>
+        {children}
+    </div>;
+
+    // The list is a combobox: it opens on typing, as it does for a real user.
+    const openSuggestions = () => cy.get('.wrolpi-searchbox input').type('n');
+
+    it('lays the suggestions out inside the panel rather than over the page', () => {
+        cy.mountUI(panel(<div className='wrolpi-search-modal'>
+            <SearchBox value='chan' results={results} onResultSelect={() => {}}/>
+        </div>));
+        openSuggestions();
+
+        cy.get('.wrolpi-searchbox-results').should(($results) => {
+            expect(getComputedStyle($results[0]).position, 'the list is in flow')
+                .to.equal('static');
+        });
+    });
+
+    it('grows the panel to fit them, so nothing is clipped', () => {
+        cy.mountUI(panel(<div className='wrolpi-search-modal'>
+            <SearchBox value='chan' results={results} onResultSelect={() => {}}/>
+        </div>));
+        openSuggestions();
+
+        cy.get('.fake-modal-content').should(($panel) => {
+            const box = $panel[0].getBoundingClientRect();
+            const list = $panel[0].querySelector('.wrolpi-searchbox-results')
+                .getBoundingClientRect();
+
+            expect(list.height, 'the list has results to show').to.be.greaterThan(100);
+            // The whole list is inside the panel, not spilling past its clipped edge.
+            expect(list.bottom, 'the list ends inside the panel')
+                .to.be.at.most(box.bottom + 0.5);
+            // And the panel actually grew for it, rather than the list having been squashed.
+            expect(box.height, 'the panel grew to hold the list')
+                .to.be.greaterThan(list.height);
+        });
+    });
+
+    it('is a real constraint: outside the modal the list still overlays', () => {
+        /*
+         * The inverse.  If the rule leaked to every searchbox, the file browser and the
+         * videos page would push their content down on every keystroke -- a worse bug than
+         * the one being fixed, and one this suite would otherwise not notice.
+         */
+        cy.mountUI(panel(
+            <SearchBox value='chan' results={results} onResultSelect={() => {}}/>
+        ));
+        openSuggestions();
+
+        cy.get('.wrolpi-searchbox-results').should(($results) => {
+            expect(getComputedStyle($results[0]).position, 'still an overlay elsewhere')
+                .to.equal('absolute');
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -2134,18 +2134,38 @@ describe('the navigation bar is legible on every colour a user can pick', () => 
             });
         });
 
-        it(`gives its icons the same foreground as its links in ${theme}`, () => {
-            // The actual complaint was about the icons, not the words.  They take `color`
-            // by inheritance, which is a thing a stylesheet can quietly break.
+        it(`gives EVERY icon in the corner the same foreground as its links in ${theme}`, () => {
+            /*
+             * The actual complaint was about the icons, not the words -- and about two of
+             * them specifically, the search glyph and the hamburger, which came out blue on
+             * every bar in every theme while the rest of the bar was correct.
+             *
+             * They inherit nothing.  An anchor takes `a {color: var(--blue)}` from
+             * tokens.css, which outranks the bar's inherited value; a Mantine ActionIcon
+             * paints `--ai-color`, its own themed blue, and Mantine writes that variable
+             * INLINE so no stylesheet variable can reach it.  Three routes to a colour, of
+             * which one worked.
+             *
+             * `querySelectorAll`, and the count asserted, because the version of this test
+             * that shipped in the first pass read `querySelector('...svg')` -- one element,
+             * the first, which was a plain inheriting Icon.  It claimed every icon and
+             * measured the only one that was never broken.
+             */
             barsFor(theme);
 
             navColorNames.forEach((color) => {
                 cy.get(`[data-nav-sample="${color}"]`).should(($sample) => {
                     const link = $sample[0].querySelector('.wrolpi-navbar-link');
-                    const icon = $sample[0].querySelector('.wrolpi-navbar-right svg');
-                    expect(icon, `${theme}/${color} has an icon to measure`).to.not.be.null;
-                    expect(getComputedStyle(icon).color, `${theme}/${color} icon colour`)
-                        .to.equal(getComputedStyle(link).color);
+                    const expected = getComputedStyle(link).color;
+                    const icons = [...$sample[0].querySelectorAll('.wrolpi-navbar-right svg')];
+
+                    // Two bare Icons, one inside an anchor, one inside an ActionIcon.  If
+                    // this drops, the loop below is covering less than it says.
+                    expect(icons.length, `${theme}/${color} icons found`).to.equal(4);
+                    icons.forEach((icon, index) => {
+                        expect(getComputedStyle(icon).color, `${theme}/${color} icon ${index}`)
+                            .to.equal(expected);
+                    });
                 });
             });
         });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -12,6 +12,7 @@ import {clearToasts, toast} from './toast';
 import {monochromeThemes, themeNames} from '../../themes/names';
 import {navColorNames} from '../../themes/navColors';
 import {NavBarSample} from '../ThemeSamplePage';
+import {DesktopNav, NavIconWrapper} from '../Nav';
 
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
@@ -2214,6 +2215,190 @@ describe('the navigation bar is legible on every colour a user can pick', () => 
                 // And the one that changed is the one that was unreadable.
                 expect(toRgb(brown), 'brown no longer takes --btn-text')
                     .to.not.equal(toRgb('#0a0000'));
+            });
+        });
+    });
+});
+
+describe('the navigation bar corner', () => {
+    /*
+     * The real <DesktopNav/>, which takes its colours, home link and indicators as props and
+     * so needs none of the polling hooks <NavBar/> wires up.  The indicators are the shapes
+     * the app actually puts there, in the real NavIconWrapper: a bare-icon anchor (share), an
+     * unwrapped anchor (search), and two IconButtons (hotspot, theme picker).  Those three
+     * shapes take their geometry by three different routes, which is the whole problem.
+     */
+    const indicators = <>
+        <NavIconWrapper>
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a href='#' data-testid='share'><Icon name='share' size='large'/></a>
+        </NavIconWrapper>
+        <NavIconWrapper>
+            <IconButton data-testid='hotspot' label='Hotspot' variant='subtle' icon={() =>
+                <IconStack corner={<Icon name='x' size={12}/>} label='Hotspot'>
+                    <Icon name='wifi' size='large'/>
+                </IconStack>}/>
+        </NavIconWrapper>
+        <NavIconWrapper>
+            <IconButton data-testid='theme' icon='sun' label='Theme' variant='subtle'/>
+        </NavIconWrapper>
+    </>;
+
+    const mountBar = (width, theme = 'light') => cy.mountUI(
+        <MemoryRouter><div style={{width}}>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={indicators}
+            />
+        </div></MemoryRouter>,
+        {theme},
+    );
+
+    const centreOf = (rect) => rect.top + rect.height / 2;
+
+    it('centres every indicator on the bar, whatever shape it is', () => {
+        /*
+         * The bug this replaces was a 0.8em top margin on the slot, which the corner centres
+         * along with its content and so half-applied as a ~6px downward shift.  It looked
+         * correct on the anchors and wrong on the two IconButtons, because an anchor's glyph
+         * already sits high inside a line box that reserves descender space.
+         *
+         * Measured against the bar's own centre rather than against each other: three things
+         * can be equally and consistently wrong, and were.
+         */
+        mountBar(1400);
+
+        cy.get('.wrolpi-navbar').should(($nav) => {
+            const bar = centreOf($nav[0].getBoundingClientRect());
+            ['share', 'hotspot', 'theme'].forEach((name) => {
+                const glyph = $nav[0].querySelector(`[data-testid="${name}"] svg`);
+                expect(glyph, `${name} has a glyph`).to.not.be.null;
+                expect(centreOf(glyph.getBoundingClientRect()), `${name} vertical centre`)
+                    .to.be.closeTo(bar, 1.5);
+            });
+        });
+    });
+
+    it('gives the right-hand links the same hit area as the left-hand ones', () => {
+        /*
+         * Help and Admin highlighted only a box around their text, while Videos and
+         * Statistics highlighted the full height of the bar.  The corner is a nested flex
+         * container that centres its children, so a link inside it is sized to its content
+         * while a link that is a direct child of the bar is stretched by `align-items:
+         * stretch`.  Same class, same rules, different parent.
+         *
+         * The hover background is painted on the link box, so this IS the hover affordance.
+         */
+        mountBar(1400);
+
+        cy.get('.wrolpi-navbar').should(($nav) => {
+            const bar = $nav[0].getBoundingClientRect().height;
+            const links = [...$nav[0].querySelectorAll('.wrolpi-navbar-link')];
+            const corner = [...$nav[0]
+                .querySelectorAll('.wrolpi-navbar-right .wrolpi-navbar-link')];
+
+            // Help and Admin.  If the corner has no links this passes on an empty list.
+            expect(corner.length, 'links in the corner').to.be.at.least(2);
+            expect(links.length, 'links in total').to.be.greaterThan(corner.length);
+
+            corner.forEach((link) => {
+                expect(link.getBoundingClientRect().height, `${link.textContent} hit area`)
+                    .to.be.closeTo(bar, 1);
+            });
+        });
+    });
+
+    it('is a real constraint: the left-hand links already filled the bar', () => {
+        // Without this the case above could pass by the bar having collapsed to the height
+        // of its text, which would be a different bug wearing the same number.
+        mountBar(1400);
+
+        cy.get('.wrolpi-navbar').should(($nav) => {
+            const bar = $nav[0].getBoundingClientRect();
+            const first = $nav[0].querySelector('.wrolpi-navbar-link');
+
+            expect(bar.height, 'the bar is taller than a line of text').to.be.greaterThan(40);
+            expect(first.getBoundingClientRect().height, 'a left-hand link fills it')
+                .to.be.closeTo(bar.height, 1);
+        });
+    });
+});
+
+describe('the navigation bar never breaks onto a second line', () => {
+    /*
+     * The bar wraps as a failsafe (`flex-wrap: wrap`) and useOverflowNav is supposed to make
+     * that unreachable by moving links into "More" before they overflow.  At certain widths
+     * it did not, and the bar took two rows.
+     *
+     * The arithmetic was off by the bar's own horizontal padding: `recalculate` measured the
+     * WRAPPER div's offsetWidth and subtracted only the home link and the corner, so it
+     * believed it had ~8px more room than the row actually has.  Any width where the last
+     * link overhangs by less than that got shown and wrapped -- a narrow band, which is why
+     * it appeared only "at certain widths" while resizing.
+     *
+     * Swept rather than spot-checked, because a band that narrow is precisely what a
+     * spot-check steps over.
+     */
+    /*
+     * Hoisted, not written inline into `icons={...}`.  The icon-name audit in ui.test.js
+     * reads every string literal inside such an expression as an icon name, so an inline
+     * `label='Theme' variant='subtle'` fails that test with two names nobody wrote.
+     */
+    const themeIcon = <NavIconWrapper>
+        <IconButton icon='sun' label='Theme' variant='subtle'/>
+    </NavIconWrapper>;
+
+    const mountAt = (width) => cy.mountUI(
+        <MemoryRouter><div style={{width}}>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={themeIcon}
+            />
+        </div></MemoryRouter>,
+    );
+
+    // Wide enough that every link fits, so this is the height of exactly one row.
+    let singleRow;
+
+    before(() => {
+        mountAt(1600);
+        cy.get('.wrolpi-navbar').then(($nav) => {
+            singleRow = $nav[0].getBoundingClientRect().height;
+            expect(singleRow, 'a single row has a height to compare against')
+                .to.be.greaterThan(30);
+        });
+    });
+
+    /*
+     * 6px steps across the range where links start moving into More.  Fine enough to land
+     * inside an 8px band wherever it falls.
+     */
+    const widths = [];
+    for (let width = 1180; width >= 640; width -= 6) widths.push(width);
+
+    it('stays one row at every width from 1180 down to 640', () => {
+        widths.forEach((width) => {
+            mountAt(width);
+            cy.get('.wrolpi-navbar').should(($nav) => {
+                expect($nav[0].getBoundingClientRect().height, `bar height at ${width}px`)
+                    .to.be.at.most(singleRow + 2);
+            });
+        });
+    });
+
+    it('keeps every visible link inside the bar rather than clipping it', () => {
+        // The failure mode a naive "just use nowrap" fix would introduce: no second row,
+        // but Admin hanging off the right edge where nothing can reach it.
+        [1180, 1000, 860, 720, 640].forEach((width) => {
+            mountAt(width);
+            cy.get('.wrolpi-navbar').should(($nav) => {
+                const bar = $nav[0].getBoundingClientRect();
+                [...$nav[0].querySelectorAll('.wrolpi-navbar-link')].forEach((link) => {
+                    expect(link.getBoundingClientRect().right, `${link.textContent} at ${width}px`)
+                        .to.be.at.most(bar.right + 0.5);
+                });
             });
         });
     });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -10,6 +10,8 @@ import {CardPoster, contrastingColor, HelpHeader, LoadStatistic} from '../Common
 import {Notifications} from '@mantine/notifications';
 import {clearToasts, toast} from './toast';
 import {monochromeThemes, themeNames} from '../../themes/names';
+import {navColorNames} from '../../themes/navColors';
+import {NavBarSample} from '../ThemeSamplePage';
 
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
@@ -2068,6 +2070,131 @@ describe('pagination sits in the middle of its container', () => {
                 .map(button => button.getBoundingClientRect());
             expect(Math.min(...buttons.map(b => b.left)), 'nothing hangs off the left')
                 .to.be.at.least(container.left - 0.5);
+        });
+    });
+});
+
+describe('the navigation bar is legible on every colour a user can pick', () => {
+    /*
+     * The bar's background is the one surface the USER chooses, by hue name, and each theme
+     * resolves those twelve names to twelve of its own colours.  Forty-eight backgrounds; the
+     * links and status icons have to read on all of them.  They did not -- every one was
+     * drawn in `--btn-text`, near-black in three of the four themes, against backgrounds like
+     * night's `--brown` (#451212).  That glyph was 1.33:1 against the bar behind it.
+     *
+     * navColors.test.js measures the mapping against the palette parsed out of tokens.css,
+     * which is the cheap and exhaustive half.  What it cannot see is whether the value the
+     * mapping returns reaches the pixels: whether the tokens resolve through the cascade,
+     * whether the style lands on the bar, and what an icon inside it actually inherits.  So
+     * this measures the painted result and holds it against the number the component claims.
+     *
+     * `NavBarSample` is the gallery's bar rather than <NavBar/> itself, which needs the
+     * settings, status and worker contexts and a dozen polling hooks.  Both build their style
+     * with the same `navBarStyle(useNavColors(colour))` call, and navColors.test.js has a
+     * source guard holding NavBar to that.
+     */
+    const barsFor = (theme) => {
+        cy.mountUI(<div>
+            {navColorNames.map(color => <NavBarSample key={color} color={color}/>)}
+        </div>, {theme});
+    };
+
+    themeNames.forEach((theme) => {
+        it(`paints a resolved background for all twelve colours in ${theme}`, () => {
+            barsFor(theme);
+
+            navColorNames.forEach((color) => {
+                cy.get(`[data-nav-sample="${color}"] .wrolpi-navbar`).should(($nav) => {
+                    const background = getComputedStyle($nav[0]).backgroundColor;
+                    // An unresolved token paints nothing at all, and a transparent bar over
+                    // the page would read as "the colour just looks wrong" rather than as a
+                    // broken style.
+                    expect(background, `${theme}/${color} bar background`)
+                        .to.not.equal('rgba(0, 0, 0, 0)');
+                });
+            });
+        });
+
+        it(`clears 3:1 on every colour in ${theme}`, () => {
+            /*
+             * 3:1 is the WCAG floor for graphical objects, which is what these icons are.
+             * Twelve of the forty-eight combinations were below it before measurement.
+             * Ten are still under 4.5:1 and cannot be lifted by any foreground -- a
+             * monochrome theme resolves all twelve names onto one ramp, and a mid-tone of a
+             * hue carries no text of that same hue.  That residue is the palette's, and it
+             * is printed beside each sample in the gallery so it can be decided on.
+             */
+            barsFor(theme);
+
+            navColorNames.forEach((color) => {
+                cy.contrastRatio(`[data-nav-sample="${color}"] .wrolpi-navbar-link`)
+                    .then((ratio) => {
+                        expect(ratio, `${theme}/${color} link contrast`).to.be.greaterThan(3);
+                    });
+            });
+        });
+
+        it(`gives its icons the same foreground as its links in ${theme}`, () => {
+            // The actual complaint was about the icons, not the words.  They take `color`
+            // by inheritance, which is a thing a stylesheet can quietly break.
+            barsFor(theme);
+
+            navColorNames.forEach((color) => {
+                cy.get(`[data-nav-sample="${color}"]`).should(($sample) => {
+                    const link = $sample[0].querySelector('.wrolpi-navbar-link');
+                    const icon = $sample[0].querySelector('.wrolpi-navbar-right svg');
+                    expect(icon, `${theme}/${color} has an icon to measure`).to.not.be.null;
+                    expect(getComputedStyle(icon).color, `${theme}/${color} icon colour`)
+                        .to.equal(getComputedStyle(link).color);
+                });
+            });
+        });
+
+        it(`paints the ratio it reports in ${theme}`, () => {
+            /*
+             * Ties the number to the pixels.  Without this the gallery could print a
+             * comfortable figure beside a bar drawn in something else entirely, and both
+             * halves would look right on their own.
+             */
+            barsFor(theme);
+
+            navColorNames.forEach((color) => {
+                cy.get(`[data-nav-sample-ratio="${color}"]`).invoke('text').then((text) => {
+                    const reported = parseFloat(text);
+                    expect(reported, `${theme}/${color} reported a ratio`).to.be.greaterThan(1);
+                    cy.contrastRatio(`[data-nav-sample="${color}"] .wrolpi-navbar-link`)
+                        .then((painted) => {
+                            expect(painted, `${theme}/${color} painted vs reported`)
+                                .to.be.closeTo(reported, 0.05);
+                        });
+                });
+            });
+        });
+    });
+
+    it('does not simply use --btn-text everywhere, which is what it replaced', () => {
+        /*
+         * The inverse.  Every case above would pass on the old fixed foreground in the two
+         * themes where `--btn-text` happens to be the right end of the palette, so without
+         * this the suite could go green on a revert.  Night is where the difference is
+         * largest: `--brown` takes `--white` (#ff8a8a) and `--red` keeps `--btn-text`, so
+         * the bar's foreground is demonstrably not one value.
+         */
+        cy.mountUI(<div>
+            <NavBarSample color='brown'/>
+            <NavBarSample color='red'/>
+        </div>, {theme: 'night'});
+
+        cy.get('[data-nav-sample="brown"] .wrolpi-navbar-link').then(($brown) => {
+            cy.get('[data-nav-sample="red"] .wrolpi-navbar-link').then(($red) => {
+                const brown = getComputedStyle($brown[0]).color;
+                const red = getComputedStyle($red[0]).color;
+                expect(brown, 'brown and red bars take different foregrounds')
+                    .to.not.equal(red);
+                // And the one that changed is the one that was unreadable.
+                expect(toRgb(brown), 'brown no longer takes --btn-text')
+                    .to.not.equal(toRgb('#0a0000'));
+            });
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -2199,8 +2199,13 @@ describe('the navigation bar is legible on every colour a user can pick', () => 
          * The inverse.  Every case above would pass on the old fixed foreground in the two
          * themes where `--btn-text` happens to be the right end of the palette, so without
          * this the suite could go green on a revert.  Night is where the difference is
-         * largest: `--brown` takes `--white` (#ff8a8a) and `--red` keeps `--btn-text`, so
-         * the bar's foreground is demonstrably not one value.
+         * largest: `--brown` takes `--white` and `--red` keeps `--btn-text`, so the bar's
+         * foreground is demonstrably not one value.
+         *
+         * `--btn-text` is READ from the theme rather than written out as a hex.  The unit
+         * tests parse tokens.css precisely so a palette edit cannot leave a stale claim
+         * behind, and a literal here would be the one place that rule was broken -- it would
+         * either go stale or quietly stop testing anything if night's token moved.
          */
         cy.mountUI(<div>
             <NavBarSample color='brown'/>
@@ -2211,11 +2216,19 @@ describe('the navigation bar is legible on every colour a user can pick', () => 
             cy.get('[data-nav-sample="red"] .wrolpi-navbar-link').then(($red) => {
                 const brown = getComputedStyle($brown[0]).color;
                 const red = getComputedStyle($red[0]).color;
+                const btnText = getComputedStyle(document.documentElement)
+                    .getPropertyValue('--btn-text');
+
+                // The premise: the token resolved.  `toRgb` throws on an unresolved value
+                // rather than letting the comparison below pass by comparing nothing.
+                expect(toRgb(btnText), 'night --btn-text resolved').to.match(/^rgb/);
                 expect(brown, 'brown and red bars take different foregrounds')
                     .to.not.equal(red);
                 // And the one that changed is the one that was unreadable.
                 expect(toRgb(brown), 'brown no longer takes --btn-text')
-                    .to.not.equal(toRgb('#0a0000'));
+                    .to.not.equal(toRgb(btnText));
+                // While red, which was always legible, still does.
+                expect(toRgb(red), 'red still takes --btn-text').to.equal(toRgb(btnText));
             });
         });
     });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -367,6 +367,22 @@ html[data-theme="amber"] .wrolpi-searchbox-control:focus-within {
     border-top: none;
 }
 
+/*
+ * Inside the global search modal the suggestions ARE the panel's content, so they sit in
+ * flow instead of floating over the page.
+ *
+ * Overlaying is right everywhere else -- a list that reflows the page while you type is
+ * unusable -- but in a modal it fails twice.  An absolutely positioned list contributes no
+ * height, so the panel sized itself to the search box alone (114px), and the panel's own
+ * `overflow: auto` then clipped the list at that edge: the modal showed an input and the
+ * first line of the first group.  In flow, the panel grows to fit and its own max-height
+ * does the scrolling.
+ */
+.wrolpi-search-modal .wrolpi-searchbox-results {
+    position: static;
+    max-height: min(50vh, 420px);
+}
+
 .wrolpi-searchbox-group-name {
     padding: 6px 10px;
     font-size: 11px;

--- a/app/src/hooks/useOverflowNav.js
+++ b/app/src/hooks/useOverflowNav.js
@@ -84,7 +84,26 @@ export function useOverflowNav({links, containerRef, homeRef, rightMenuRef, more
         setIsReady(true);
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // ResizeObserver for ongoing resizes.
+    /*
+     * Recalculate when the container resizes -- and when either of the two fixed blocks
+     * either side of the links does, which is the part that was missing.
+     *
+     * The corner does not keep a constant width.  The ⌘K hint beside the search glyph only
+     * renders once `useKeyboardDetected` has seen a keypress, so it materialises at an
+     * arbitrary later moment and widens the corner by about 30px.  The status indicators do
+     * the same in both directions: the load, memory, temperature and drive warnings appear
+     * and disappear as the machine's state changes, and a Raspberry Pi under load grows two
+     * or three of them.
+     *
+     * Every one of those changes the space the links have, and none of them changes the
+     * container's size -- so with only the container observed, nothing recalculated and the
+     * bar simply wrapped.  That is the other half of "at certain widths": whether the extra
+     * width overflowed depended on how much slack the last-fitted link happened to leave, so
+     * the same viewport wrapped or not depending on whether the user had touched a key.
+     *
+     * This converges rather than oscillating: the More button lives outside the corner, so
+     * the corner's width does not depend on how many links are visible.
+     */
     useLayoutEffect(() => {
         const container = containerRef.current;
         if (!container) return;
@@ -93,8 +112,16 @@ export function useOverflowNav({links, containerRef, homeRef, rightMenuRef, more
             recalculate();
         });
         observer.observe(container);
+        if (rightMenuRef.current) {
+            observer.observe(rightMenuRef.current);
+        }
+        // `homeRef` is a `display: contents` span, which has no box of its own to observe.
+        const homeEl = homeRef.current?.firstElementChild;
+        if (homeEl) {
+            observer.observe(homeEl);
+        }
         return () => observer.disconnect();
-    }, [containerRef, recalculate]);
+    }, [containerRef, homeRef, rightMenuRef, recalculate]);
 
     const visibleLinks = links.slice(0, visibleCount);
     const overflowLinks = links.slice(visibleCount);

--- a/app/src/hooks/useOverflowNav.js
+++ b/app/src/hooks/useOverflowNav.js
@@ -15,7 +15,25 @@ export function useOverflowNav({links, containerRef, homeRef, rightMenuRef, more
         const container = containerRef.current;
         if (!container || itemWidths.current.length === 0) return;
 
-        const containerWidth = container.offsetWidth;
+        /*
+         * The width a row of links actually has, which is NOT the wrapper's.
+         *
+         * The bar carries `padding: 0 0.25em`, and this measured the wrapper and subtracted
+         * only the home link and the corner -- so it believed it had about 8px more room
+         * than the row does.  Any width where the last link overhangs by less than that was
+         * kept in the bar, the bar wrapped, and the user got two rows.  A narrow band, which
+         * is why it showed up only "at certain widths" while resizing rather than always.
+         *
+         * SAFETY covers subpixel rounding on top: item widths come from
+         * getBoundingClientRect and are fractional, while clientWidth is an integer.
+         */
+        const SAFETY = 1;
+        const bar = container.firstElementChild || container;
+        const barStyle = window.getComputedStyle(bar);
+        const containerWidth = bar.clientWidth
+            - (parseFloat(barStyle.paddingLeft) || 0)
+            - (parseFloat(barStyle.paddingRight) || 0)
+            - SAFETY;
         const homeEl = homeRef.current?.firstElementChild || homeRef.current;
         const homeWidth = homeEl ? homeEl.getBoundingClientRect().width : 0;
         const rightWidth = rightMenuRef.current ? rightMenuRef.current.getBoundingClientRect().width : 0;

--- a/app/src/themes/contrast.ts
+++ b/app/src/themes/contrast.ts
@@ -1,0 +1,72 @@
+/*
+ * WCAG contrast primitives.
+ *
+ * These live in `themes/` rather than in Common.js because theme code needs them and
+ * Common.js is a large module that imports half the component library -- `themes/`
+ * importing it is how an import cycle starts, and this app has already paid for one of
+ * those (see import-cycles.test.js).  Common.js re-exports `contrastRatio` from here so
+ * its existing callers are unaffected.
+ */
+
+/** A hex colour as [r, g, b], accepting both `#rrggbb` and the shorthand `#rgb`. */
+export function hexToRGBArray(color: string): number[] | undefined {
+    let hex = (typeof color === 'string' ? color : '').trim().replace(/^#/, '');
+    if (hex.length === 3) {
+        // #abc means #aabbcc, not #0a0b0c.
+        hex = hex.split('').map(digit => digit + digit).join('');
+    }
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+        return undefined;
+    }
+    const rgb: number[] = [];
+    for (let i = 0; i <= 2; i++) rgb[i] = parseInt(hex.substr(i * 2, 2), 16);
+    return rgb;
+}
+
+/**
+ * WCAG relative luminance: sRGB channels linearised first, then Rec. 709 weighted.
+ *
+ * The linearisation is the part that matters.  Weighting the gamma-encoded bytes directly
+ * is a rough approximation that misjudges mid-tone blues and purples badly enough to pick
+ * the wrong text colour for them.
+ */
+export function relativeLuminance(color: string | number[]): number {
+    const rgb = (typeof color === 'string') ? hexToRGBArray(color) : color;
+    if (!rgb) {
+        return 0;
+    }
+    const linear = rgb.map(value => {
+        const channel = value / 255;
+        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+    });
+    return (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2]);
+}
+
+/** WCAG contrast ratio between two colours, from 1:1 (identical) to 21:1 (black on white). */
+export function contrastRatio(a: string | number[], b: string | number[]): number {
+    const luminances = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+    return (luminances[0] + 0.05) / (luminances[1] + 0.05);
+}
+
+/**
+ * Whichever candidate actually reads best on `background`.
+ *
+ * Measures every option rather than comparing a brightness figure to a threshold.  A
+ * threshold picks the worse of two options for every mid-tone -- which is the whole
+ * defect this exists to avoid -- and a mid-tone is exactly what a user picks when they
+ * choose a navbar colour.
+ *
+ * Ties go to the earlier candidate, so a caller can order them by preference.
+ */
+export function bestForeground(background: string, candidates: string[]): string | undefined {
+    let best: string | undefined;
+    let bestRatio = -1;
+    candidates.filter(Boolean).forEach((candidate) => {
+        const ratio = contrastRatio(candidate, background);
+        if (ratio > bestRatio) {
+            best = candidate;
+            bestRatio = ratio;
+        }
+    });
+    return best;
+}

--- a/app/src/themes/contrast.ts
+++ b/app/src/themes/contrast.ts
@@ -8,19 +8,59 @@
  * its existing callers are unaffected.
  */
 
-/** A hex colour as [r, g, b], accepting both `#rrggbb` and the shorthand `#rgb`. */
+/** A hex colour as [r, g, b], accepting `#rgb`, `#rrggbb`, and `#rrggbbaa`. */
 export function hexToRGBArray(color: string): number[] | undefined {
     let hex = (typeof color === 'string' ? color : '').trim().replace(/^#/, '');
-    if (hex.length === 3) {
-        // #abc means #aabbcc, not #0a0b0c.
+    if (hex.length === 3 || hex.length === 4) {
+        // #abc means #aabbcc, not #0a0b0c.  A fourth digit is alpha; see parseColor.
         hex = hex.split('').map(digit => digit + digit).join('');
     }
-    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+    if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) {
         return undefined;
     }
     const rgb: number[] = [];
     for (let i = 0; i <= 2; i++) rgb[i] = parseInt(hex.substr(i * 2, 2), 16);
     return rgb;
+}
+
+/**
+ * Any colour these measurements can actually read, as [r, g, b] — or undefined.
+ *
+ * Undefined matters as much as the value.  `relativeLuminance` used to return 0 for
+ * everything it could not parse, which is indistinguishable from black: a token written as
+ * `rgb(90, 79, 168)` measured as pure black, so the "best" foreground was chosen against a
+ * colour the theme does not contain, and the wrong one was frozen into the bar's inline
+ * style.  A caller that cannot tell "unreadable" from "black" cannot fall back, and the
+ * custom YAML themes ahead of us are exactly where a non-hex token will first appear.
+ *
+ * Alpha is deliberately dropped rather than rejected: WCAG contrast is defined on composited
+ * colour, and what a translucent value composites over is not knowable here.  Every token in
+ * tokens.css is opaque, so this only arises for a hand-written theme, where measuring the
+ * colour itself is a better answer than refusing.
+ */
+export function parseColor(color: string): number[] | undefined {
+    const value = (typeof color === 'string' ? color : '').trim();
+    if (!value) return undefined;
+    if (value.startsWith('#')) return hexToRGBArray(value);
+
+    // `rgb(90 79 168 / 0.5)` and `rgba(90, 79, 168, 0.5)` are both current syntax.
+    const functional = value.match(/^rgba?\(([^)]*)\)$/i);
+    if (functional) {
+        const parts = functional[1].split(/[\s,/]+/).filter(Boolean).slice(0, 3);
+        if (parts.length !== 3) return undefined;
+        const channels = parts.map((part) => {
+            // A percentage is 0-100 of full scale; a bare number is already 0-255.
+            const numeric = parseFloat(part);
+            if (Number.isNaN(numeric)) return NaN;
+            return part.includes('%') ? (numeric / 100) * 255 : numeric;
+        });
+        if (channels.some(Number.isNaN)) return undefined;
+        return channels.map(channel => Math.min(255, Math.max(0, channel)));
+    }
+
+    // A named colour, `hsl()`, `color-mix()`, or an unresolved `var()`.  Not measurable
+    // here, and saying so is the point.
+    return undefined;
 }
 
 /**
@@ -31,8 +71,11 @@ export function hexToRGBArray(color: string): number[] | undefined {
  * the wrong text colour for them.
  */
 export function relativeLuminance(color: string | number[]): number {
-    const rgb = (typeof color === 'string') ? hexToRGBArray(color) : color;
+    const rgb = (typeof color === 'string') ? parseColor(color) : color;
     if (!rgb) {
+        // Zero is black's luminance, so this is a lie -- but the signature has no way to
+        // say otherwise, and every caller that needs to distinguish the two asks
+        // `isMeasurable` first.
         return 0;
     }
     const linear = rgb.map(value => {
@@ -47,6 +90,9 @@ export function contrastRatio(a: string | number[], b: string | number[]): numbe
     const luminances = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
     return (luminances[0] + 0.05) / (luminances[1] + 0.05);
 }
+
+/** Whether a colour can be measured at all, as distinct from measuring as black. */
+export const isMeasurable = (color: string): boolean => parseColor(color) !== undefined;
 
 /**
  * Whichever candidate actually reads best on `background`.

--- a/app/src/themes/navColors.test.js
+++ b/app/src/themes/navColors.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {contrastRatio} from './contrast';
+import {contrastRatio, isMeasurable} from './contrast';
 import {defaultNavColor, navColorNames, navColorsFrom} from './navColors';
 import {themeNames} from './names';
 import {semanticUIColorMap} from '../components/Vars';
@@ -150,11 +150,11 @@ describe('the navbar foreground', () => {
 
 describe('what measurement cannot fix', () => {
     /*
-     * Eleven of the forty-eight combinations still sit under 4.5:1, and no choice of
+     * Ten of the forty-eight combinations still sit under 4.5:1, and no choice of
      * foreground will lift them, because the shortfall is in the BACKGROUND.
      *
      * A monochrome theme resolves all twelve colour names onto one red (or amber) ramp, and
-     * seven of night's land in the middle of it -- #b03030 is 2.91:1 from night's darkest red
+     * six of night's land in the middle of it -- #b03030 is 3.27:1 from night's darkest red
      * and 2.52:1 from its brightest, so the best available option is the one this picks and
      * it is still short.  There is no foreground in a one-hue palette that reads on a
      * mid-tone of that same hue; the fix, if the residue matters, is to the palette.
@@ -240,5 +240,87 @@ describe('when the tokens cannot be read', () => {
         const read = readerFor('light');
         expect(navColorsFrom(read, 'chartreuse').background)
             .toEqual(paletteOf('light')[`--${defaultNavColor}`]);
+    });
+});
+
+describe('a token this cannot measure', () => {
+    /*
+     * Every token in tokens.css is a hex, so this is about the custom YAML themes ahead of
+     * us -- the first place a palette will be written by hand, and the first place something
+     * other than a hex will appear.
+     *
+     * The failure it guards was silent and worse than doing nothing.  An unparseable colour
+     * measured as luminance zero, indistinguishable from black, so the bar chose its
+     * foreground against a colour the theme does not contain and then froze the wrong hex
+     * into an inline style, where CSS could no longer correct it.  Falling back leaves the
+     * bar painted by CSS: wrong about the foreground at worst, rather than about both.
+     */
+    const hexPalette = () => paletteOf('light');
+
+    /** The light palette with one token rewritten into some other notation. */
+    const readerWith = (overrides) => {
+        const palette = {...hexPalette(), ...overrides};
+        return (token) => palette[token] || '';
+    };
+
+    it('measures rgb() as readily as hex, since both are colours', () => {
+        // `--violet` is #5c4fa8 in light.  The same colour, written the other way, must
+        // produce the same answer rather than falling back.
+        const asHex = navColorsFrom(readerFor('light'), 'violet');
+        const asRgb = navColorsFrom(readerWith({'--violet': 'rgb(92, 79, 168)'}), 'violet');
+
+        expect(asRgb.color).toEqual(asHex.color);
+        expect(asRgb.ratio).toBeCloseTo(asHex.ratio, 4);
+    });
+
+    it('handles the modern space-separated form too', () => {
+        const asHex = navColorsFrom(readerFor('light'), 'violet');
+        const asRgb = navColorsFrom(readerWith({'--violet': 'rgb(92 79 168 / 1)'}), 'violet');
+
+        expect(asRgb.ratio).toBeCloseTo(asHex.ratio, 4);
+    });
+
+    it('falls back rather than measuring a background it cannot read', () => {
+        // `color-mix` is the shape a hand-written theme is most likely to reach for, and
+        // resolving it needs a browser.
+        const colors = navColorsFrom(
+            readerWith({'--olive': 'color-mix(in srgb, #6f7a24 60%, white)'}), 'olive');
+
+        expect(colors).toEqual({
+            background: 'var(--olive)', color: 'var(--btn-text)', ratio: null,
+        });
+    });
+
+    it('falls back when no candidate foreground can be read', () => {
+        const colors = navColorsFrom(readerWith({
+            '--btn-text': 'hsl(0 0% 100%)', '--black': 'rebeccapurple', '--white': 'hsl(0 0% 0%)',
+        }), 'violet');
+
+        expect(colors.ratio).toBeNull();
+    });
+
+    it('still measures when only SOME candidates are unreadable', () => {
+        /*
+         * The narrow case, and the reason the unreadable ones are filtered out rather than
+         * the whole measurement abandoned.  A theme that writes one token oddly should not
+         * lose the measurement for the other two.
+         */
+        const colors = navColorsFrom(
+            readerWith({'--white': 'oklch(0.9 0.1 20)'}), 'violet');
+
+        expect(colors.ratio).not.toBeNull();
+        expect([hexPalette()['--btn-text'], hexPalette()['--black']]).toContain(colors.color);
+    });
+
+    it('is a real constraint: an unreadable colour is NOT treated as black', () => {
+        /*
+         * Without this the fallback could be removed and every case above would still pass
+         * on `relativeLuminance` returning zero -- which is precisely the bug, because zero
+         * is a legitimate luminance and nothing downstream could tell the two apart.
+         */
+        expect(contrastRatio('color-mix(in srgb, red, blue)', '#ffffff'))
+            .toBeCloseTo(contrastRatio('#000000', '#ffffff'), 4);
+        expect(isMeasurable('color-mix(in srgb, red, blue)')).toBe(false);
+        expect(isMeasurable('#000000')).toBe(true);
     });
 });

--- a/app/src/themes/navColors.test.js
+++ b/app/src/themes/navColors.test.js
@@ -1,0 +1,244 @@
+import fs from 'fs';
+import path from 'path';
+import {contrastRatio} from './contrast';
+import {defaultNavColor, navColorNames, navColorsFrom} from './navColors';
+import {themeNames} from './names';
+import {semanticUIColorMap} from '../components/Vars';
+
+/*
+ * The navbar foreground, measured against the palette that actually ships.
+ *
+ * The bar's background is the one colour a user picks by name, so there are twelve of them
+ * per theme and forty-eight in total -- too many to eyeball, and the reason the bar drew
+ * near-black text on night's #451212 for as long as it did.  The tokens are parsed out of
+ * tokens.css rather than restated here: a list restated here is a list that agrees with
+ * itself while disagreeing with the stylesheet.
+ */
+
+const tokensCss = fs.readFileSync(path.join(__dirname, 'tokens.css'), 'utf8');
+
+/** Every `--name: #hex` declared in one theme's block. */
+const paletteOf = (theme) => {
+    const pattern = theme === 'light'
+        ? /:root,\s*html\[data-theme="light"]\s*{([^}]*)}/
+        : new RegExp(`html\\[data-theme="${theme}"]\\s*{([^}]*)}`);
+    const match = tokensCss.match(pattern);
+    if (!match) throw new Error(`tokens.css has no block for ${theme}`);
+    return Object.fromEntries([...match[1].matchAll(/(--[\w-]+)\s*:\s*(#[0-9a-fA-F]{3,6})\s*;/g)]
+        .map(m => [m[1], m[2]]));
+};
+
+/** A token reader for one theme, as `navColorsFrom` expects. */
+const readerFor = (theme) => {
+    const palette = paletteOf(theme);
+    return (name) => palette[name] || '';
+};
+
+/** Every (theme, navColor) pair, with what the bar resolves to. */
+const everyCombination = () => themeNames.flatMap(theme => navColorNames.map((navColor) => {
+    const read = readerFor(theme);
+    return {theme, navColor, palette: paletteOf(theme), ...navColorsFrom(read, navColor)};
+}));
+
+describe('the navbar palette', () => {
+    it('parses a palette for every theme', () => {
+        // The premise for every case below.  Without it a broken parser reads as a
+        // navbar that never fails, because there would be nothing to measure.
+        themeNames.forEach((theme) => {
+            const palette = paletteOf(theme);
+            expect({theme, colors: Object.keys(palette).length > 15}).toEqual(
+                {theme, colors: true});
+        });
+    });
+
+    it('offers exactly the colours the favicon has an icon for', () => {
+        /*
+         * `semanticUIColorMap` supplies the fixed hexes for `/favicon-<colour>.svg` and the
+         * `theme-color` meta tag -- a file on disk and OS chrome, neither of which can take a
+         * token.  A colour offered here with no icon there falls back to violet, so the bar
+         * and the browser tab would disagree.
+         */
+        expect([...navColorNames].sort()).toEqual(Object.keys(semanticUIColorMap).sort());
+    });
+
+    it('defaults to a colour it offers', () => {
+        expect(navColorNames).toContain(defaultNavColor);
+    });
+});
+
+describe('the navbar foreground', () => {
+    /** The tokens the bar is allowed to draw its text in. */
+    const candidatesOf = (palette) =>
+        [palette['--btn-text'], palette['--black'], palette['--white']];
+
+    it('takes a colour the theme itself supplies, never a literal black or white', () => {
+        /*
+         * A literal white pixel in night mode undoes the user's dark adaptation, which is the
+         * one thing that theme exists to prevent.  Night's "white" is #ff8a8a and its "black"
+         * is #2a0808; both are red, and both are among what this must choose between.
+         */
+        everyCombination().forEach(({theme, navColor, color, palette}) => {
+            expect({theme, navColor, color}).toEqual({
+                theme, navColor,
+                color: candidatesOf(palette).includes(color)
+                    ? color : `expected a theme token, got ${color}`,
+            });
+        });
+    });
+
+    it('picks the best of them, every time', () => {
+        // The invariant.  A brightness threshold picks the worse option for every mid-tone,
+        // and a mid-tone is exactly what a navbar colour is.
+        everyCombination().forEach(({theme, navColor, background, color, palette}) => {
+            const chosenRatio = contrastRatio(color, background);
+            const rejected = candidatesOf(palette)
+                .filter(candidate => candidate !== color)
+                .map(candidate => contrastRatio(candidate, background));
+
+            expect({theme, navColor, best: rejected.every(ratio => chosenRatio >= ratio)})
+                .toEqual({theme, navColor, best: true});
+        });
+    });
+
+    it('reports the ratio it measured', () => {
+        everyCombination().forEach(({theme, navColor, background, color, ratio}) => {
+            expect({theme, navColor, ratio: Number(ratio.toFixed(4))}).toEqual({
+                theme, navColor, ratio: Number(contrastRatio(color, background).toFixed(4)),
+            });
+        });
+    });
+
+    it('never does worse than the --btn-text it replaced', () => {
+        /*
+         * The regression guard, and the whole claim of the change.  `--btn-text` is a single
+         * value per theme, so it was right for whichever end of the palette it happened to
+         * match and wrong for the other -- 1.33:1 on night's brown.
+         */
+        everyCombination().forEach(({theme, navColor, background, ratio, palette}) => {
+            const before = contrastRatio(palette['--btn-text'], background);
+
+            expect({theme, navColor, atLeastAsGood: ratio >= before - 0.001})
+                .toEqual({theme, navColor, atLeastAsGood: true});
+        });
+    });
+
+    it('lifts every combination clear of 3:1', () => {
+        /*
+         * 3:1 is the WCAG floor for large text and for graphical objects, which is what the
+         * bar's icons are.  Twelve combinations were below it -- night's brown at 1.33:1 was
+         * a glyph the same colour as the bar behind it.
+         */
+        const failing = everyCombination()
+            .filter(({ratio}) => ratio < 3)
+            .map(({theme, navColor, ratio}) => `${theme}/${navColor} ${ratio.toFixed(2)}`);
+
+        expect(failing).toEqual([]);
+    });
+
+    it('is a real constraint: --btn-text does NOT clear 3:1', () => {
+        /*
+         * Without this the case above could pass on any mapping at all, including the one it
+         * replaced, and would prove nothing.  Seventeen combinations sat below 4.5:1 with a
+         * fixed foreground and twelve below 3:1.
+         */
+        const failing = everyCombination()
+            .filter(({background, palette}) => contrastRatio(palette['--btn-text'], background) < 3);
+
+        expect(failing.length).toBeGreaterThan(5);
+    });
+});
+
+describe('what measurement cannot fix', () => {
+    /*
+     * Eleven of the forty-eight combinations still sit under 4.5:1, and no choice of
+     * foreground will lift them, because the shortfall is in the BACKGROUND.
+     *
+     * A monochrome theme resolves all twelve colour names onto one red (or amber) ramp, and
+     * seven of night's land in the middle of it -- #b03030 is 2.91:1 from night's darkest red
+     * and 2.52:1 from its brightest, so the best available option is the one this picks and
+     * it is still short.  There is no foreground in a one-hue palette that reads on a
+     * mid-tone of that same hue; the fix, if the residue matters, is to the palette.
+     *
+     * Recorded as a number rather than a comment so it cannot quietly grow.  /theme-sample
+     * prints the measured ratio beside every sample, which is where this gets decided.
+     */
+    const belowAA = () => everyCombination()
+        .filter(({ratio}) => ratio < 4.5)
+        .map(({theme, navColor}) => `${theme}/${navColor}`);
+
+    it('leaves ten combinations short of 4.5:1, all of them mid-tones', () => {
+        expect(belowAA().sort()).toEqual([
+            'amber/blue', 'amber/grey', 'amber/teal',
+            'light/yellow',
+            'night/blue', 'night/green', 'night/grey', 'night/pink', 'night/teal',
+            'night/violet',
+        ]);
+    });
+
+    it('holds the worst case above 3:1 -- night/green, at 3.27', () => {
+        // Nothing is invisible any more, which is the bar this change had to clear.  The
+        // number is here so that a palette edit which makes it worse has to say so.
+        const worst = everyCombination().sort((a, b) => a.ratio - b.ratio)[0];
+
+        expect({combination: `${worst.theme}/${worst.navColor}`, above3: worst.ratio > 3})
+            .toEqual({combination: 'night/green', above3: true});
+    });
+
+    it('leaves none of them in dark, which has a full palette to draw on', () => {
+        // The contrast with the monochrome themes, and the evidence that the shortfall is
+        // the palette's rather than the mapping's.
+        expect(belowAA().filter(name => name.startsWith('dark/'))).toEqual([]);
+    });
+});
+
+describe('the bar the app actually renders', () => {
+    /*
+     * Nav.js draws two bars -- one for mobile, one for desktop -- and neither is reachable
+     * from a test that could measure it.  <NavBar/> needs the settings, status and file-worker
+     * contexts and a dozen polling hooks, and which of the two renders is decided by a media
+     * query.  ui-layout.cy.js measures the gallery's bar instead, which is the same chrome
+     * built with the same call; these hold Nav.js to that call, so a bar that stops going
+     * through the measurement cannot pass by being untested.
+     */
+    const source = fs.readFileSync(
+        path.join(__dirname, '../components/Nav.js'), 'utf8');
+
+    it('styles both bars through navBarStyle', () => {
+        const bars = [...source.matchAll(/className='wrolpi-navbar'[^>]*/g)].map(m => m[0]);
+
+        // Mobile and desktop.  If this drops to one, the case below is covering half of
+        // what it claims to.
+        expect(bars.length).toBe(2);
+        bars.forEach(bar => expect(bar).toContain('style={navBarStyle(navColors)}'));
+    });
+
+    it('never hardcodes the foreground on the bar again', () => {
+        // What it did before: one token for forty-eight backgrounds.
+        expect(source).not.toMatch(/color:\s*'var\(--btn-text\)'/);
+    });
+});
+
+describe('when the tokens cannot be read', () => {
+    /*
+     * jsdom resolves no stylesheet, and neither does the first render before the document
+     * has one.  The bar must still be painted by CSS then, and must still follow the theme --
+     * falling through to an empty `background` would leave a transparent bar over the page.
+     */
+    it('falls back to the tokens themselves', () => {
+        expect(navColorsFrom(() => '', 'olive')).toEqual({
+            background: 'var(--olive)', color: 'var(--btn-text)', ratio: null,
+        });
+    });
+
+    it('falls back for an unknown colour too', () => {
+        // `nav_color` comes from a config file, which a user edits by hand.
+        expect(navColorsFrom(() => '', 'chartreuse').background)
+            .toEqual(`var(--${defaultNavColor})`);
+    });
+
+    it('resolves an unknown colour to the default when tokens ARE readable', () => {
+        const read = readerFor('light');
+        expect(navColorsFrom(read, 'chartreuse').background)
+            .toEqual(paletteOf('light')[`--${defaultNavColor}`]);
+    });
+});

--- a/app/src/themes/navColors.ts
+++ b/app/src/themes/navColors.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {bestForeground, contrastRatio} from './contrast';
+import {bestForeground, contrastRatio, isMeasurable} from './contrast';
 
 
 /*
@@ -23,8 +23,31 @@ import {bestForeground, contrastRatio} from './contrast';
  * night's "white" is #ff8a8a, a bright red, and amber's is #ffc875.
  *
  * Measuring at runtime rather than shipping a paired `--on-red`/`--on-olive` token for every
- * colour also means the custom YAML themes still ahead of us get this for free: a theme
- * supplies a palette, and the correct foreground for each entry falls out of it.
+ * colour also means a theme only has to supply a palette: the correct foreground for each
+ * entry falls out of it, with nothing extra to declare and nothing to keep in step.
+ *
+ * What is NOT measured, and should be: the warning indicators.  NavBar still picks their
+ * colour from `conflictingColors`, a hardcoded list of navbar names that swaps `yellow`/`red`
+ * for `null`/`black` on the five bars those hues would blend into.  It is the same defect
+ * this replaced -- a name list standing in for a measurement -- and it is worse than the one
+ * fixed here rather than better: `--danger` and `--warning` measure 1.0-1.8:1 against the bar
+ * in EVERY theme, light and dark included, because a red icon on a red bar is a red icon on a
+ * red bar.  It is left alone deliberately, because the fix is not a better colour.  Those
+ * icons have to stay distinguishable from each other AND from the bar's own text, and in a
+ * monochrome theme there is no third brightness to spend, so severity has to stop being a
+ * hue -- a filled badge, or a shape.  That is a redesign of how severity reads, not a
+ * substitution, and it is not this change.
+ *
+ * /theme-sample draws the indicators as they are, taking the measured bar colour, which is
+ * what the bar does when nothing is wrong.  It does not stage a fake overheating Pi to
+ * exhibit a fault nobody has agreed how to fix.
+ *
+ * Two limits on the measuring that IS done here, both of which the custom YAML themes will
+ * meet before anything else does.  A token has to be a colour these measurements can read -- hex or `rgb()`; anything
+ * else falls back to CSS rather than being measured (see navColorsFrom).  And re-measurement
+ * is triggered by `data-theme` changing, which is how a theme is applied today; a future
+ * editor that patches custom properties in place without touching the attribute would leave
+ * the bar on the values it last measured (see useNavColors).
  */
 
 /**
@@ -73,17 +96,28 @@ export function navColorsFrom(read: (name: string) => string, navColor: string):
      */
     const candidates = [read('--btn-text'), read('--black'), read('--white')].filter(Boolean);
 
-    if (!background || candidates.length === 0) {
+    const measurable = candidates.filter(isMeasurable);
+
+    if (!isMeasurable(background) || measurable.length === 0) {
         /*
-         * No stylesheet to read: jsdom, or a very early render.  Fall back to the tokens
-         * themselves so the bar is still painted by CSS and still changes with the theme --
-         * this is the pre-measurement behaviour, and it is only ever wrong about the
-         * foreground.
+         * Nothing readable to measure, so measure nothing and let CSS do its job.
+         *
+         * Two cases reach here.  The ordinary one is that there is no stylesheet yet -- jsdom,
+         * or a very early render -- and the reader returns empty strings.  The other is a
+         * token this cannot parse: a hand-written theme writing `rgb(90 79 168)` or
+         * `color-mix(...)` rather than a hex.  That one used to be silent and worse than
+         * useless: an unparseable colour measured as luminance zero, indistinguishable from
+         * black, so the bar picked its foreground against a colour the theme does not contain
+         * and then froze the wrong hex into an inline style, where CSS could not correct it.
+         *
+         * Falling back to the tokens themselves is the pre-measurement behaviour: the bar is
+         * painted by CSS, follows the theme, and is only ever wrong about the foreground --
+         * which is a great deal better than being confidently wrong about both.
          */
         return {background: `var(--${name})`, color: 'var(--btn-text)', ratio: null};
     }
 
-    const color = bestForeground(background, candidates) as string;
+    const color = bestForeground(background, measurable) as string;
     return {background, color, ratio: contrastRatio(color, background)};
 }
 
@@ -126,6 +160,13 @@ export function navBarStyle(colors: NavColors): React.CSSProperties {
  *
  * The attribute is also stamped by the inline script in index.html before React loads, and
  * that is a change no context can report at all.
+ *
+ * This assumes token VALUES only change when `data-theme` does, which holds for every way a
+ * theme is applied today.  It will not hold for a custom-theme editor that rewrites custom
+ * properties in place: the measured pair is a snapshot of hexes, so the bar would keep the
+ * old one until the theme name or the chosen colour changed.  When that editor exists it
+ * should either re-stamp the attribute or announce the change for this to observe -- there
+ * is no event for "a custom property was assigned" to watch instead.
  */
 export function useNavColors(navColor: string): NavColors {
     const [colors, setColors] = React.useState<NavColors>(

--- a/app/src/themes/navColors.ts
+++ b/app/src/themes/navColors.ts
@@ -1,0 +1,150 @@
+import React from 'react';
+import {bestForeground, contrastRatio} from './contrast';
+
+
+/*
+ * The navigation bar's colours.
+ *
+ * The bar's background is the one colour in the interface the USER picks (Settings ->
+ * navbar colour), and it is picked by hue name -- `violet`, `olive`, `brown` -- which each
+ * theme then resolves to its own hex.  So the bar has a background the theme cannot know in
+ * advance, and its links and status icons have to stay legible on all twelve of them in all
+ * four themes: forty-eight combinations, not one.
+ *
+ * It used to draw them all with the single `--btn-text` token, which is white in light and
+ * near-black in the other three.  Near-black on night's `--brown` (#451212) is 1.33:1 and on
+ * amber's (#452708) 1.48:1 -- nine of night's twelve colours and seven of amber's sat below
+ * 4.5:1, which is why the bar's icons were unreadable.  `--btn-text` is the right token for
+ * a button, whose fill the theme chooses; it was never the right one here.
+ *
+ * So the foreground is MEASURED instead, against the background the theme actually resolved.
+ * The two candidates are the theme's own `--black` and `--white` rather than literal black and
+ * white, because a literal white pixel in night mode defeats the entire point of the mode --
+ * night's "white" is #ff8a8a, a bright red, and amber's is #ffc875.
+ *
+ * Measuring at runtime rather than shipping a paired `--on-red`/`--on-olive` token for every
+ * colour also means the custom YAML themes still ahead of us get this for free: a theme
+ * supplies a palette, and the correct foreground for each entry falls out of it.
+ */
+
+/**
+ * The colours offered for the bar, in picker order.
+ *
+ * The same keys as `semanticUIColorMap` in components/Vars.js, which maps them to the fixed
+ * hexes used for the favicon and the mobile status bar (those are files and OS chrome, so
+ * they cannot take a token).  navColors.test.js holds the two lists together.
+ */
+export const navColorNames: string[] = [
+    'red', 'orange', 'yellow', 'olive', 'green', 'teal',
+    'blue', 'violet', 'purple', 'pink', 'brown', 'grey',
+];
+
+export const defaultNavColor = 'violet';
+
+export interface NavColors {
+    /** CSS colour for the bar itself. */
+    background: string;
+    /** CSS colour its text and icons take. */
+    color: string;
+    /**
+     * Measured contrast of `color` on `background`, or null when the tokens could not be
+     * read and the pair below is the un-measured fallback.  Surfaced so /theme-sample can
+     * show the number next to the sample.
+     */
+    ratio: number | null;
+}
+
+/**
+ * The bar's colours, given a way to read theme tokens.
+ *
+ * Takes a reader rather than an element so it can be measured against the real palette in a
+ * unit test without a browser -- the shipped tokens are parsed out of tokens.css and handed
+ * in.  Forty-eight combinations is far too many to eyeball.
+ */
+export function navColorsFrom(read: (name: string) => string, navColor: string): NavColors {
+    const name = navColorNames.includes(navColor) ? navColor : defaultNavColor;
+    const background = read(`--${name}`);
+    /*
+     * `--btn-text` leads because it is the token this used to use unconditionally, so where
+     * it was already the best choice nothing changes -- and in the monochrome themes it is
+     * genuinely the darkest thing the theme has (night's is #0a0000 against a `--black` of
+     * #2a0808), which makes it the right foreground for every bright bar.  It was never
+     * wrong; it was just applied without looking at what it was being drawn on.
+     */
+    const candidates = [read('--btn-text'), read('--black'), read('--white')].filter(Boolean);
+
+    if (!background || candidates.length === 0) {
+        /*
+         * No stylesheet to read: jsdom, or a very early render.  Fall back to the tokens
+         * themselves so the bar is still painted by CSS and still changes with the theme --
+         * this is the pre-measurement behaviour, and it is only ever wrong about the
+         * foreground.
+         */
+        return {background: `var(--${name})`, color: 'var(--btn-text)', ratio: null};
+    }
+
+    const color = bestForeground(background, candidates) as string;
+    return {background, color, ratio: contrastRatio(color, background)};
+}
+
+/** The bar's colours read from a live document. */
+export function resolveNavColors(
+    navColor: string,
+    element: Element = document.documentElement,
+): NavColors {
+    const styles = window.getComputedStyle(element);
+    return navColorsFrom(name => styles.getPropertyValue(name).trim(), navColor);
+}
+
+/**
+ * The inline style for a bar painted in these colours.
+ *
+ * Shared by the real navigation bar and the /theme-sample gallery, so a sample cannot end
+ * up demonstrating a bar the app does not actually draw.
+ */
+export function navBarStyle(colors: NavColors): React.CSSProperties {
+    return {
+        background: colors.background,
+        color: colors.color,
+        /*
+         * The hotspot glyph stacks two icons, and the corner one paints a disc of its
+         * surface behind itself.  The bar's colour is the user's choice, so it has to be
+         * handed down rather than looked up from a token.
+         */
+        '--icon-stack-bg': colors.background,
+    } as React.CSSProperties;
+}
+
+/**
+ * The bar's colours, kept current as the theme changes.
+ *
+ * Watches the `data-theme` attribute rather than subscribing to ThemeContext, because the
+ * attribute is what the tokens actually key off and it is stamped by ThemeProvider in an
+ * effect of its own.  React runs child effects before parent effects, so a consumer that
+ * re-read the tokens when the context value changed would read them one theme late -- and
+ * the bar would sit on the previous theme's foreground until something else re-rendered it.
+ *
+ * The attribute is also stamped by the inline script in index.html before React loads, and
+ * that is a change no context can report at all.
+ */
+export function useNavColors(navColor: string): NavColors {
+    const [colors, setColors] = React.useState<NavColors>(
+        () => navColorsFrom(() => '', navColor));
+
+    React.useLayoutEffect(() => {
+        const update = () => setColors(resolveNavColors(navColor));
+        update();
+
+        if (typeof MutationObserver !== 'function') {
+            return;
+        }
+        const observer = new MutationObserver(update);
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+        });
+        return () => observer.disconnect();
+    }, [navColor]);
+
+    return colors;
+}


### PR DESCRIPTION
The navbar's icons were hard to read. They were hard to read in a specific, measurable way.

## What was wrong

The bar's background is the one surface in the app a **user** picks — twelve colour names, which each theme resolves to twelve of its own colours. That is forty-eight backgrounds, and the links and status icons were drawn on all of them in a single token, `--btn-text`, which is near-black in three of the four themes.

Night's `--brown` is `#451212`. A near-black glyph on it is **1.33:1**.

| | below 4.5:1 | below 3:1 |
|---|---|---|
| light | 1 of 12 | 0 |
| dark | 0 | 0 |
| night | 9 of 12 | 7 |
| amber | 7 of 12 | 5 |

`--btn-text` is the right token for a button, whose fill the theme chooses. It was never the right one here; it was applied without looking at what it was being drawn on.

## The fix

The foreground is measured against the background the theme actually resolved, choosing between that theme's own `--btn-text`, `--black` and `--white`.

Its *own*, not literal ones — a white pixel in night mode undoes the dark adaptation the theme exists to protect, so night's "white" is `#ff8a8a` and its "black" is `#2a0808`. Measuring at runtime rather than shipping an `--on-red` token per colour also means the custom YAML themes still ahead of us get this for free: a theme supplies a palette, and the correct foreground for each entry falls out of it.

**Nothing is below 3:1 any more. The worst case is 3.27:1, up from 1.33:1, and no combination is worse than it was.**

## What measurement cannot fix — for you to decide

Ten of the forty-eight are still under 4.5:1, and no choice of foreground will lift them, because the shortfall is in the **background**. A monochrome theme resolves all twelve colour names onto one red (or amber) ramp, and a mid-tone of a hue cannot carry text of that same hue. Night's `--green` is `#b03030`: 3.27:1 from the theme's darkest red and 2.52:1 from its brightest. The one this picks is the best available, and it is still short.

`amber/blue` `amber/grey` `amber/teal` `light/yellow` `night/blue` `night/green` `night/grey` `night/pink` `night/teal` `night/violet`

So **/theme-sample now draws all twelve bars with the measured ratio printed beside each one**, and calls out the ten. That is the thing you asked to see, and it is where this gets decided — the options are retuning the monochrome palettes, giving the bar its own colour scale, or accepting a 3.3:1 floor on ten combinations nobody may ever pick.

## Two things I deliberately left alone

- **The warning-icon colours.** `conflictingColors` in Nav.js is the same defect solved by hand — a hardcoded list standing in for a measurement. It is worse than I expected: `--danger`/`--warning` measure **1.0–1.8:1** against the bar in *light and dark too*, because a red icon on a red bar is a red icon on a red bar. Fixing it properly means encoding severity as something other than hue (a filled badge, say), which is a redesign rather than a patch. Flagging it rather than bundling it.
- **`--btn-text` elsewhere.** Only the bar changed.

## Testing

- `themes/navColors.test.js` — 17 cases. Measures all forty-eight against the palette **parsed out of tokens.css**, not a list restated in the spec. Asserts the pick is the best available, that no combination got worse, that all clear 3:1, and pins the ten that don't clear 4.5:1 as a list so it cannot quietly grow. Paired with the inverse (`--btn-text` does *not* clear 3:1) so the suite cannot pass on the mapping it replaced.
- Neither bar in Nav.js is reachable from a test that could measure it — `<NavBar/>` needs the settings, status and worker contexts and a dozen polling hooks, and a media query picks which of the two renders. So a **source guard** holds both to `navBarStyle(navColors)`, the same technique used for MapViewer's unreachable branch.
- `ui-layout.cy.js` — 17 new cases (160 → 177). Measures the **painted** result in a real browser in all four themes, checks the icons inherit what the links get, and holds the painted ratio against the number the component reports.
- **Planted the revert.** A fixed foreground reddens 4 jest cases and 3 cypress ones.

1115 jest / 62 suites, 177 in `ui-layout.cy.js`, clean `npm run build`.

## Incidental

The WCAG primitives move to `themes/contrast.ts` so theme code can measure a colour without importing `Common.js`, which pulls in half the component library — `themes/` importing it is how the last import cycle started.

`Common.js` forwards `contrastRatio` with a **delegating function**, not `export {contrastRatio}`, and that is load-bearing. A bare re-export compiles to a getter; six specs mock the module with `{...jest.requireActual('./Common')}`; a spread invokes every getter; and those spreads run re-entrantly while the module is still evaluating. The getter fired before its import binding existed and took six suites down. Found it by running them, not by reasoning about it.