### PR TITLE
ui: only the top modal answers Escape, and the audited widths

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,3 +1,8 @@
+:root {
+    /* Shared with the toast offset below, so the two cannot drift apart. */
+    --navbar-height: 3.4em;
+}
+
 /* Nav bar: a hand-rolled flexbox bar (was a Semantic Menu).  The user-chosen background
    and the foreground measured against it are set inline (see themes/navColors); this
    stylesheet only supplies structure and hover affordances. */
@@ -10,8 +15,28 @@
      * is the one link a user needs to reach the settings that fix a broken WROLPi.
      */
     flex-wrap: wrap;
-    min-height: 3.4em;
+    min-height: var(--navbar-height);
     padding: 0 0.25em;
+}
+
+/*
+ * Toasts start below the navigation bar instead of on top of it.
+ *
+ * They are fixed at `top: var(--mantine-spacing-md)` -- 16px -- while the bar occupies the
+ * first 54px of the page, so every toast landed over the bar's right-hand corner: the search
+ * glyph, the hamburger, Help and Admin.  For as long as the toast was up those controls could
+ * not be clicked, and an error toast is exactly when a user reaches for Admin.
+ *
+ * It went unnoticed until the search glyph was given a proper hit area: at 18px it sat in the
+ * gap under the toast, and growing it to the height of the bar moved it into the overlap.
+ * The toast was always covering that corner; there was just nothing there to hit.
+ *
+ * `:where()` gives Mantine's own rule zero specificity, so one class is enough to win, but
+ * the attribute is matched too -- only the top-anchored positions need moving, and a future
+ * switch to `bottom-right` should not silently inherit a top offset.
+ */
+html .mantine-Notifications-root[data-position^='top'] {
+    top: calc(var(--navbar-height) + var(--mantine-spacing-md, 16px));
 }
 
 .wrolpi-navbar-right {

--- a/app/src/DashboardPage.js
+++ b/app/src/DashboardPage.js
@@ -251,7 +251,7 @@ export function Getters() {
 
     let getterModal;
     if (selectedGetter === 'downloads') {
-        getterModal = <Modal closeIcon
+        getterModal = <Modal size='large' closeIcon
                              open={true}
                              centered={false}
                              onClose={() => handleSetGetter(null, null)}
@@ -266,7 +266,7 @@ export function Getters() {
             </Modal.Content>
         </Modal>;
     } else if (selectedGetter === 'upload') {
-        getterModal = <Modal closeIcon
+        getterModal = <Modal size='large' closeIcon
                              open={true}
                              centered={false}
                              onClose={() => handleSetGetter(null, null)}

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -332,7 +332,7 @@ function EditTagsModal() {
     ];
 
     return <>
-        <Modal open={open} onClose={localOnClose}>
+        <Modal size='large' open={open} onClose={localOnClose}>
             <Modal.Header>Edit Tags</Modal.Header>
             <div id='editModalContent'>
                 <Group gap={6}>
@@ -567,7 +567,7 @@ export function AddTagsButton({
             type='button'
             disabled={disabled}
         />
-        <Modal open={open} onClose={() => setOpen(false)}>
+        <Modal size='small' open={open} onClose={() => setOpen(false)}>
             <Modal.Content>
                 {loading && <Loading size='xs'>Updating tags…</Loading>}
                 <Header as='h4'>Applied Tags</Header>

--- a/app/src/components/BulkTagModal.js
+++ b/app/src/components/BulkTagModal.js
@@ -125,7 +125,7 @@ export function BulkTagModal({open, onClose, paths, onComplete}) {
         : 0;
 
     return (
-        <Modal closeIcon open={open} onClose={handleClose} size="small">
+        <Modal closeIcon open={open} onClose={handleClose} size='large'>
             <Modal.Header>Bulk Tag Files</Modal.Header>
             <Modal.Content>
                 {state === 'loading' && (

--- a/app/src/components/Channels.js
+++ b/app/src/components/Channels.js
@@ -309,7 +309,7 @@ export function ChannelEditPage() {
                     New Download
                 </Button>
             </Group>
-            <Modal open={downloadModalOpen} onClose={() => setDownloadModalOpen(false)}>
+            <Modal size='small' open={downloadModalOpen} onClose={() => setDownloadModalOpen(false)}>
                 <Modal.Content>
                     <Header as='h2'>New Channel Download</Header>
                     <ChannelDownloadForm

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1674,7 +1674,7 @@ export function SortButton({sorts = []}) {
     }
 
     return <>
-        <Modal closeIcon
+        <Modal size='small' closeIcon
                open={open}
                onClose={() => setOpen(false)}
         >

--- a/app/src/components/DonatePage.js
+++ b/app/src/components/DonatePage.js
@@ -18,7 +18,7 @@ function CoinQRButton({qrCodeValue, header, buttonColor}) {
     return <>
         <IconButton icon='qrcode' label={`Show ${header} QR code`} color={buttonColor}
                     onClick={() => setOpen(true)}/>
-        <Modal closeIcon
+        <Modal size='small' closeIcon
                open={open}
                onClose={() => setOpen(false)}
                onOpen={() => setOpen(true)}

--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -420,7 +420,7 @@ export function FilePreviewProvider({children}) {
         setErrorModalOpen(false);
     }
 
-    const errorModal = <Modal open={errorModalOpen}
+    const errorModal = <Modal size='large' open={errorModalOpen}
                               onClose={handleErrorModalClose}
     >
         <Modal.Header>Unknown File</Modal.Header>

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -644,7 +644,7 @@ export function SearchFilterModal(
         >{i}</Button>
     );
 
-    return <Modal open={open} onClose={handleClose} closeIcon size='small'>
+    return <Modal open={open} onClose={handleClose} closeIcon size='large'>
         <Modal.Header>Search Filters</Modal.Header>
         <Modal.Content>
             <Stack gap='lg'>

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -943,7 +943,7 @@ export function FlasherPage() {
                 </>}
             </Panel>
 
-            <Modal open={saveModalOpen} onClose={() => setSaveModalOpen(false)} size='sm'>
+            <Modal open={saveModalOpen} onClose={() => setSaveModalOpen(false)} size='tiny'>
                 <Modal.Header>Save firmware configuration</Modal.Header>
                 <Modal.Content>
                     <TextInput

--- a/app/src/components/KeyboardShortcutsProvider.js
+++ b/app/src/components/KeyboardShortcutsProvider.js
@@ -81,7 +81,7 @@ function SearchModal({open, onClose}) {
     if (!open) return null;
 
     return (
-        <Modal open={open} onClose={onClose} centered={false} title='Search'>
+        <Modal size='small' open={open} onClose={onClose} centered={false} title='Search'>
             <Modal.Content>
                 {/*
                   * `wrolpi-search-modal` makes the suggestion list part of the panel rather

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -115,7 +115,7 @@ function RegionPreviewModal({bbox, name, open, onClose}) {
         return () => { if (map) map.remove(); };
     }, [open, bbox]);
 
-    return <Modal open={open} onClose={onClose} size='large' closeIcon title={name}>
+    return <Modal open={open} onClose={onClose} size='fullscreen' closeIcon title={name}>
         {/* No `.media` here: the bbox highlight is drawn as a map layer on the canvas itself
             (see the `bbox` source/layers above), so the automatic `canvas` element-type filter
             already covers it. There is no separate DOM overlay to wrap. */}

--- a/app/src/components/Share.js
+++ b/app/src/components/Share.js
@@ -38,7 +38,7 @@ export const ShareButton = () => {
     }
 
     return <>
-        <Modal closeIcon
+        <Modal size='small' closeIcon
                open={open}
                onClose={handleClose}
         >

--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -110,7 +110,7 @@ export const OutdatedZimsMessage = ({onClick}) => {
         <p></p>
 
         <Button role='danger' onClick={() => setOpen(true)}>Delete</Button>
-        <Modal open={open}
+        <Modal size='small' open={open}
                onClose={onClose}
                title='Delete'
         >
@@ -165,7 +165,7 @@ const ZimSearchEntry = ({zimId, onTag, onUntag, entry}) => {
             {tagIcon}
         </Header>
         <HeadlineText headline={headline}/>
-        <Modal open={open}
+        <Modal size='large' open={open}
                onClose={() => setOpen(false)}>
             <div className='preview-fit'>
                 <ZimViewer src={url} style={{

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -1383,7 +1383,7 @@ function SambaSection() {
             <Modal open={addOpen} onClose={() => {
                 setAddOpen(false);
                 setShareAll(true);
-            }} size='small'>
+            }} size='large'>
                 <Modal.Header>Add Samba Share</Modal.Header>
                 <Modal.Content>
                     <TextInput
@@ -1589,7 +1589,7 @@ function HotspotSettingsForm() {
                 style={{marginLeft: '0.5em'}}
                 onClick={() => setQrOpen(true)}
             />
-            <Modal open={qrOpen} onClose={() => setQrOpen(false)} closeIcon>
+            <Modal size='small' open={qrOpen} onClose={() => setQrOpen(false)} closeIcon>
                 <Modal.Header>Scan this code to join the hotspot</Modal.Header>
                 <Modal.Content>
                     {/* `media`: filtered as a unit by night mode; a QR code needs real black-on-white

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -64,7 +64,7 @@ function DownloadProgressModal({progress, url}) {
         <Button size='small' onClick={() => setOpen(true)} style={{marginLeft: '0.5em'}}>
             {buttonLabel}
         </Button>
-        <Modal closeIcon open={open} onClose={() => setOpen(false)} size='small'>
+        <Modal closeIcon open={open} onClose={() => setOpen(false)} size='fullscreen'>
             <Modal.Header>Download Progress</Modal.Header>
             <Modal.Content>
                 <Progress
@@ -224,7 +224,7 @@ function RecurringDownloadRow({download, fetchDownloads, onDelete}) {
         (text) => <Link to={location}>{text}</Link> :
         (text) => <a href={url} target='_blank' rel='noopener noreferrer'>{text}</a>;
 
-    const errorModal = <Modal
+    const errorModal = <Modal size='fullscreen'
         closeIcon
         onClose={handleErrorClose}
         open={errorModalOpen}
@@ -308,7 +308,7 @@ function RecurringDownloadRow({download, fetchDownloads, onDelete}) {
         />;
     }
 
-    const editModal = <Modal closeIcon
+    const editModal = <Modal size='large' closeIcon
                              open={editModalOpen}
                              onClose={handleEditClose}
     >
@@ -456,7 +456,7 @@ function OnceDownloadRow({download, fetchDownloads, isSelected, onSelect}) {
             <IconButton icon='exclamation triangle' label='Download error' color='danger'
                         onClick={() => setErrorModalOpen(true)}/>
         )
-        errorModal = <Modal
+        errorModal = <Modal size='fullscreen'
             closeIcon
             open={errorModalOpen}
             onClose={() => setErrorModalOpen(false)}
@@ -470,7 +470,7 @@ function OnceDownloadRow({download, fetchDownloads, isSelected, onSelect}) {
 
     if (downloader === Downloaders.Video) {
         editModal = (
-            <Modal
+            <Modal size='large'
                 closeIcon
                 open={editModalOpen}
                 onClose={handleEditClose}
@@ -500,7 +500,7 @@ function OnceDownloadRow({download, fetchDownloads, isSelected, onSelect}) {
         );
     } else if (downloader === Downloaders.Archive) {
         editModal = (
-            <Modal
+            <Modal size='large'
                 closeIcon
                 open={editModalOpen}
                 onClose={handleEditClose}

--- a/app/src/components/collections/CollectionTagModal.js
+++ b/app/src/components/collections/CollectionTagModal.js
@@ -98,7 +98,7 @@ export function CollectionTagModal({
     const saveButtonText = hasDirectory && moveToTagDirectory ? 'Move' : 'Save';
 
     return (
-        <Modal
+        <Modal size='large'
             open={open}
             onClose={handleClose}
             closeIcon

--- a/app/src/components/inventory/InventoryRoute.js
+++ b/app/src/components/inventory/InventoryRoute.js
@@ -36,7 +36,7 @@ function NewInventoryModal({open, onClose, onCreate}) {
         }
     };
 
-    return <Modal open={open} onClose={onClose} closeIcon>
+    return <Modal size='small' open={open} onClose={onClose} closeIcon>
         <Modal.Header>New Inventory</Modal.Header>
         <Modal.Content>
             <TextInput autoFocus label='Name' value={name} onChange={e => setName(e.currentTarget.value)}

--- a/app/src/components/ui/Overlays.tsx
+++ b/app/src/components/ui/Overlays.tsx
@@ -45,6 +45,78 @@ export interface ModalProps extends Omit<React.ComponentProps<typeof MModal>, 'o
     closeIcon?: boolean;
 }
 
+/*
+ * Nested modals: which one is on top.
+ *
+ * Mantine binds a window-level `keydown` listener per open modal, gated only on whether that
+ * modal is open -- there is no check for whether it is the one the user is looking at.  Two
+ * modals open meant two listeners, so a single Escape closed BOTH: opening the search modal
+ * over the dashboard's download modal and pressing Escape once left you on the dashboard.
+ * Semantic handled this; the migration lost it.
+ *
+ * Mantine's own answer is `Modal.Stack` with a `stackId` per modal, which is the only thing
+ * that gates `closeOnEscape`.  It is not used here for two reasons: it requires every call
+ * site to be rewritten to hoist its modal into a stack, and it sets `__hidden` on everything
+ * below the top -- the parent disappears while the child is open.  We want the parent dimmed
+ * and still visible behind the child, which is what it did before.
+ *
+ * So the wrapper keeps the register itself.  A module-level list rather than React context,
+ * because the two modals in the bug are not nested in the JSX at all: the search modal is
+ * rendered by KeyboardShortcutsProvider near the app root while the download modal is
+ * rendered by the dashboard.  They are siblings that happen to be open at once, and no
+ * context relates them.  Most recently opened is on top.
+ */
+let openModalIds: string[] = [];
+const modalStackListeners = new Set<() => void>();
+const notifyModalStack = () => modalStackListeners.forEach(listener => listener());
+
+/** Mantine's default modal z-index; popovers and tooltips sit at 300. */
+const MODAL_Z_INDEX = 200;
+
+/**
+ * Where this modal sits in the stack of open ones.
+ *
+ * Exported for the tests, which need to assert the register empties -- a modal that failed to
+ * deregister would leave every later modal believing it was not on top, and nothing would
+ * close on Escape at all.
+ */
+export const openModalCount = () => openModalIds.length;
+
+function useModalStackPosition(opened: boolean): {isTop: boolean; zIndex: number} {
+    const id = React.useId();
+    const [, rerender] = React.useReducer((count: number) => count + 1, 0);
+
+    React.useEffect(() => {
+        modalStackListeners.add(rerender);
+        return () => {
+            modalStackListeners.delete(rerender);
+        };
+    }, []);
+
+    React.useEffect(() => {
+        if (!opened) return;
+        // Re-opening an already-registered modal moves it to the top, which is what a user
+        // who clicked its trigger again means.
+        openModalIds = [...openModalIds.filter(other => other !== id), id];
+        notifyModalStack();
+        return () => {
+            openModalIds = openModalIds.filter(other => other !== id);
+            notifyModalStack();
+        };
+    }, [opened, id]);
+
+    const depth = openModalIds.indexOf(id);
+    return {
+        isTop: depth === -1 || depth === openModalIds.length - 1,
+        /*
+         * Two per level, so a child's overlay clears its parent's content.  Kept small on
+         * purpose: Mantine puts popovers and select dropdowns at 300, and a modal stack that
+         * climbed past that would paint over the dropdowns inside itself.
+         */
+        zIndex: MODAL_Z_INDEX + Math.max(depth, 0) * 2,
+    };
+}
+
 function ModalBase({open, opened, size, closeIcon, title, children, ...props}: ModalProps) {
     const slots: Record<string, React.ReactNode[]> = {header: [], actions: [], body: []};
     React.Children.forEach(children, child => {
@@ -54,13 +126,25 @@ function ModalBase({open, opened, size, closeIcon, title, children, ...props}: M
         else slots.body.push(child);
     });
 
+    const isOpen = opened ?? open ?? false;
+    const {isTop, zIndex} = useModalStackPosition(isOpen);
+
     return <MModal
-        opened={opened ?? open ?? false}
+        opened={isOpen}
         centered
         size={typeof size === 'string' ? (modalSizes[size] ?? size) : size}
         title={slots.header.length ? slots.header : title}
         // Flat surfaces: the overlay separates the modal from the page, not a shadow.
         overlayProps={{backgroundOpacity: 0.55, blur: 0}}
+        /*
+         * Only the modal on top answers the keyboard.  Without this every open modal has its
+         * own window-level Escape listener and one press closes the lot.  Focus goes with it:
+         * two traps fighting over the same Tab is its own bug, and the user is working in the
+         * top one.
+         */
+        closeOnEscape={isTop}
+        trapFocus={isTop}
+        zIndex={zIndex}
         {...props}
     >
         {slots.body}

--- a/app/src/components/ui/Overlays.tsx
+++ b/app/src/components/ui/Overlays.tsx
@@ -107,7 +107,13 @@ function useModalStackPosition(opened: boolean): {isTop: boolean; zIndex: number
 
     const depth = openModalIds.indexOf(id);
     return {
-        isTop: depth === -1 || depth === openModalIds.length - 1,
+        /*
+         * Not yet registered -- the first paint of a modal that just opened, before the
+         * effect runs.  It is only on top if nothing else is open; claiming top while a
+         * parent is registered gives both modals the same z-index for a frame, which is a
+         * visible flash of the wrong one in front when a child opens.
+         */
+        isTop: depth === -1 ? openModalIds.length === 0 : depth === openModalIds.length - 1,
         /*
          * Two per level, so a child's overlay clears its parent's content.  Kept small on
          * purpose: Mantine puts popovers and select dropdowns at 300, and a modal stack that
@@ -117,7 +123,27 @@ function useModalStackPosition(opened: boolean): {isTop: boolean; zIndex: number
     };
 }
 
-function ModalBase({open, opened, size, closeIcon, title, children, ...props}: ModalProps) {
+function ModalBase({
+    open, opened, size, closeIcon, title, children,
+    /*
+     * Pulled out of `props` so the spread below cannot overwrite the stack's decision.
+     *
+     * These were set BEFORE `{...props}` at first, which meant a call site passing
+     * `closeOnEscape` won and re-armed Mantine's window-level Escape listener on a modal
+     * that is not on top -- reinstating the exact bug this exists to fix.  Three call sites
+     * pass it: CollectionReorganizeModal and BatchReorganizeModal disable Escape while a
+     * reorganize is running, and Flasher while it is writing an image.  Conflict resolution
+     * opens as a sibling ON TOP of the reorganize modal, so once the reorganize finished and
+     * `closeOnEscape` went back to true, one Escape closed both again.
+     *
+     * They are composed rather than ignored: "only the top modal answers Escape" and "this
+     * modal must not be dismissed while it is busy" are both true, and the answer is AND.
+     */
+    closeOnEscape = true,
+    trapFocus = true,
+    zIndex,
+    ...props
+}: ModalProps) {
     const slots: Record<string, React.ReactNode[]> = {header: [], actions: [], body: []};
     React.Children.forEach(children, child => {
         const type = React.isValidElement(child) ? child.type : undefined;
@@ -127,7 +153,7 @@ function ModalBase({open, opened, size, closeIcon, title, children, ...props}: M
     });
 
     const isOpen = opened ?? open ?? false;
-    const {isTop, zIndex} = useModalStackPosition(isOpen);
+    const {isTop, zIndex: stackZIndex} = useModalStackPosition(isOpen);
 
     return <MModal
         opened={isOpen}
@@ -136,16 +162,18 @@ function ModalBase({open, opened, size, closeIcon, title, children, ...props}: M
         title={slots.header.length ? slots.header : title}
         // Flat surfaces: the overlay separates the modal from the page, not a shadow.
         overlayProps={{backgroundOpacity: 0.55, blur: 0}}
-        /*
-         * Only the modal on top answers the keyboard.  Without this every open modal has its
-         * own window-level Escape listener and one press closes the lot.  Focus goes with it:
-         * two traps fighting over the same Tab is its own bug, and the user is working in the
-         * top one.
-         */
-        closeOnEscape={isTop}
-        trapFocus={isTop}
-        zIndex={zIndex}
         {...props}
+        /*
+         * AFTER the spread, deliberately -- see the destructuring above.  Only the modal on
+         * top answers the keyboard: without this every open modal has its own window-level
+         * Escape listener and one press closes the lot.  Focus goes with it, because two
+         * traps fighting over the same Tab is its own bug and the user is working in the top
+         * one.  Mantine's own Modal.Stack applies its stack props after the caller's for the
+         * same reason.
+         */
+        closeOnEscape={isTop && closeOnEscape}
+        trapFocus={isTop && trapFocus}
+        zIndex={zIndex ?? stackZIndex}
     >
         {slots.body}
         {slots.actions.length > 0 && <div className='wrolpi-modal-actions'>{slots.actions}</div>}
@@ -185,7 +213,9 @@ export function Confirm({
     onConfirm,
     onCancel,
 }: ConfirmProps) {
-    return <Modal opened={open} onClose={() => onCancel?.()} title={title} size='sm'>
+    // `tiny`, not Mantine's raw `sm`.  Same 380px, but the audited vocabulary -- and the
+    // guard in ui.test.js exists to keep raw Mantine names out of call sites.
+    return <Modal opened={open} onClose={() => onCancel?.()} title={title} size='tiny'>
         {children}
         <div style={{display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 18}}>
             <Button role='cancel' onClick={onCancel}>{cancelLabel}</Button>

--- a/app/src/components/ui/modal-stack.cy.js
+++ b/app/src/components/ui/modal-stack.cy.js
@@ -1,0 +1,199 @@
+import React from 'react';
+import {Button, Modal} from './index';
+import {openModalCount} from './Overlays';
+
+/*
+ * Nested modals: only the one on top answers the keyboard, and the one underneath stays on
+ * screen behind it.
+ *
+ * Mantine binds a window-level `keydown` listener per open modal, gated only on whether that
+ * modal is open -- nothing checks which one the user is looking at.  Two open modals meant
+ * two listeners, so one Escape closed both: opening the search modal over the dashboard's
+ * download modal and pressing Escape once left you on the dashboard.  Reproduced in the
+ * running app before this was written.
+ *
+ * A real browser, because none of it is visible to jsdom: the listener is on `window` with
+ * `capture: true`, the stacking is z-index, and "still visible behind" is geometry.
+ */
+
+const Nested = ({onParentClose, onChildClose}) => {
+    const [parent, setParent] = React.useState(false);
+    const [child, setChild] = React.useState(false);
+    return <>
+        <Button data-testid='open-parent' onClick={() => setParent(true)}>Open parent</Button>
+        <Modal open={parent} size='large'
+               onClose={() => {
+                   setParent(false);
+                   onParentClose?.();
+               }}>
+            <Modal.Header>Parent</Modal.Header>
+            <Modal.Content>
+                <p data-testid='parent-body'>The parent's own content.</p>
+                <Button data-testid='open-child' onClick={() => setChild(true)}>Open child</Button>
+            </Modal.Content>
+        </Modal>
+        {/*
+          * A SIBLING of the parent in the JSX, not a descendant.  This is the shape the bug
+          * actually took -- the search modal is rendered by KeyboardShortcutsProvider near
+          * the app root while the download modal is rendered by the dashboard -- and it is
+          * why the register is module-level rather than a React context, which could not
+          * relate these two at all.
+          */}
+        <Modal open={child} size='small'
+               onClose={() => {
+                   setChild(false);
+                   onChildClose?.();
+               }}>
+            <Modal.Header>Child</Modal.Header>
+            <Modal.Content><p data-testid='child-body'>The child's own content.</p></Modal.Content>
+        </Modal>
+    </>
+};
+
+const titles = () => [...Cypress.$('.mantine-Modal-title')].map(el => el.textContent);
+
+const openBoth = () => {
+    cy.mountUI(<Nested/>);
+    cy.get('[data-testid="open-parent"]').click();
+    cy.contains('.mantine-Modal-title', 'Parent').should('exist');
+    cy.get('[data-testid="open-child"]').click();
+    cy.contains('.mantine-Modal-title', 'Child').should('exist');
+};
+
+// Escape has to come from a real element: Mantine's handler calls
+// `event.target.getAttribute(...)`, which throws if the event was dispatched on `document`.
+const pressEscape = () => cy.get('body').trigger('keydown', {key: 'Escape', bubbles: true});
+
+describe('a modal opened over another', () => {
+    it('closes only itself on Escape, leaving the one underneath open', () => {
+        // The bug, exactly: one press used to take both.
+        openBoth();
+
+        pressEscape();
+
+        cy.contains('.mantine-Modal-title', 'Child').should('not.exist');
+        cy.contains('.mantine-Modal-title', 'Parent').should('exist');
+    });
+
+    it('lets the next Escape close the one underneath', () => {
+        // The other half: suppressing Escape on the parent must be temporary, or the parent
+        // becomes unclosable by keyboard for the rest of its life.
+        openBoth();
+
+        pressEscape();
+        cy.contains('.mantine-Modal-title', 'Child').should('not.exist');
+        pressEscape();
+
+        cy.contains('.mantine-Modal-title', 'Parent').should('not.exist');
+    });
+
+    it('keeps the parent on screen behind the child, not hidden', () => {
+        /*
+         * Mantine's own Modal.Stack sets `__hidden` on everything below the top, so the
+         * parent vanishes while the child is open.  That is the behaviour this deliberately
+         * does not use -- the parent should be dimmed and still there.
+         *
+         * Not `should('be.visible')`: that is an occlusion check, and a child drawn over its
+         * parent trips it by definition -- at the default component viewport the 440px child
+         * covers the 620px parent completely and the assertion fails on correct behaviour.
+         * A wide viewport instead, where the parent is genuinely broader than the child, and
+         * the claim is stated as what it is: the parent is rendered, and some of it is not
+         * behind the child.
+         */
+        cy.viewport(1200, 800);
+        openBoth();
+
+        cy.get('.mantine-Modal-content').should(($contents) => {
+            expect($contents, 'both modals are rendered').to.have.length(2);
+
+            const boxes = [...$contents].map(content => ({
+                el: content, box: content.getBoundingClientRect(),
+                display: getComputedStyle(content).display,
+                visibility: getComputedStyle(content).visibility,
+            }));
+            const [child, parent] = [...boxes].sort((a, b) => a.box.width - b.box.width);
+
+            // `__hidden` would show up as either of these.
+            expect(parent.display, 'the parent is not display:none').to.not.equal('none');
+            expect(parent.visibility, 'the parent is not hidden').to.equal('visible');
+            expect(parent.box.height, 'the parent still has a box').to.be.greaterThan(0);
+
+            // And it is wider than the child on both sides, so it is actually seen.
+            expect(parent.box.left, 'parent shows to the left of the child')
+                .to.be.lessThan(child.box.left - 1);
+            expect(parent.box.right, 'parent shows to the right of the child')
+                .to.be.greaterThan(child.box.right + 1);
+        });
+    });
+
+    it('draws the child above the parent', () => {
+        // Both modals used to sit at z-index 200, so which one won was DOM order rather than
+        // which one the user opened.
+        openBoth();
+
+        cy.get('.mantine-Modal-inner').should(($inners) => {
+            const zIndexes = [...$inners].map(inner =>
+                parseInt(getComputedStyle(inner).zIndex, 10));
+
+            expect(zIndexes, 'two modals are stacked').to.have.length(2);
+            expect(Math.max(...zIndexes), 'the child clears the parent')
+                .to.be.greaterThan(Math.min(...zIndexes));
+        });
+    });
+
+    it('keeps the stack below the popovers that open inside it', () => {
+        /*
+         * A Select or date picker inside a modal renders at Mantine's popover z-index of 300.
+         * A stack that climbed past that would paint over the dropdowns in its own form,
+         * which is a worse bug than the one being fixed.
+         */
+        openBoth();
+
+        cy.get('.mantine-Modal-inner').should(($inners) => {
+            const highest = Math.max(...[...$inners]
+                .map(inner => parseInt(getComputedStyle(inner).zIndex, 10)));
+            expect(highest, 'top modal stays under the popover layer').to.be.lessThan(300);
+        });
+    });
+});
+
+describe('the register of open modals', () => {
+    it('empties as they close', () => {
+        /*
+         * The failure mode of keeping a module-level list: a modal that unmounts without
+         * deregistering leaves a ghost on top forever, and then NOTHING closes on Escape --
+         * every real modal believes something else is above it.  Silent, permanent, and
+         * invisible to a test that only ever opens one modal.
+         */
+        openBoth();
+        cy.then(() => expect(openModalCount(), 'both registered').to.equal(2));
+
+        pressEscape();
+        cy.contains('.mantine-Modal-title', 'Child').should('not.exist');
+        cy.then(() => expect(openModalCount(), 'child deregistered').to.equal(1));
+
+        pressEscape();
+        cy.contains('.mantine-Modal-title', 'Parent').should('not.exist');
+        cy.then(() => expect(openModalCount(), 'register is empty').to.equal(0));
+    });
+
+    it('is empty before anything opens, so the counts above mean something', () => {
+        cy.mountUI(<Nested/>);
+        cy.then(() => expect(openModalCount()).to.equal(0));
+    });
+});
+
+describe('a single modal', () => {
+    it('still closes on Escape', () => {
+        // The premise for every case above.  Suppressing Escape on all but the top is
+        // worthless if the top does not respond either.
+        cy.mountUI(<Nested/>);
+        cy.get('[data-testid="open-parent"]').click();
+        cy.contains('.mantine-Modal-title', 'Parent').should('exist');
+
+        pressEscape();
+
+        cy.contains('.mantine-Modal-title', 'Parent').should('not.exist');
+        expect(titles()).to.not.include('Parent');
+    });
+});

--- a/app/src/components/ui/modal-stack.cy.js
+++ b/app/src/components/ui/modal-stack.cy.js
@@ -50,8 +50,6 @@ const Nested = ({onParentClose, onChildClose}) => {
     </>
 };
 
-const titles = () => [...Cypress.$('.mantine-Modal-title')].map(el => el.textContent);
-
 const openBoth = () => {
     cy.mountUI(<Nested/>);
     cy.get('[data-testid="open-parent"]').click();
@@ -194,6 +192,64 @@ describe('a single modal', () => {
         pressEscape();
 
         cy.contains('.mantine-Modal-title', 'Parent').should('not.exist');
-        expect(titles()).to.not.include('Parent');
+    });
+});
+
+describe('a parent that disables Escape while it is busy', () => {
+    /*
+     * Three call sites pass `closeOnEscape` of their own: CollectionReorganizeModal and
+     * BatchReorganizeModal disable it while a reorganize runs, Flasher while it writes an
+     * image.  The stack props were set BEFORE the `{...props}` spread, so those call sites
+     * overwrote the stack's decision and re-armed Mantine's window-level listener on a modal
+     * that is not on top.
+     *
+     * The concrete breakage: ConflictResolutionModal opens as a sibling above the reorganize
+     * modal, so as soon as the reorganize finished and `closeOnEscape` went back to true, one
+     * Escape closed both again -- the original bug, in the one place the app really does
+     * stack two modals.
+     *
+     * "Only the top modal answers Escape" and "do not dismiss me while I am busy" are both
+     * true; they compose with AND.
+     */
+    const Busy = ({busy}) => {
+        const [parent, setParent] = React.useState(true);
+        const [child, setChild] = React.useState(true);
+        return <>
+            <Modal open={parent} size='large' closeOnEscape={!busy}
+                   onClose={() => setParent(false)}>
+                <Modal.Header>Reorganize</Modal.Header>
+                <Modal.Content><p>working</p></Modal.Content>
+            </Modal>
+            <Modal open={child} size='small' onClose={() => setChild(false)}>
+                <Modal.Header>Conflicts</Modal.Header>
+                <Modal.Content><p>resolve these</p></Modal.Content>
+            </Modal>
+        </>
+    };
+
+    it('still closes only the child when the parent has re-enabled Escape', () => {
+        cy.mountUI(<Busy busy={false}/>);
+        cy.contains('.mantine-Modal-title', 'Conflicts').should('exist');
+
+        pressEscape();
+
+        cy.contains('.mantine-Modal-title', 'Conflicts').should('not.exist');
+        cy.contains('.mantine-Modal-title', 'Reorganize').should('exist');
+    });
+
+    it('honours the parent\'s own refusal once it is on top again', () => {
+        /*
+         * The other direction, and the reason the two are composed rather than the stack
+         * simply winning: a busy parent must stay put even when nothing is above it.
+         */
+        cy.mountUI(<Busy busy/>);
+        cy.contains('.mantine-Modal-title', 'Conflicts').should('exist');
+
+        pressEscape();
+        cy.contains('.mantine-Modal-title', 'Conflicts').should('not.exist');
+        pressEscape();
+
+        cy.contains('.mantine-Modal-title', 'Reorganize')
+            .should('exist');
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -2745,3 +2745,95 @@ describe('the global search modal shows its results', () => {
         });
     });
 });
+
+describe('a toast does not cover the navigation bar', () => {
+    /*
+     * Toasts are fixed at `top: var(--mantine-spacing-md)` -- 16px -- while the bar occupies
+     * the first 54px of the page, so every toast landed over the bar's right-hand corner:
+     * the search glyph, the hamburger, Help and Admin.  For as long as it was up those
+     * controls could not be clicked, and an error toast is exactly the moment a user reaches
+     * for Admin.
+     *
+     * It surfaced as six e2e failures the day the search glyph was given a proper hit area:
+     * at 18px it sat in the gap beneath the toast, and growing it to the height of the bar
+     * moved it into the overlap.  The toast had been covering that corner all along; there
+     * was simply nothing there to hit.
+     *
+     * Measured as `elementFromPoint`, which is the same question Cypress's actionability
+     * check asks and the one a mouse asks -- a geometry-only comparison would miss a toast
+     * that overlaps but sits behind, and a z-index comparison would miss one that is in
+     * front but elsewhere on the screen.
+     */
+    const themeIcon = <NavIconWrapper>
+        <IconButton icon='sun' label='Theme' variant='subtle'/>
+    </NavIconWrapper>;
+
+    const mountBarWithToast = () => {
+        cy.mountUI(<MemoryRouter>
+            <Notifications position='top-right'/>
+            <DesktopNav
+                navColors={{background: '#5c4fa8', color: '#ffffff', ratio: 6.69}}
+                homeLink={<a className='wrolpi-navbar-link' href='#'><i>WROLPi</i></a>}
+                icons={themeIcon}
+            />
+        </MemoryRouter>);
+        cy.then(() => {
+            clearToasts();
+            // The shape CI produces: an error toast, which is the kind that lingers.
+            toast({type: 'error', title: 'Unexpected error', description: 'Something failed.'});
+        });
+        cy.get('.mantine-Notification-root').should('exist');
+    };
+
+    it('leaves the search control clickable while a toast is up', () => {
+        mountBarWithToast();
+
+        cy.get('.wrolpi-navbar [aria-label="Search"]').should(($search) => {
+            const box = $search[0].getBoundingClientRect();
+            const topmost = document.elementFromPoint(
+                box.left + box.width / 2, box.top + box.height / 2);
+
+            expect(topmost, 'something is at the search glyph').to.not.be.null;
+            expect($search[0].contains(topmost) || topmost === $search[0],
+                `search is the topmost element, not ${topmost && topmost.className}`).to.be.true;
+        });
+    });
+
+    it('leaves every control in the corner clickable', () => {
+        // Help and Admin are the ones that matter most: an error toast is when a user goes
+        // looking for the admin pages, and it was sitting on top of the link.
+        mountBarWithToast();
+
+        cy.get('.wrolpi-navbar-right').should(($corner) => {
+            const controls = [...$corner[0].querySelectorAll('a, button')];
+            expect(controls.length, 'there are controls to check').to.be.at.least(3);
+
+            const covered = controls.filter((control) => {
+                const box = control.getBoundingClientRect();
+                const topmost = document.elementFromPoint(
+                    box.left + box.width / 2, box.top + box.height / 2);
+                return !(control.contains(topmost) || topmost === control);
+            }).map(control => control.textContent.trim()
+                || control.getAttribute('aria-label') || '(unlabelled)');
+
+            expect(covered).to.deep.equal([]);
+        });
+    });
+
+    it('starts the toast below the bar rather than beside it', () => {
+        /*
+         * The mechanism, stated separately from the effect.  The two cases above would also
+         * pass if the toast merely happened to be narrow enough to miss the controls at this
+         * viewport, which is how the bar came to be covered at some widths and not others.
+         */
+        mountBarWithToast();
+
+        cy.get('.mantine-Notifications-root').should(($root) => {
+            const toastTop = $root[0].getBoundingClientRect().top;
+            const barBottom = Cypress.$('.wrolpi-navbar')[0].getBoundingClientRect().bottom;
+
+            expect(barBottom, 'the bar has height to clear').to.be.greaterThan(40);
+            expect(toastTop, 'the toast starts below the bar').to.be.at.least(barBottom);
+        });
+    });
+});

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -1530,13 +1530,34 @@ describe('modal sizes', () => {
 
     it('never lets a call site name a size the table does not know', () => {
         /*
-         * A name the table has never heard of is passed straight to Mantine, which ignores
-         * anything it does not recognise and renders the default -- so a typo is a modal that
-         * silently reverts to 440px with no warning anywhere.  Flasher was passing Mantine's
-         * own `sm` directly, which worked but bypassed the naming the audit used.
+         * Two different hazards, and neither announces itself.
+         *
+         * A misspelled SEMANTIC name is not in the table, so it passes through untranslated,
+         * Mantine does not recognise it either, and the modal silently renders at the default
+         * 440px.  A raw MANTINE name -- `sm`, `md` -- is recognised and honoured: it works,
+         * so nothing ever complains, and the call site quietly sits outside the vocabulary
+         * the widths were audited in and outside the table that can retune them.  Flasher and
+         * Confirm were both doing the second.
+         *
+         * The tag is scanned with a paren counter rather than matched with `[^>]*?`, which is
+         * what the first version of this did.  `onClose={() => ...}` contains a `>`, so that
+         * pattern stopped at the arrow and skipped the rest of the tag: it saw 44 of the 56
+         * modals that declare a size, and the twelve it missed included Confirm's `size='sm'`
+         * in this very library -- the one offender it was written to catch.
          */
         const known = new Set(['mini', 'tiny', 'small', 'large', 'fullscreen']);
-        const offenders = [];
+
+        /** The opening tag starting at `start`, honouring braces in prop expressions. */
+        const openingTag = (source, start) => {
+            let depth = 0;
+            for (let i = start; i < source.length; i++) {
+                const character = source[i];
+                if (character === '{' || character === '(') depth += 1;
+                else if (character === '}' || character === ')') depth -= 1;
+                else if (character === '>' && depth === 0) return source.slice(start, i + 1);
+            }
+            return '';
+        };
 
         const walk = (directory) => fs.readdirSync(directory, {withFileTypes: true})
             .flatMap(entry => {
@@ -1547,15 +1568,24 @@ describe('modal sizes', () => {
                 return [[full, fs.readFileSync(full, 'utf8')]];
             });
 
+        const offenders = [];
+        let scanned = 0;
         for (const [file, source] of walk(path.join(__dirname, '..', '..'))) {
-            // Only `<Modal ... size='x'>`; a computed `size={...}` is the caller's business.
-            for (const match of source.matchAll(/<Modal\b[^>]*?\bsize='([^']+)'/g)) {
-                if (!known.has(match[1])) {
-                    offenders.push(`${path.basename(file)}: size='${match[1]}'`);
+            for (const match of source.matchAll(/<Modal\b/g)) {
+                const tag = openingTag(source, match.index);
+                // Quote-agnostic; a computed `size={...}` is the caller's business.
+                const declared = tag.match(/\bsize=["']([^"']+)["']/);
+                if (!declared) continue;
+                scanned += 1;
+                if (!known.has(declared[1])) {
+                    offenders.push(`${path.basename(file)}: size='${declared[1]}'`);
                 }
             }
         }
 
+        // The premise.  A scanner that silently matched nothing would report no offenders
+        // and read exactly like a clean codebase, which is how the first version passed.
+        expect(scanned).toBeGreaterThan(50);
         expect(offenders).toEqual([]);
     });
 });

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -1487,3 +1487,75 @@ describe('Confirm', () => {
         expect(screen.getByRole('button', {name: 'Wipe'})).toHaveClass('wrolpi-button-danger');
     });
 });
+
+describe('modal sizes', () => {
+    /*
+     * The size table is the single thing that halved every modal in the migration.
+     *
+     * Semantic's names were measured on the pre-migration build: mini 360, tiny 540, small
+     * 720, large 1080, fullscreen 95%.  They are mapped onto Mantine's much smaller scale, so
+     * a modal that said `small` went from 720px to 440px and one that said nothing at all
+     * went from 900px to 440px.  That is deliberate now -- the sizes were audited call site
+     * by call site against this scale -- but it means the table IS the design, and a quiet
+     * edit to it moves seventy modals at once.
+     */
+    const MANTINE_PX = {xs: 320, sm: 380, md: 440, lg: 620, xl: 780};
+
+    it('resolves each name to the width the audit was done against', () => {
+        // Read out of Mantine's own stylesheet rather than restated, so a version bump that
+        // changes the scale fails here instead of silently resizing the app.
+        const css = fs.readFileSync(
+            path.join(__dirname, '../../../node_modules/@mantine/core/styles.css'), 'utf8');
+
+        Object.entries(MANTINE_PX).forEach(([name, px]) => {
+            const declared = css.match(
+                new RegExp(`--modal-size-${name}:\\s*calc\\(([\\d.]+)rem`));
+            expect({name, px: declared && Math.round(parseFloat(declared[1]) * 16)})
+                .toEqual({name, px});
+        });
+    });
+
+    it('maps every Semantic name onto that scale', () => {
+        // The mapping the call sites are written against.  `fullscreen` is the one that did
+        // not shrink, and the one several audited modals were moved TO.
+        const source = fs.readFileSync(path.join(__dirname, 'Overlays.tsx'), 'utf8');
+        const table = source.match(/const modalSizes[^=]*=\s*{([^}]*)}/)[1];
+        const pairs = Object.fromEntries([...table.matchAll(/(\w+):\s*'([^']+)'/g)]
+            .map(m => [m[1], m[2]]));
+
+        expect(pairs).toEqual({
+            mini: 'xs', tiny: 'sm', small: 'md', large: 'lg', fullscreen: '100%',
+        });
+    });
+
+    it('never lets a call site name a size the table does not know', () => {
+        /*
+         * A name the table has never heard of is passed straight to Mantine, which ignores
+         * anything it does not recognise and renders the default -- so a typo is a modal that
+         * silently reverts to 440px with no warning anywhere.  Flasher was passing Mantine's
+         * own `sm` directly, which worked but bypassed the naming the audit used.
+         */
+        const known = new Set(['mini', 'tiny', 'small', 'large', 'fullscreen']);
+        const offenders = [];
+
+        const walk = (directory) => fs.readdirSync(directory, {withFileTypes: true})
+            .flatMap(entry => {
+                const full = path.join(directory, entry.name);
+                if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : walk(full);
+                if (!/\.(js|jsx|tsx)$/.test(entry.name)) return [];
+                if (/\.(test|cy)\./.test(entry.name)) return [];
+                return [[full, fs.readFileSync(full, 'utf8')]];
+            });
+
+        for (const [file, source] of walk(path.join(__dirname, '..', '..'))) {
+            // Only `<Modal ... size='x'>`; a computed `size={...}` is the caller's business.
+            for (const match of source.matchAll(/<Modal\b[^>]*?\bsize='([^']+)'/g)) {
+                if (!known.has(match[1])) {
+                    offenders.push(`${path.basename(file)}: size='${match[1]}'`);
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
Two things, both reported from the running app.

## Nested modals could not exist

Mantine binds a **window-level keydown listener per open modal**, gated only on whether that modal is open — nothing checks which one the user is looking at:

```js
// @mantine/core ModalBase/use-modal.mjs
useWindowEvent('keydown', (event) => {
  if (event.key === 'Escape' && closeOnEscape && !event.isComposing && opened) { ... onClose(); }
}, {capture: true});
```

Two open modals meant two listeners, so **one Escape closed both**. Reproduced on the dashboard: download modal, search modal over it, one press, both gone. They also both sat at `z-index: 200`, so which one drew on top was DOM order rather than which the user opened.

Mantine's own answer is `Modal.Stack` with a `stackId`, which is the only thing that gates `closeOnEscape`:

```js
const stackProps = ctx && stackId ? {closeOnEscape: ctx.currentId === stackId, ...} : {}
```

**Not used**, for two reasons: every call site would have to be rewritten to hoist its modal into a stack, and it sets `__hidden` on everything below the top — the parent *disappears* while the child is open. Roland asked for the parent dimmed and still visible, which is what it did before the migration.

So the wrapper keeps the register itself: a module-level list of open modals, most recent on top, from which each modal takes `closeOnEscape`, `trapFocus` and a z-index two above its parent. **Module-level rather than React context**, because the two modals in the bug aren't nested in the JSX at all — the search modal is rendered by `KeyboardShortcutsProvider` near the app root, the download modal by the dashboard. They're siblings that happen to be open together, and no context relates them. The increment is deliberately small: Mantine puts popovers at 300, and a stack climbing past that would paint over the select dropdowns inside its own forms.

## Widths

Roland audited the full modal list and chose sizes against Mantine's scale.

**Wider (16):** Download from the Internet, Upload from your device, Edit Tags, Unknown File, Add to Playlist, Add Samba Share, Edit Download, Edit Video Download, Edit Archive Download, Directory Conflict, Bulk Tag Files, Search Filters → `large` (620). Download Error ×2, Download Progress, Region Preview → `fullscreen`.

**Unchanged in pixels (11)**, but the size is now written down so the decision lives in the source rather than in a default: Tags picker, Channel tag picker, Sort By, Donate QR, Search, Share this page, Zim delete, Hotspot QR, New Inventory, Restore Backup (all `small`/440) and Unlock Cookies (`tiny`/380).

Flasher was passing Mantine's raw `sm` — worked, but bypassed the naming the audit used. It says `tiny` now.

## The size table is now guarded

It's the single thing that halved every modal in the migration, and a quiet edit moves seventy at once. Semantic's widths, **measured on the pre-migration build still running on the QA Pi**, against Mantine's, read out of its stylesheet:

| name | Semantic | Mantine | |
|---|---|---|---|
| mini | 360 | `xs` 320 | |
| tiny | 540 | `sm` 380 | −30% |
| small | 720 | `md` 440 | **−39%** |
| large | 1080 | `lg` 620 | −43% |
| *(none)* | 900 | `md` 440 | **−51%** |

Three cases hold the scale, the mapping, and the rule that no call site may name a size the table doesn't know — an unknown name is passed to Mantine, ignored, and silently rendered at the default, so a typo is a modal that quietly reverts to 440px.

## Testing

A real browser throughout: none of this is visible to jsdom — the listener is on `window` with capture, the stacking is z-index, and "still visible behind" is geometry.

One thing worth flagging: **`should('be.visible')` is the wrong assertion for the parent.** It's an occlusion check, so a child drawn correctly over its parent trips it — my first version failed on correct behaviour. The test now uses a wide viewport and asserts the parent is rendered (not `display:none`, not `visibility:hidden`, non-zero box) and shows to *both sides* of the child, which is the actual inverse of Mantine's hide-the-parent.

The register also has its own test: a modal that unmounts without deregistering would leave a ghost on top forever and then **nothing** would close on Escape — silent, permanent, and invisible to any test that only opens one modal.

**Planting the pre-fix behaviour reddens three.**

1124 jest / 62 suites, 8 in `modal-stack.cy.js`, clean `npm run build`. The 12 failures in `Tags/Channels/Download/Inventory.cy.js` are the known pre-existing Semantic-era selector failures — same four files, same count, unchanged.