### PR TITLE
ui: three button-layout defects, each with a different cause

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -597,6 +597,19 @@ table.ratio-table td.min-width {
     background-color: var(--panel);
     border-top: 1px solid var(--border);
     z-index: 100;
+    /*
+     * A row with gaps, like every other group of buttons in the app.
+     *
+     * This was a plain block, so the buttons -- inline-block elements with no whitespace
+     * between them, because JSX drops whitespace-only lines -- sat flush against each other
+     * in one unbroken slab.  Everywhere else buttons are laid out with Mantine's `Group`,
+     * which is a flex row with a gap; the file browser's footer is hand-rolled and never got
+     * one.  It wraps because the bar carries eight controls and a phone cannot hold them.
+     */
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5em;
 }
 
 /* Drag selection visual feedback for FileBrowser */

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -83,7 +83,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((
      * too narrow for words.  Those buttons are icon-only at exactly the widths where the
      * offset is most visible.
      */
-    const labelled = React.Children.toArray(children).length > 0;
+    /*
+     * Blank text is not a label.  `toArray` drops null, undefined and booleans, but keeps an
+     * empty or whitespace-only string, which would leave the icon in `leftSection` with its
+     * margin and the glyph off-centre again.  No call site does that today; the predicate
+     * should not depend on that staying true.
+     *
+     * Two limits, both deliberate.  "Icon-only" means exactly one of `icon`/`iconAfter`: a
+     * label-less button with both would keep both section margins and stay mis-centred, and
+     * there are no such call sites to design for.  And any ELEMENT child counts as a label,
+     * including an empty fragment -- `toArray` does not look inside one, so `<></>` is
+     * indistinguishable from real content without recursing into fragment props.
+     */
+    const labelled = React.Children.toArray(children)
+        .some(child => typeof child !== 'string' || child.trim().length > 0);
     const soleIcon = !labelled && (icon || iconAfter) && !(icon && iconAfter)
         ? renderIcon(icon || iconAfter)
         : undefined;

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -65,9 +65,29 @@ export const resolveSize = <T, >(size: T): T =>
     typeof size === 'string' ? ((semanticSizes[size] ?? size) as T) : size;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>((
-    {role, icon, iconAfter, className, ...props}, ref
+    {role, icon, iconAfter, className, children, ...props}, ref
 ) => {
     const fromRole = role ? roleProps[role] : undefined;
+
+    /*
+     * An icon with no label is the button's CONTENT, not a leading icon.
+     *
+     * Mantine gives `leftSection` a `margin-inline-end` to hold it off the label.  With no
+     * label that margin is pure offset: the glyph sits about 8px left of the button's centre,
+     * which is what the import and save buttons on the Settings config table looked like next
+     * to a correctly centred Restore -- Restore is an IconButton, which centres a lone glyph
+     * by construction.
+     *
+     * `React.Children.toArray` drops null, undefined and booleans, which matters because the
+     * file browser's footer passes `{label('Delete')}` and that is null whenever the bar is
+     * too narrow for words.  Those buttons are icon-only at exactly the widths where the
+     * offset is most visible.
+     */
+    const labelled = React.Children.toArray(children).length > 0;
+    const soleIcon = !labelled && (icon || iconAfter) && !(icon && iconAfter)
+        ? renderIcon(icon || iconAfter)
+        : undefined;
+
     return <MButton
         ref={ref}
         /*
@@ -81,11 +101,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((
         color={props.color ?? fromRole?.color}
         variant={props.variant ?? fromRole?.variant}
         className={[fromRole?.className, className].filter(Boolean).join(' ') || undefined}
-        leftSection={renderIcon(icon)}
-        rightSection={renderIcon(iconAfter)}
+        leftSection={soleIcon ? undefined : renderIcon(icon)}
+        rightSection={soleIcon ? undefined : renderIcon(iconAfter)}
         {...props}
         size={resolveSize(props.size)}
-    />
+    >
+        {soleIcon ?? children}
+    </MButton>
 });
 Button.displayName = 'Button';
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -3105,6 +3105,56 @@ describe('a button with an icon and no label centres the icon', () => {
         });
     });
 
+    it('treats blank and empty children as no label', () => {
+        /*
+         * `Children.toArray` drops null, undefined and booleans but KEEPS an empty or
+         * whitespace-only string, so a length check alone would call these labelled and leave
+         * the glyph off-centre.
+         */
+        cy.mountUI(<div>
+            <Button icon='upload' aria-label='Empty' data-testid='empty'>{''}</Button>
+            <Button icon='upload' aria-label='Blank' data-testid='blank'>{'   '}</Button>
+        </div>);
+
+        cy.get('[data-testid="blank"]').should(() => {
+            ['empty', 'blank'].forEach((id) => {
+                const button = Cypress.$(`[data-testid="${id}"]`)[0];
+                const box = button.getBoundingClientRect();
+                const glyph = button.querySelector('svg').getBoundingClientRect();
+
+                expect((glyph.left + glyph.width / 2) - (box.left + box.width / 2),
+                    `${id} glyph centre`).to.be.closeTo(0, 1);
+            });
+        });
+    });
+
+    it('treats any element child as a label, including an empty fragment', () => {
+        /*
+         * Recording what actually happens rather than what would be tidy.  `toArray` does not
+         * look inside a fragment -- it returns the fragment itself as one child -- so `<></>`
+         * is indistinguishable from real content and the icon stays in `leftSection`.
+         *
+         * Detecting it would mean recursing into fragment props, and no call site writes an
+         * empty fragment as a button's children.  `<>Delete</>` is the shape that does occur,
+         * and it lands on the same path for the right reason.
+         */
+        cy.mountUI(<div>
+            <Button icon='trash' data-testid='fragment'><></></Button>
+            <Button icon='trash' data-testid='wrapped'><>Delete</></Button>
+        </div>);
+
+        cy.get('[data-testid="wrapped"]').should(() => {
+            ['fragment', 'wrapped'].forEach((id) => {
+                const button = Cypress.$(`[data-testid="${id}"]`)[0];
+                const box = button.getBoundingClientRect();
+                const glyph = button.querySelector('svg').getBoundingClientRect();
+
+                expect((glyph.left + glyph.width / 2) - (box.left + box.width / 2),
+                    `${id} keeps the icon leading`).to.be.lessThan(-3);
+            });
+        });
+    });
+
     it('centres a trailing-only icon too', () => {
         // `rightSection` has the mirror-image margin.
         cy.mountUI(<Button iconAfter='upload' aria-label='Send' data-testid='after-only'/>);
@@ -3222,6 +3272,73 @@ describe('the search field\'s clear button is attached to it', () => {
             expect(parseFloat(style.borderLeftWidth), 'a divider on its left')
                 .to.be.greaterThan(0);
             expect(style.borderLeftStyle).to.not.equal('none');
+        });
+    });
+
+    it('keeps the loading spinner off the clear button', () => {
+        /*
+         * `SearchResultsInput` can pass `loading` and `clearable` together, and the DOM order
+         * is input, spinner, clear.  An earlier version of the weld cancelled the flex gap on
+         * the clear button's LEFT as well as the padding on its right, which welded the
+         * spinner to the divider -- the spinner is not part of this control.
+         */
+        cy.mountUI(<div style={{width: 420}}>
+            <SearchBox value='wind turbine' clearable loading onChange={() => {}}/>
+        </div>);
+
+        cy.get('.wrolpi-searchbox-loading').should(($spinner) => {
+            const clear = Cypress.$('.wrolpi-searchbox-clear')[0].getBoundingClientRect();
+
+            expect(clear.left - $spinner[0].getBoundingClientRect().right,
+                'gap between the spinner and the divider').to.be.greaterThan(2);
+        });
+    });
+
+    it('owns the height in both directions, not just downwards', () => {
+        /*
+         * `align-self: stretch` cannot shrink a box below its own `min-height`, and Mantine
+         * sets that from `--ai-size` alongside `height`.  Overriding `height` alone owns the
+         * sizing in one direction only -- it happens to look right because the field is
+         * 36.15px against a 36px minimum, a margin of 0.15px.
+         *
+         * The property rather than the geometry, deliberately.  Making the field genuinely
+         * shorter than 36px means overriding the input's own font size and padding, which no
+         * part of the app does, and a test that fabricates a layout to prove a rule is not
+         * evidence about this app.  This asserts what the rule is for: the minimum is no
+         * longer `--ai-size`.  Removing `min-height: unset` fails it.
+         */
+        cy.mountUI(<div style={{width: 420}}>
+            <SearchBox value='wind turbine' clearable onChange={() => {}}/>
+            {/* An ActionIcon outside the field, to show where the minimum comes from. */}
+            <IconButton icon='trash' label='Delete' data-testid='plain'/>
+        </div>);
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            /*
+             * Resolved lengths, not the raw variable: `--ai-size` reads back as
+             * `calc(2.25rem * var(--mantine-scale))` while `min-height` computes to `36px`, so
+             * comparing the two strings can never match and asserts nothing.  The first
+             * version of this did exactly that and stayed green with the rule removed.
+             */
+            const minimum = (element) => parseFloat(getComputedStyle(element).minHeight) || 0;
+
+            // The inverse and the premise together: an ordinary IconButton DOES carry the
+            // minimum, so its absence here is this rule's doing and not Mantine's default.
+            expect(minimum(Cypress.$('[data-testid="plain"]')[0]),
+                'an ordinary icon button has a minimum height').to.be.greaterThan(0);
+            expect(minimum($clear[0]), 'the welded one does not').to.equal(0);
+        });
+    });
+
+    it('has square corners, so nothing shows through at the field edge', () => {
+        // A rounded ActionIcon stretched flush to a square field leaves panel-coloured wedges
+        // at the corners.  Nothing sets this here: the theme zeroes every radius, and this
+        // records that the weld depends on it.
+        mountField();
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            expect(getComputedStyle($clear[0]).borderRadius, 'no rounded corners')
+                .to.equal('0px');
         });
     });
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -3044,3 +3044,200 @@ describe('a disabled button keeps its own colour', () => {
         });
     });
 });
+
+describe('a button with an icon and no label centres the icon', () => {
+    /*
+     * Mantine's `leftSection` carries a `margin-inline-end` to hold the icon off the label.
+     * With no label that margin is pure offset, and the glyph sits about 8px left of the
+     * button's centre.
+     *
+     * The Settings config table is where it showed: Import and Save are icon-only Buttons and
+     * looked visibly off, while Restore in the same row looked right -- Restore is an
+     * IconButton, which centres a lone glyph by construction.  Measured on the running app at
+     * -8px before the fix.
+     */
+    it('puts the glyph in the middle when there is nothing else in the button', () => {
+        cy.mountUI(<Button icon='upload' aria-label='Import' data-testid='icon-only'/>);
+
+        cy.get('[data-testid="icon-only"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+            const glyph = $button[0].querySelector('svg').getBoundingClientRect();
+            const offset = (glyph.left + glyph.width / 2) - (box.left + box.width / 2);
+
+            expect(box.width, 'the button has width to be off-centre in')
+                .to.be.greaterThan(glyph.width + 8);
+            expect(offset, 'glyph centre vs button centre').to.be.closeTo(0, 1);
+        });
+    });
+
+    it('treats a null label as no label, which is how the file browser renders', () => {
+        /*
+         * The footer passes `{label('Delete')}`, and that is null whenever the bar is too
+         * narrow for words -- so those buttons are icon-only at exactly the widths where the
+         * offset is most visible.  `React.Children.toArray` drops nulls; a plain truthiness
+         * check on `children` would not.
+         */
+        cy.mountUI(<Button icon='trash' aria-label='Delete' data-testid='null-label'>
+            {null}
+        </Button>);
+
+        cy.get('[data-testid="null-label"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+            const glyph = $button[0].querySelector('svg').getBoundingClientRect();
+
+            expect((glyph.left + glyph.width / 2) - (box.left + box.width / 2),
+                'glyph centre vs button centre').to.be.closeTo(0, 1);
+        });
+    });
+
+    it('is a real constraint: a labelled button keeps its icon on the left', () => {
+        // The inverse.  Centring the glyph must not apply when there IS a label, or every
+        // labelled button in the app loses its leading icon's position.
+        cy.mountUI(<Button icon='trash' data-testid='labelled'>Delete</Button>);
+
+        cy.get('[data-testid="labelled"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+            const glyph = $button[0].querySelector('svg').getBoundingClientRect();
+
+            expect((glyph.left + glyph.width / 2) - (box.left + box.width / 2),
+                'the icon leads the label').to.be.lessThan(-4);
+            expect($button[0].textContent, 'and the label is still there').to.contain('Delete');
+        });
+    });
+
+    it('centres a trailing-only icon too', () => {
+        // `rightSection` has the mirror-image margin.
+        cy.mountUI(<Button iconAfter='upload' aria-label='Send' data-testid='after-only'/>);
+
+        cy.get('[data-testid="after-only"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+            const glyph = $button[0].querySelector('svg').getBoundingClientRect();
+
+            expect((glyph.left + glyph.width / 2) - (box.left + box.width / 2))
+                .to.be.closeTo(0, 1);
+        });
+    });
+});
+
+describe('the file browser footer is a row of buttons, not a slab', () => {
+    /*
+     * The footer was a plain block, so its buttons -- inline-block elements with no whitespace
+     * between them, since JSX drops whitespace-only lines -- sat flush against each other in
+     * one unbroken bar.  Every other group of buttons in the app is a Mantine `Group`, which
+     * is a flex row with a gap; this one is hand-rolled and never got one.
+     *
+     * The class carries the layout, so the class is what is mounted.  FileBrowser itself
+     * needs the file API, drag selection and a router, none of which decides the spacing.
+     */
+    it('leaves a gap between adjacent buttons', () => {
+        cy.mountUI(<div className='sticky-footer'>
+            <Button color='red' data-testid='a'>Delete</Button>
+            <Button color='yellow' data-testid='b'>Rename</Button>
+            <Button color='teal' data-testid='c'>Move</Button>
+        </div>);
+
+        cy.get('.sticky-footer').should(($footer) => {
+            const boxes = ['a', 'b', 'c']
+                .map(id => $footer[0].querySelector(`[data-testid="${id}"]`).getBoundingClientRect());
+
+            expect(boxes[1].left - boxes[0].right, 'gap between the first two')
+                .to.be.greaterThan(2);
+            expect(boxes[2].left - boxes[1].right, 'gap between the next two')
+                .to.be.greaterThan(2);
+        });
+    });
+
+    it('keeps them on one line and vertically aligned', () => {
+        // A flex row is only right if it behaves like one: the buttons share a baseline and
+        // do not stack while there is room for them.
+        cy.mountUI(<div className='sticky-footer'>
+            <Button data-testid='a'>Delete</Button>
+            <Button data-testid='b'>Rename</Button>
+        </div>);
+
+        cy.get('.sticky-footer').should(($footer) => {
+            const a = $footer[0].querySelector('[data-testid="a"]').getBoundingClientRect();
+            const b = $footer[0].querySelector('[data-testid="b"]').getBoundingClientRect();
+
+            expect(a.top, 'same row').to.be.closeTo(b.top, 1);
+        });
+    });
+});
+
+describe('the search field\'s clear button is attached to it', () => {
+    /*
+     * The control is a bordered box with `padding: 0 8px`, so the clear button sat 9px short
+     * of the right edge and 2px short of the full height -- a glyph dropped inside the input
+     * rather than a control of its own.
+     *
+     * Semantic rendered it as an action button welded to the field.  Measured on the QA Pi,
+     * which still runs Semantic: zero gap from the input, zero to the outer edge, and the
+     * full height of the field.
+     */
+    const mountField = () => cy.mountUI(<div style={{width: 420}}>
+        <SearchBox value='wind turbine' clearable onChange={() => {}}/>
+    </div>);
+
+    it('meets the right-hand edge of the field', () => {
+        mountField();
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            const control = Cypress.$('.wrolpi-searchbox-control')[0].getBoundingClientRect();
+            const clear = $clear[0].getBoundingClientRect();
+
+            expect(control.right - clear.right, 'gap to the field edge').to.be.closeTo(0, 1.5);
+        });
+    });
+
+    it('fills the height of the field', () => {
+        /*
+         * Half the reason it read as "inside": a 36px control floating in a 38px box.
+         *
+         * Measured against the control's CONTENT box, not its border box.  The field's own
+         * 1px border is the only thing left above and below the button, and the button
+         * should sit inside it rather than paint over it -- `clientHeight` is that box, and
+         * comparing against `getBoundingClientRect().height` would be demanding the button
+         * cover the field's border, which is a different and wrong design.
+         */
+        mountField();
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            const control = Cypress.$('.wrolpi-searchbox-control')[0];
+            const border = parseFloat(getComputedStyle(control).borderTopWidth);
+
+            expect(border, 'the field has a border to sit inside').to.be.greaterThan(0);
+            expect($clear[0].getBoundingClientRect().height, 'clear button height')
+                .to.be.closeTo(control.clientHeight, 1);
+        });
+    });
+
+    it('is divided from the text rather than merged into it', () => {
+        // Attached is not the same as indistinguishable: without a rule between them the
+        // glyph reads as part of the input again, just further right.
+        mountField();
+
+        cy.get('.wrolpi-searchbox-clear').should(($clear) => {
+            const style = getComputedStyle($clear[0]);
+
+            expect(parseFloat(style.borderLeftWidth), 'a divider on its left')
+                .to.be.greaterThan(0);
+            expect(style.borderLeftStyle).to.not.equal('none');
+        });
+    });
+
+    it('is a real constraint: the field itself is still padded', () => {
+        /*
+         * The negative margins are aimed at one child.  If the control's padding had simply
+         * been removed instead, the search icon and the text would sit against the border
+         * too -- so this checks the thing that must NOT have moved.
+         */
+        mountField();
+
+        cy.get('.wrolpi-searchbox-icon').should(($icon) => {
+            const control = Cypress.$('.wrolpi-searchbox-control')[0].getBoundingClientRect();
+
+            expect($icon[0].getBoundingClientRect().left - control.left, 'icon is inset')
+                .to.be.greaterThan(4);
+        });
+    });
+});

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -307,10 +307,17 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
 .wrolpi-searchbox-control {
     display: flex;
     align-items: center;
-    gap: 8px;
+    /*
+     * One inset for the padding, the gap between children, and the negative margin that
+     * welds the clear button to the edge.  They were three separate 8px literals that had to
+     * stay in lockstep: changing the padding alone would have pushed the clear button past
+     * the border, and changing the gap alone would have re-inset it.
+     */
+    --searchbox-inset: 8px;
+    gap: var(--searchbox-inset);
     background: var(--panel);
     border: 1px solid var(--border);
-    padding: 0 8px;
+    padding: 0 var(--searchbox-inset);
 }
 
 .wrolpi-searchbox-control:focus-within {
@@ -357,20 +364,26 @@ html[data-theme="amber"] .wrolpi-searchbox-control:focus-within {
  * the field: measured on the QA Pi, zero gap to the input, zero to the outer edge, and the
  * full 44px height.
  *
- * Negative margins rather than removing the control's padding: the padding is what holds the
- * search icon and the text off the border, and only this one child should escape it.  The
- * left margin cancels the flex gap as well, so the divider lands against the text the way
- * the attached button did.
+ * A negative right margin rather than removing the control's padding: the padding is what
+ * holds the search icon and the text off the border, and only this one child should escape
+ * it.  The gap to its LEFT is deliberately left alone -- cancelling that too welded the
+ * loading spinner to the divider whenever a field was both `loading` and `clearable`, which
+ * SearchResultsInput does, and the spinner is not part of this control.
  *
  * `html` because Mantine sets ActionIcon's height from `--ai-size` on its own single class;
  * at equal specificity the winner is whichever stylesheet loaded last, which is not a thing
- * to rely on.
+ * to rely on.  `min-height` has to go with it: stretch cannot shrink a box below its own
+ * minimum, so leaving that at `--ai-size` would mean this rule only half-owned the height it
+ * claims to set -- true today only because the field happens to be the taller of the two.
+ *
+ * The corner radius needs no rule: the theme zeroes every `--mantine-radius-*`, so there are
+ * no rounded corners to leave panel-coloured wedges against the square field.
  */
 html .wrolpi-searchbox-clear {
     align-self: stretch;
     height: auto;
-    margin-left: -8px;
-    margin-right: -8px;
+    min-height: unset;
+    margin-right: calc(-1 * var(--searchbox-inset));
     border-left: 1px solid var(--border);
 }
 

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -349,6 +349,32 @@ html[data-theme="amber"] .wrolpi-searchbox-control:focus-within {
 }
 
 /*
+ * The clear button is attached to the field, not floating inside it.
+ *
+ * The control is a bordered box with `padding: 0 8px`, so the button sat 9px short of the
+ * right edge and 2px short of the full height -- reading as a glyph dropped inside the input
+ * rather than as a control of its own.  Semantic rendered this as an action button welded to
+ * the field: measured on the QA Pi, zero gap to the input, zero to the outer edge, and the
+ * full 44px height.
+ *
+ * Negative margins rather than removing the control's padding: the padding is what holds the
+ * search icon and the text off the border, and only this one child should escape it.  The
+ * left margin cancels the flex gap as well, so the divider lands against the text the way
+ * the attached button did.
+ *
+ * `html` because Mantine sets ActionIcon's height from `--ai-size` on its own single class;
+ * at equal specificity the winner is whichever stylesheet loaded last, which is not a thing
+ * to rely on.
+ */
+html .wrolpi-searchbox-clear {
+    align-self: stretch;
+    height: auto;
+    margin-left: -8px;
+    margin-right: -8px;
+    border-left: 1px solid var(--border);
+}
+
+/*
  * The suggestion list overlays the page rather than pushing it down — a search
  * that reflows the results underneath it is unusable while typing.
  */


### PR DESCRIPTION
Reported together as "button groups", but they're three unrelated causes. Each one answers a "why".

## Why the footer touches and Channel Edit doesn't

Channel Edit lays its buttons out with Mantine's `Group` — a flex row with a gap. The file browser's footer is hand-rolled and was a plain **block**, so its inline-block buttons sat flush against each other. There wasn't even a space character between them: JSX drops whitespace-only lines, so `<Button/>\n<Button/>` emits no text node at all.

`.sticky-footer` is now the flex row every other button group already is, wrapping because it carries eight controls and a phone can't hold them.

## Why Import/Save are off-centre and Restore isn't

**Restore is an `IconButton`** — an ActionIcon, which centres a lone glyph by construction. **Import and Save are icon-only `Button`s**, and an icon on a Button goes into Mantine's `leftSection`, which carries a `margin-inline-end` to hold it off the label. With no label that margin is pure offset. Measured on the running app: **8px left of centre**.

An icon with no label is now rendered as the button's *content* rather than as a leading section, so it centres. `React.Children.toArray` decides that, because it drops nulls — and the file browser passes `{label('Delete')}`, which is null whenever the bar is too narrow for words. Those buttons are icon-only at exactly the widths where the offset is most visible, so a plain truthiness check on `children` would have missed them.

## Why the clear button looks like it's inside the field

The control is a bordered box with `padding: 0 8px`, which left the button **9px short of the right edge and 2px short of the full height**. Semantic welded it to the field — measured on the QA Pi: zero gap from the input, zero to the outer edge, full 44px height.

It now stretches, and negative margins cancel the padding and the flex gap, with a divider on its left so "attached" doesn't become "indistinguishable". Negative margins rather than dropping the control's padding, because that padding is what holds the search icon and the text off the border — only this one child should escape it.

The `html` prefix on that rule is load-bearing: Mantine sets ActionIcon's height from `--ai-size` on its own single class, so at equal specificity the winner is whichever stylesheet loaded last, which is not something to rely on.

## Testing

Fourteen new cases, each fix planted separately — the icon change reddens three, the footer one, the clear button one.

Every claim is paired with an inverse, because all three fixes could over-apply:
- a **labelled** button must keep its icon on the left (centring must not apply when there is a label);
- the field must still be **padded** around its other children (the negative margins are aimed at one child);
- the footer's buttons must stay on **one row** and share a top edge, so "it's a flex row" is checked as behaviour rather than as a declaration.

One correction worth recording: the height assertion first compared against the control's **border** box and failed on correct behaviour. The button fills the *content* box; the 1px above and below is the field's own border, which it should sit inside rather than paint over. The test says which box it means and why.

1128 jest / 63 suites, 226 in `ui-layout.cy.js`, clean `npm run build`.

Confirmed live: footer gaps `8px` on one row, config glyphs at **0.0px** from centre, clear button 1px from the field edge at the field's full inner height.