### PR TITLE
fix: an unnamed language code took down the whole Zim manage page

### DIFF
--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -292,7 +292,7 @@ const ViewerMessage = () => {
     </HandPointMessage>
 }
 
-const ZimCatalogItemRow = ({item, subscriptions, iso_639_codes, fetchSubscriptions}) => {
+export const ZimCatalogItemRow = ({item, subscriptions, iso_639_codes, fetchSubscriptions}) => {
     const {name, languages, size} = item;
     const subscription = name in subscriptions ? subscriptions[name] : null;
     const subscriptionLanguage = subscription ? subscription['language'] : 'en';
@@ -328,8 +328,24 @@ const ZimCatalogItemRow = ({item, subscriptions, iso_639_codes, fetchSubscriptio
         }
     }
 
+    /*
+     * The code itself when the API's table has no name for it.
+     *
+     * `iso_639_codes` covers 639-1 and 639-2; the Kiwix catalog also carries 639-3 codes and
+     * locale variants -- `ami`, `ary`, `arz`, `be-tarask` -- and 89 of the codes in the
+     * catalog on a live WROLPi are absent from its 672-entry table.  Each of those produced
+     * `label: undefined`, and a `searchable` Mantine Select calls `option.label.toLowerCase()`
+     * while building its dropdown on mount, before anyone opens it.  One unnamed language
+     * anywhere in the catalog therefore took the whole /zim/manage page down.
+     *
+     * The code rather than a blank: a user choosing which language to subscribe to has to be
+     * able to tell one unnamed language from another, and the code is all we know.
+     *
+     * `iso_639_codes` is also null on first render -- ManageZim initialises it that way and
+     * fills it from the API -- so it is read defensively too.
+     */
     const languageOptions = languages.map(i => {
-        return {value: i, label: iso_639_codes[i]}
+        return {value: i, label: (iso_639_codes && iso_639_codes[i]) || i}
     });
     const languageDropdown = <Select
         searchable

--- a/app/src/components/Zim.test.js
+++ b/app/src/components/Zim.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import {render, screen} from '../test-utils';
+import {ZimCatalogItemRow} from './Zim';
+import {Table} from './ui';
+
+/*
+ * The Zim catalog's language dropdown.
+ *
+ * `/zim/manage` crashed the whole page -- a white screen with
+ * `Cannot read properties of undefined (reading 'toLowerCase')` repeated for every row.  The
+ * dropdown is built as `{value: code, label: iso_639_codes[code]}`, and the catalog carries
+ * language codes the API's table has no name for: 89 of them against a 672-entry table,
+ * measured from the running instance.  `ami`, `ary`, `arz`, `be-tarask` and the rest are
+ * ISO 639-3 codes and locale variants; the table is 639-1/639-2.
+ *
+ * A missing name gave the option `label: undefined`, and a `searchable` Mantine Select runs
+ * `option.label.toLowerCase()` while building its dropdown -- on mount, before anyone opens
+ * it.  So one unnamed language anywhere in the catalog took the page down.
+ */
+
+const item = (languages) => ({name: 'Wikipedia (mini)', languages, size: 1024});
+
+// The row renders `<Table.Row>`, which Mantine refuses to mount without a table around it --
+// so the row has to be given one, or the spec fails before it reaches the dropdown at all.
+const renderRow = (languages, iso_639_codes) => render(
+    <Table>
+        <Table.Body>
+            <ZimCatalogItemRow item={item(languages)} subscriptions={[]}
+                               iso_639_codes={iso_639_codes}/>
+        </Table.Body>
+    </Table>);
+
+// A deliberately small stand-in for the API's table: `eng` is named, `ami` is not.  That is
+// the whole shape of the bug.
+const codes = {eng: 'English', fra: 'French'};
+
+describe('the Zim catalog language dropdown', () => {
+    it('renders a language the code table has no name for', () => {
+        // `ami` is real -- it is in the catalog on a live WROLPi and absent from the table.
+        renderRow(['eng', 'ami'], codes);
+
+        expect(screen.getByPlaceholderText('Language')).toBeInTheDocument();
+    });
+
+    it('falls back to the code itself, so the option is still identifiable', () => {
+        /*
+         * Not a blank entry: a user subscribing to a Zim has to be able to tell one unnamed
+         * language from another, and the code is the only thing we know about it.  Mantine
+         * renders the selected option's label in the input.
+         */
+        renderRow(['ami'], codes);
+        const input = screen.getByPlaceholderText('Language');
+
+        // Mantine keeps the options in the DOM for a closed dropdown's combobox; the label
+        // is what a user reads when they open it.
+        expect(input).toBeInTheDocument();
+        expect(document.body.textContent).toContain('ami');
+    });
+
+    it('still prefers the real name when the table has one', () => {
+        // The inverse: falling back must not replace names that exist.
+        renderRow(['eng'], codes);
+
+        expect(document.body.textContent).toContain('English');
+        expect(document.body.textContent).not.toContain('eng<');
+    });
+
+    it('survives a table that never arrived', () => {
+        // ManageZim initialises `iso_639_codes: null` and fills it from the API, so the first
+        // render of every row happens with no table at all.
+        renderRow(['eng', 'ami'], null);
+
+        expect(screen.getByPlaceholderText('Language')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
`/zim/manage` rendered a white screen with `Cannot read properties of undefined (reading 'toLowerCase')` repeated once per catalog row.

## Cause

The language dropdown is built as `{value: code, label: iso_639_codes[code]}`.

That table covers ISO 639-1 and 639-2. The Kiwix catalog also carries **639-3 codes and locale variants** — `ami`, `ary`, `arz`, `be-tarask` — and measured against the running instance, **89 of the codes in the catalog are absent from its 672-entry table**. Every one produced `label: undefined`.

A `searchable` Mantine Select calls `option.label.toLowerCase()` while building its dropdown **on mount**, before anyone opens it. So one unnamed language anywhere in the catalog took the whole page down — and Wikipedia alone carries dozens.

## Fix

The option falls back to the code. Not to a blank: someone choosing a language to subscribe to has to be able to tell one unnamed language from another, and the code is the only thing we know about it.

`iso_639_codes` is read defensively too — `ManageZim` initialises it to `null` and fills it from the API, so the first render of every row happens with no table at all.

I checked the rest of the app for the same shape: the only other lookup-derived labels are in `ControllerPage` (`hotspotProtocolLabels[protocol] || protocol`) and `Configs` (`TYPE_LABELS[type] || type`), and both already fall back. Zim was the sole offender, so this stays a one-line fix rather than a guard in the `Select` wrapper — which is a bare re-export of Mantine's and would be a different change.

## Testing

Four cases, written first. Worth noting they initially failed for the **wrong reason** — `Table component was not found in the tree`, because the row renders `<Table.Row>` and Mantine refuses to mount one without a table. That would have proved nothing, so the row is now given the table it needs, and the specs then failed with the exact `toLowerCase` TypeError from the report.

One of the four is the inverse: a code the table **does** name must still render its name, so the fallback cannot quietly replace every label. It passed throughout, including while the other three were red.

1128 jest / 63 suites, clean `npm run build`. Confirmed on the running app — the page loads with 32 language dropdowns, 33 rows, and no error overlay.