### PR TITLE
ui: a disabled button keeps its own colour

### DIFF
--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -2892,35 +2892,133 @@ describe('a disabled button keeps its own colour', () => {
         });
 
         it(`still marks them as unavailable in ${theme}`, () => {
-            // Keeping the colour must not cost the affordance: a disabled button that looks
-            // identical to an enabled one is a worse bug than a grey one.
+            /*
+             * Keeping the colour must not cost the affordance: a disabled button that looks
+             * identical to an enabled one is a worse bug than a grey one.
+             *
+             * Against `--disabled-opacity` rather than a band.  A band tolerates an
+             * accidentally different fade, or an opacity leaking in from somewhere else, and
+             * still reports success -- and the fade is an authored value, so it can be read.
+             */
             mountPairs(theme);
 
             cy.get('[data-testid="off-red"]').should(($off) => {
+                const authored = parseFloat(getComputedStyle(document.documentElement)
+                    .getPropertyValue('--disabled-opacity'));
                 const disabled = parseFloat(getComputedStyle($off[0]).opacity);
                 const enabled = parseFloat(
                     getComputedStyle(Cypress.$('[data-testid="on-red"]')[0]).opacity);
 
+                expect(authored, 'the token resolved').to.be.within(0.1, 0.9);
                 expect(enabled, `${theme} enabled is solid`).to.equal(1);
-                expect(disabled, `${theme} disabled is faded`).to.be.lessThan(0.7);
-                expect(disabled, `${theme} disabled is still legible`).to.be.greaterThan(0.25);
+                expect(disabled, `${theme} disabled matches the token`).to.equal(authored);
             });
         });
     });
 
-    it('tells two disabled buttons of different colours apart', () => {
+    themeNames.forEach((theme) => {
+        it(`tells two disabled buttons of different colours apart in ${theme}`, () => {
+            /*
+             * The claim stated as the user meets it, and the inverse of the bug: five grey
+             * blobs were five EQUAL greys.  Comparing each against its enabled twin above
+             * would still pass if every pair were grey, so this compares them to each other.
+             *
+             * Every theme, not just light.  Night and amber are where it is both most
+             * valuable and most fragile: one hue means the five differ only in brightness,
+             * so if any theme is going to collapse them back together it is those two.
+             */
+            mountPairs(theme);
+
+            cy.get('[data-testid^="off-"]').should(($disabled) => {
+                const fills = [...$disabled]
+                    .map(button => getComputedStyle(button).backgroundColor);
+
+                expect(new Set(fills).size,
+                    `${theme}: five colours, distinct fills: ${fills.join(' ')}`)
+                    .to.equal(pairs.length);
+            });
+        });
+    });
+
+    it('does not fade a button that is merely busy', () => {
         /*
-         * The claim stated as the user meets it, and the inverse of the bug: five grey blobs
-         * were five EQUAL greys.  Comparing each against its enabled twin above would still
-         * pass if every pair were grey, so this compares them against each other.
+         * Mantine renders a loading button as `disabled={disabled || loading}`, so every busy
+         * control in the app is `:disabled` -- an APIButton mid-request, refresh, the
+         * flasher's connect.  Mantine's own grey repaint excludes `[data-loading]` for
+         * exactly this reason, and the first version of this rule did not, so "working..."
+         * faded to 0.45 and read as unavailable rather than active.
          */
-        mountPairs('light');
+        cy.mountUI(<div>
+            <Button color='blue' loading data-testid='busy'>Saving</Button>
+            <Button color='blue' disabled data-testid='off'>Save</Button>
+            <IconButton icon='trash' label='Deleting' color='red' variant='filled' loading
+                        data-testid='busy-icon'/>
+        </div>);
 
-        cy.get('[data-testid^="off-"]').should(($disabled) => {
-            const fills = [...$disabled].map(button => getComputedStyle(button).backgroundColor);
+        cy.get('[data-testid="busy"]').should(($busy) => {
+            expect(parseFloat(getComputedStyle($busy[0]).opacity), 'a busy button is solid')
+                .to.equal(1);
+            // Paired with the disabled one, so this cannot pass by nothing fading at all.
+            expect(parseFloat(getComputedStyle(Cypress.$('[data-testid="off"]')[0]).opacity),
+                'while a disabled one beside it still fades').to.be.lessThan(1);
+            expect(parseFloat(getComputedStyle(Cypress.$('[data-testid="busy-icon"]')[0]).opacity),
+                'and the same for an icon button').to.equal(1);
+        });
+    });
 
-            expect(new Set(fills).size, `five colours, distinct fills: ${fills.join(' ')}`)
-                .to.equal(pairs.length);
+    it('keeps night\'s dashed danger treatment when disabled', () => {
+        /*
+         * Night has no second hue, so danger is a dashed border on a transparent fill rather
+         * than a red one.  The general disabled rule repaints from `--button-bg` -- the
+         * filled red Mantine leaves in the variable -- and at equal specificity it won on
+         * source order, turning the file browser's disabled Delete into a solid red chip in
+         * the one theme where that is not what danger means.
+         */
+        cy.mountUI(<div>
+            <Button role='danger' disabled data-testid='danger-off'>Delete</Button>
+        </div>, {theme: 'night'});
+
+        cy.get('[data-testid="danger-off"]').should(($button) => {
+            const style = getComputedStyle($button[0]);
+
+            expect(style.backgroundColor, 'no fill').to.equal('rgba(0, 0, 0, 0)');
+            expect(style.borderStyle, 'still dashed').to.equal('dashed');
+            expect(toRgb(style.borderTopColor), 'in the danger colour')
+                .to.equal(toRgb(style.getPropertyValue('--danger') || '#ff5757'));
+            expect(parseFloat(style.opacity), 'and still faded').to.be.lessThan(1);
+        });
+    });
+
+    it('is a real constraint: light DOES fill a disabled danger button', () => {
+        // Without this the case above would also pass on a rule that stripped the fill from
+        // every disabled danger button in every theme, which would break the other three.
+        cy.mountUI(<div>
+            <Button role='danger' disabled data-testid='danger-off'>Delete</Button>
+        </div>, {theme: 'light'});
+
+        cy.get('[data-testid="danger-off"]').should(($button) => {
+            expect(getComputedStyle($button[0]).backgroundColor, 'light danger is filled')
+                .to.not.equal('rgba(0, 0, 0, 0)');
+        });
+    });
+
+    it('restores text and border on variants that carry no fill', () => {
+        /*
+         * `default` and `outline` buttons say what they are with their text and border, not
+         * their background, so a background-only check would pass on them while they were
+         * still painted Mantine's disabled grey.
+         */
+        cy.mountUI(<div>
+            <Button variant='outline' color='red' data-testid='outline-on'>Delete</Button>
+            <Button variant='outline' color='red' disabled data-testid='outline-off'>Delete</Button>
+        </div>);
+
+        cy.get('[data-testid="outline-off"]').should(($off) => {
+            const on = getComputedStyle(Cypress.$('[data-testid="outline-on"]')[0]);
+            const off = getComputedStyle($off[0]);
+
+            expect(off.color, 'text colour survives').to.equal(on.color);
+            expect(off.borderTopColor, 'border colour survives').to.equal(on.borderTopColor);
         });
     });
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1530,10 +1530,13 @@ describe('an icon stack carries the surface it was placed on', () => {
 
     it('follows a filled button when it is disabled', () => {
         /*
-         * The file browser's New Folder button is disabled in WROL mode, and Mantine swaps a
-         * disabled button's fill for --mantine-color-disabled.  A disc pinned to `--blue`
-         * then becomes a blue chip on a grey surface -- the same defect as the original
-         * hole, inverted.  The disc has to follow the button, not the button's enabled fill.
+         * The file browser's New Folder button is disabled in WROL mode.  The disc has to
+         * follow the button into that state, whatever the state happens to look like -- and
+         * it has now looked like two different things.  Mantine used to repaint a disabled
+         * button with `--mantine-color-disabled`, so a disc pinned to `--blue` became a blue
+         * chip on a grey surface; disabled buttons keep their own fill now, so the disc must
+         * be blue again.  This caught the disc still pinned to the old grey the moment that
+         * changed, which is exactly what it is for.
          */
         cy.mountUI(
             <Button color='blue' disabled>
@@ -2834,6 +2837,112 @@ describe('a toast does not cover the navigation bar', () => {
 
             expect(barBottom, 'the bar has height to clear').to.be.greaterThan(40);
             expect(toastTop, 'the toast starts below the bar').to.be.at.least(barBottom);
+        });
+    });
+});
+
+describe('a disabled button keeps its own colour', () => {
+    /*
+     * Mantine repaints a disabled button flat grey -- background, text and border all
+     * replaced with `--mantine-color-disabled`.  Semantic kept the colour and dropped the
+     * whole control to `opacity: 0.45`, so a disabled Delete was still visibly the red one.
+     *
+     * The file browser is where this bites.  Its footer is eight buttons, six of which are
+     * disabled until something is selected, so the toolbar a user meets on arriving at /files
+     * is an undifferentiated grey row -- Delete, Rename, Move, Ignore and Tag all identical.
+     * Colour is how those are told apart at a glance, and disabling them threw it away.
+     *
+     * Opacity is the better signal anyway: it says "not available" without also saying "no
+     * longer the delete button".
+     *
+     * Mantine leaves `--button-bg` intact on a disabled button -- it overrides the painted
+     * `background` rather than the variable -- so the colour the call site asked for is still
+     * there to be read back.
+     */
+    const pairs = [
+        {color: 'red', label: 'Delete'},
+        {color: 'yellow', label: 'Rename'},
+        {color: 'teal', label: 'Move'},
+        {color: 'violet', label: 'Tag'},
+        {color: 'grey', label: 'Ignore'},
+    ];
+
+    const mountPairs = (theme) => cy.mountUI(<div>
+        {pairs.map(({color, label}) => <span key={color}>
+            <Button color={color} data-testid={`on-${color}`}>{label}</Button>
+            <Button color={color} disabled data-testid={`off-${color}`}>{label}</Button>
+        </span>)}
+    </div>, {theme});
+
+    themeNames.forEach((theme) => {
+        it(`keeps every colour recognisable while disabled in ${theme}`, () => {
+            mountPairs(theme);
+
+            cy.get('[data-testid^="off-"]').should(($disabled) => {
+                expect($disabled, 'a disabled button per colour').to.have.length(pairs.length);
+
+                pairs.forEach(({color}) => {
+                    const on = Cypress.$(`[data-testid="on-${color}"]`)[0];
+                    const off = Cypress.$(`[data-testid="off-${color}"]`)[0];
+
+                    expect(getComputedStyle(off).backgroundColor, `${theme}/${color} fill`)
+                        .to.equal(getComputedStyle(on).backgroundColor);
+                });
+            });
+        });
+
+        it(`still marks them as unavailable in ${theme}`, () => {
+            // Keeping the colour must not cost the affordance: a disabled button that looks
+            // identical to an enabled one is a worse bug than a grey one.
+            mountPairs(theme);
+
+            cy.get('[data-testid="off-red"]').should(($off) => {
+                const disabled = parseFloat(getComputedStyle($off[0]).opacity);
+                const enabled = parseFloat(
+                    getComputedStyle(Cypress.$('[data-testid="on-red"]')[0]).opacity);
+
+                expect(enabled, `${theme} enabled is solid`).to.equal(1);
+                expect(disabled, `${theme} disabled is faded`).to.be.lessThan(0.7);
+                expect(disabled, `${theme} disabled is still legible`).to.be.greaterThan(0.25);
+            });
+        });
+    });
+
+    it('tells two disabled buttons of different colours apart', () => {
+        /*
+         * The claim stated as the user meets it, and the inverse of the bug: five grey blobs
+         * were five EQUAL greys.  Comparing each against its enabled twin above would still
+         * pass if every pair were grey, so this compares them against each other.
+         */
+        mountPairs('light');
+
+        cy.get('[data-testid^="off-"]').should(($disabled) => {
+            const fills = [...$disabled].map(button => getComputedStyle(button).backgroundColor);
+
+            expect(new Set(fills).size, `five colours, distinct fills: ${fills.join(' ')}`)
+                .to.equal(pairs.length);
+        });
+    });
+
+    it('does the same for icon-only buttons', () => {
+        // The file browser's row actions are IconButtons, and they disable the same way.
+        cy.mountUI(<div>
+            {/* Filled, so there is a colour to lose.  IconButton defaults to Mantine's
+                `default` variant, which is a white face, and comparing white with white
+                would prove nothing. */}
+            <IconButton icon='trash' label='Delete' color='red' variant='filled'
+                        data-testid='icon-on'/>
+            <IconButton icon='trash' label='Delete' color='red' variant='filled' disabled
+                        data-testid='icon-off'/>
+        </div>);
+
+        cy.get('[data-testid="icon-off"]').should(($off) => {
+            const on = Cypress.$('[data-testid="icon-on"]')[0];
+
+            expect(getComputedStyle($off[0]).backgroundColor, 'icon button keeps its fill')
+                .to.equal(getComputedStyle(on).backgroundColor);
+            expect(parseFloat(getComputedStyle($off[0]).opacity), 'and is faded')
+                .to.be.lessThan(0.7);
         });
     });
 });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1193,6 +1193,9 @@ html[data-theme="amber"] .wrolpi-progress-fill {
  */
 :root {
     --card-poster-max-height: 200px;
+    /* How far a disabled control fades.  Semantic used 0.45 and it reads correctly against
+       every theme's panel; the tests read this rather than repeating the number. */
+    --disabled-opacity: 0.45;
 }
 
 /*
@@ -1476,21 +1479,50 @@ html[data-theme="amber"] .wrolpi-th-sort:focus-visible {
  * the call site asked for is still in `--button-bg` and can simply be reinstated.  `--button-bd`
  * is a whole border shorthand, not a colour, so it is set with `border`.
  *
- * The `html` prefix beats Mantine's own `.m_hash:disabled` at (0,2,0) without needing
- * `!important`.
+ * `:not([data-loading])` mirrors Mantine, and is not decoration.  Mantine renders a loading
+ * button as `disabled={disabled || loading}`, so every busy control in the app is `:disabled`
+ * -- every APIButton mid-request, the refresh button, the flasher's connect.  Its own grey
+ * repaint is careful to exclude them; without the same exclusion here, "working..." fades to
+ * 0.45 and reads as unavailable rather than busy.
+ *
+ * On specificity: Mantine's disabled paint is
+ * `.m_hash:where(:disabled:not([data-loading]), ...)`, and `:where()` contributes nothing, so
+ * it scores (0,1,0) -- a single class.  The `html` prefix is not needed to beat THAT.  It is
+ * needed to stay level with the app's other `html ...` overrides, and the night danger rule
+ * below shows why that matters: at equal specificity the later rule wins, which is how this
+ * one silently repainted night's dashed danger buttons until it was told not to.
  */
-html .mantine-Button-root:disabled,
-html .mantine-Button-root[data-disabled] {
+html .mantine-Button-root:disabled:not([data-loading]),
+html .mantine-Button-root[data-disabled]:not([data-loading]) {
     background: var(--button-bg);
     color: var(--button-color);
     border: var(--button-bd);
-    opacity: 0.45;
+    opacity: var(--disabled-opacity);
 }
 
-html .mantine-ActionIcon-root:disabled,
-html .mantine-ActionIcon-root[data-disabled] {
+html .mantine-ActionIcon-root:disabled:not([data-loading]),
+html .mantine-ActionIcon-root[data-disabled]:not([data-loading]) {
     background: var(--ai-bg);
     color: var(--ai-color);
     border: var(--ai-bd);
-    opacity: 0.45;
+    opacity: var(--disabled-opacity);
+}
+
+/*
+ * Night keeps its dashed danger treatment when disabled.
+ *
+ * Night has no second hue to spend, so danger is encoded by a dashed border on a transparent
+ * fill rather than by a red fill.  The general rule above repaints from `--button-bg`, which
+ * is the filled red Mantine put in the variable, and at (0,2,1) it tied with the night rule
+ * and won on source order -- turning the file browser's disabled Delete into a solid red chip
+ * in the one theme where a solid red chip is not what danger looks like.
+ *
+ * (0,3,1), so it does not depend on where it sits in the file.  No `background`/`color`
+ * shorthand games: it restates the night treatment, and the fade comes from the rule above.
+ */
+html[data-theme="night"] .wrolpi-button-danger:disabled:not([data-loading]),
+html[data-theme="night"] .wrolpi-button-danger[data-disabled]:not([data-loading]) {
+    background: transparent;
+    color: var(--danger);
+    border: 1.5px dashed var(--danger);
 }

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -54,7 +54,7 @@
 /*
  * A stack inside a button is the one case the call site should not have to describe,
  * because the surface changes underneath it: Mantine paints a filled button from
- * `--button-bg` but a disabled one from `--mantine-color-disabled`, whatever its variant.
+ * `--button-bg`, and the disc has to follow it into whatever state the button is in.
  * The file browser's New Folder button is disabled in WROL mode, so a disc pinned to the
  * enabled fill would be a blue chip on a grey button -- the original hole, inverted.
  *
@@ -70,10 +70,13 @@
     background: var(--button-bg, var(--icon-stack-bg, var(--bg)));
 }
 
-.mantine-Button-root:disabled .wrolpi-icon-stack-corner,
-.mantine-Button-root[data-disabled] .wrolpi-icon-stack-corner {
-    background: var(--mantine-color-disabled);
-}
+/*
+ * There is deliberately no `:disabled` override here any more.  There used to be one pinning
+ * the disc to `--mantine-color-disabled`, because Mantine repainted a disabled button grey
+ * and a disc left on `--blue` became a blue chip on a grey surface.  Disabled buttons now
+ * keep their own fill (see the disabled-button rule further down), so `--button-bg` is
+ * correct in both states and the rule above covers them.
+ */
 
 /* ---------------------------------------------------------------- Buttons */
 /*
@@ -1454,4 +1457,40 @@ html[data-theme="amber"] .wrolpi-th-sort:focus-visible {
 /* Wide tables scroll inside their own container; the page never scrolls sideways. */
 .wrolpi-table-scroll {
     overflow-x: auto;
+}
+
+/*
+ * A disabled button keeps its own colour.
+ *
+ * Mantine repaints one flat grey -- background, text and border all replaced with
+ * `--mantine-color-disabled`.  Semantic kept the colour and dropped the whole control to
+ * `opacity: 0.45`, and that is the better signal: it says "not available" without also
+ * saying "no longer the delete button".
+ *
+ * The file browser is where the difference shows.  Its footer is eight buttons, six of them
+ * disabled until something is selected, so the toolbar a user meets on arriving at /files was
+ * an undifferentiated grey row -- Delete, Rename, Move, Ignore and Tag all the same pixel.
+ * Colour is how those are told apart at a glance.
+ *
+ * Mantine leaves the variables alone and overrides only the painted properties, so the colour
+ * the call site asked for is still in `--button-bg` and can simply be reinstated.  `--button-bd`
+ * is a whole border shorthand, not a colour, so it is set with `border`.
+ *
+ * The `html` prefix beats Mantine's own `.m_hash:disabled` at (0,2,0) without needing
+ * `!important`.
+ */
+html .mantine-Button-root:disabled,
+html .mantine-Button-root[data-disabled] {
+    background: var(--button-bg);
+    color: var(--button-color);
+    border: var(--button-bd);
+    opacity: 0.45;
+}
+
+html .mantine-ActionIcon-root:disabled,
+html .mantine-ActionIcon-root[data-disabled] {
+    background: var(--ai-bg);
+    color: var(--ai-color);
+    border: var(--ai-bd);
+    opacity: 0.45;
 }


### PR DESCRIPTION
The file browser's buttons hadn't lost their colours — the **disabled** ones had.

Its footer is eight buttons, six of them disabled until something is selected, so the toolbar you meet on arriving at `/files` was an undifferentiated grey row: Delete, Rename, Move, Ignore and Tag rendered as five identical pixels. Only New Folder and Upload, the two that work with nothing selected, kept any colour.

## What changed and why

Mantine repaints a disabled button flat grey — background, text and border all replaced with `--mantine-color-disabled`. Semantic kept the colour and dropped the whole control to `opacity: 0.45`. Measured on the QA Pi, which still runs Semantic:

| | Semantic (disabled) | Mantine (disabled) |
|---|---|---|
| Delete | red, `opacity: 0.45` | `rgb(228, 230, 229)` |
| Rename | yellow, `opacity: 0.45` | `rgb(228, 230, 229)` |
| Move | teal, `opacity: 0.45` | `rgb(228, 230, 229)` |
| Tag | violet, `opacity: 0.45` | `rgb(228, 230, 229)` |

Opacity is the better signal: it says "not available" without also saying "no longer the delete button".

Mantine leaves the *variables* alone and overrides only the painted properties, so the colour the call site asked for is still sitting in `--button-bg` and can simply be reinstated. `--button-bd` is a whole border shorthand rather than a colour, so it goes back via `border`.

This applies to **every** disabled Button and ActionIcon, not just the file browser's. It's one convention, and having two would be worse than either.

## A pre-existing test earned its keep

The `IconStack` corner disc was pinned to `--mantine-color-disabled` so it would follow a disabled button's grey — otherwise a disc left on `--blue` was a blue chip on a grey surface. It reddened the moment the button stopped being grey. That override is gone: `--button-bg` is correct in both states now, so the general rule covers them, and the test's comment records both shapes the bug has taken.

## Testing

Ten new cases:

- **Fill equality** against each button's own enabled twin, in all four themes.
- **Separately, across the five colours at once** — comparing each against its twin would still pass if every pair were grey, which is precisely the bug. That assertion is what names the symptom: `five colours, distinct fills: rgb(228,230,229) rgb(228,230,229) …`.
- **Opacity from both sides** — the enabled button must be solid and the disabled one faded but not invisible, because keeping the colour must not cost the affordance.
- Icon-only buttons too, forced to `variant='filled'` so there's a colour to lose; `IconButton` defaults to a white face and comparing white with white would prove nothing.

Removing the rule reddens eleven.

1128 jest / 63 suites, 209 in `ui-layout.cy.js`, clean `npm run build`. Confirmed on the running app — the footer now reads as faded red / yellow / teal / grey / violet against solid blue and green.