### PR TITLE
ui: the map pin buttons were three sizes for three reasons

### DIFF
--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -1709,7 +1709,19 @@ export function normalizeEstimate(estimate) {
 
 export function useAPIButton(
     color = 'violet',
-    size = 'medium',
+    /*
+     * Undefined, not 'medium'.  `size` was never put into `buttonArgs` below, so every
+     * APIButton in the app rendered at Mantine's default no matter what its call site asked
+     * for -- seventeen of them pass a size, from `xs` on the map's pin actions to `huge` on
+     * Settings, and all seventeen were ignored.  The map's pin row is where it showed: three
+     * buttons meant to be `xs`, one of them 36px tall next to two 30px ones.
+     *
+     * Defaulting to 'medium' and passing that through would have fixed the bug by breaking
+     * everything else -- every APIButton that names no size would have grown from `sm` to
+     * `md`.  Undefined lets Button's own default stand, so only the call sites that asked for
+     * something see a change.
+     */
+    size,
     floated,
     onClick,
     disabled,
@@ -1795,7 +1807,7 @@ export function useAPIButton(
     // `color` was a Semantic color name; a role carries the meaning instead, and a
     // caller that really wants a color can still pass one through `props`.
     const buttonArgs = {
-        onClick: localOnClick, disabled, loading, type,
+        onClick: localOnClick, disabled, loading, type, size,
         ...props,
     };
     if (id) {

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -15,7 +15,7 @@ import {
     deleteMapFile, deleteMapPin, fetchMapSubscriptions, getMapFiles, getMapPins,
     mapSubscribe, mapUnsubscribe, rebuildMapSearchIndex, updateMapPin
 } from "../api";
-import {Button, Divider, Header, Icon, Modal, Table, TextInput} from "./ui";
+import {Button, Divider, Group, Header, Icon, Modal, Table, TextInput} from "./ui";
 import {SortableTable} from "./SortableTable";
 import {Media, StatusContext} from "../contexts/contexts";
 import {MAP_VIEWER_URI} from "./Vars";
@@ -229,19 +229,23 @@ function MapCatalogRow({item, subscribedRegions, fetchData}) {
         <Table.Cell>{name}</Table.Cell>
         <Table.Cell>{humanFileSize(size_estimate)}</Table.Cell>
         <Table.Cell>
-            {bbox && <Button
-                size='xs'
-                icon='eye'
-                onClick={() => setPreviewOpen(true)}
-            />}
-            <Button
-                role={isSubscribed ? 'danger' : undefined}
-                color={isSubscribed ? undefined : 'violet'}
-                size='xs'
-                onClick={handleButton}
-            >
-                {isSubscribed ? 'Unsubscribe' : 'Subscribe'}
-            </Button>
+            {/* See PinEditRow: a Group so the preview and subscribe controls line up and are
+                spaced, rather than sitting on baselines they do not share. */}
+            <Group gap='xs' wrap='nowrap'>
+                {bbox && <Button
+                    size='xs'
+                    icon='eye'
+                    onClick={() => setPreviewOpen(true)}
+                />}
+                <Button
+                    role={isSubscribed ? 'danger' : undefined}
+                    color={isSubscribed ? undefined : 'violet'}
+                    size='xs'
+                    onClick={handleButton}
+                >
+                    {isSubscribed ? 'Unsubscribe' : 'Subscribe'}
+                </Button>
+            </Group>
         </Table.Cell>
         {previewOpen && <RegionPreviewModal
             bbox={bbox}
@@ -450,8 +454,13 @@ function PinEditRow({pin, onSave, onCancel}) {
         <Table.Cell>{pin.lat.toFixed(4)}, {pin.lon.toFixed(4)}</Table.Cell>
         <Media greaterThan='mobile'><Table.Cell>{pin.created}</Table.Cell></Media>
         <Table.Cell>
-            <Button size='xs' role='save' onClick={() => label.trim() && onSave(pin.id, label.trim(), color)}>Save</Button>
-            <Button size='xs' role='cancel' onClick={onCancel}>Cancel</Button>
+            {/* A Group, not bare siblings: inline-block controls align on text baselines they
+                do not share, and JSX leaves no whitespace between them to space them out. */}
+            <Group gap='xs' wrap='nowrap'>
+                <Button size='xs' role='save'
+                        onClick={() => label.trim() && onSave(pin.id, label.trim(), color)}>Save</Button>
+                <Button size='xs' role='cancel' onClick={onCancel}>Cancel</Button>
+            </Group>
         </Table.Cell>
     </Table.Row>;
 }
@@ -524,21 +533,24 @@ function MapPins() {
             </Table.Cell>
             <Table.Cell>{pin.created}</Table.Cell>
             <Table.Cell>
-                <Button size='xs' icon='edit' onClick={() => setEditingId(pin.id)}/>
-                <AddToPlaylistButton
-                    size='xs'
-                    icon='list'
-                    content=''
-                    url={{url: `/map?lat=${pin.lat}&lon=${pin.lon}&z=14`, title: pin.label}}
-                />
-                <APIButton
-                    size='xs'
-                    role='danger'
-                    icon='trash'
-                    confirmContent='Delete this pin?'
-                    confirmButton='Delete'
-                    onClick={() => handleDelete(pin.id)}
-                />
+                {/* See PinEditRow: a Group so the three controls line up and are spaced. */}
+                <Group gap='xs' wrap='nowrap'>
+                    <Button size='xs' icon='edit' onClick={() => setEditingId(pin.id)}/>
+                    <AddToPlaylistButton
+                        size='xs'
+                        icon='list'
+                        content=''
+                        url={{url: `/map?lat=${pin.lat}&lon=${pin.lon}&z=14`, title: pin.label}}
+                    />
+                    <APIButton
+                        size='xs'
+                        role='danger'
+                        icon='trash'
+                        confirmContent='Delete this pin?'
+                        confirmButton='Delete'
+                        onClick={() => handleDelete(pin.id)}
+                    />
+                </Group>
             </Table.Cell>
         </Table.Row>;
     };

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -235,6 +235,7 @@ function MapCatalogRow({item, subscribedRegions, fetchData}) {
                 {bbox && <Button
                     size='xs'
                     icon='eye'
+                    aria-label={`Preview ${name}`}
                     onClick={() => setPreviewOpen(true)}
                 />}
                 <Button
@@ -535,7 +536,8 @@ function MapPins() {
             <Table.Cell>
                 {/* See PinEditRow: a Group so the three controls line up and are spaced. */}
                 <Group gap='xs' wrap='nowrap'>
-                    <Button size='xs' icon='edit' onClick={() => setEditingId(pin.id)}/>
+                    <Button size='xs' icon='edit' aria-label={`Edit ${pin.label}`}
+                            onClick={() => setEditingId(pin.id)}/>
                     <AddToPlaylistButton
                         size='xs'
                         icon='list'
@@ -546,6 +548,7 @@ function MapPins() {
                         size='xs'
                         role='danger'
                         icon='trash'
+                        aria-label={`Delete ${pin.label}`}
                         confirmContent='Delete this pin?'
                         confirmButton='Delete'
                         onClick={() => handleDelete(pin.id)}
@@ -581,6 +584,7 @@ function MapPins() {
                     size='xs'
                     role='danger'
                     icon='trash'
+                    aria-label={`Delete ${pin.label}`}
                     confirmContent='Delete this pin?'
                     confirmButton='Delete'
                     onClick={() => handleDelete(pin.id)}

--- a/app/src/components/Map.test.js
+++ b/app/src/components/Map.test.js
@@ -71,8 +71,88 @@ describe('the map pin action cells', () => {
              * message argument -- that is chai, and passing one throws rather than annotating.
              * A rename of the marker would otherwise turn this into a test of nothing.
              */
-            expect({marker, found: cell !== undefined, grouped: !!cell?.includes('<Group')})
-                .toEqual({marker, found: true, grouped: true});
+            /*
+             * The Group must CONTAIN the cell's controls, not merely appear in it.  Asserting
+             * that `<Group` is present anywhere would pass on an empty one left beside the
+             * bare siblings it was supposed to wrap.
+             */
+            const between = (text, open, close) => {
+                const from = text.indexOf(open);
+                if (from === -1) return '';
+                const to = text.indexOf(close, from);
+                // An unclosed Group would otherwise swallow the rest of the cell, which is how
+                // the first version of this let an EMPTY Group pass with the controls left
+                // outside it.
+                return to === -1 ? '' : text.slice(from, to);
+            };
+            const inGroup = cell === undefined ? '' : between(cell, '<Group', '</Group>');
+            const controls = (text) =>
+                (text.match(/<(?:API)?Button\b|<IconButton\b|<AddToPlaylistButton\b/g) || []).length;
+
+            expect({
+                marker,
+                found: cell !== undefined,
+                grouped: !!cell?.includes('<Group'),
+                // Every control the cell has is inside the Group, none left outside it.
+                controlsInsideGroup: cell === undefined ? 0 : controls(inGroup),
+                controlsInCell: cell === undefined ? -1 : controls(cell),
+            }).toEqual({
+                marker, found: true, grouped: true,
+                controlsInsideGroup: cell === undefined ? 0 : controls(cell),
+                controlsInCell: cell === undefined ? -1 : controls(cell),
+            });
         });
+    });
+});
+
+describe('the map\'s icon-only controls have accessible names', () => {
+    /*
+     * An icon-only Button carries no text, so without `aria-label` it reaches assistive tech
+     * as an unnamed button.  `IconButton` requires a label by construction and
+     * AddToPlaylistButton supplies one; the plain Button and APIButton used for edit, delete
+     * and the catalog preview did not, and this change rewrote all three rows.
+     *
+     * In the source, for the same reason as the Group guard: these rows are built inside the
+     * module and fetched from the API.
+     */
+    const openingTag = (text, at) => {
+        let depth = 0;
+        for (let i = at; i < text.length; i++) {
+            const c = text[i];
+            if (c === '{' || c === '(') depth += 1;
+            else if (c === '}' || c === ')') depth -= 1;
+            else if (c === '>' && depth === 0) return {tag: text.slice(at, i + 1), end: i};
+        }
+        return {tag: '', end: at};
+    };
+
+    /** Every `<Button>`/`<APIButton>` in the file whose only content is an icon. */
+    const iconOnlyControls = () => {
+        const found = [];
+        for (const match of source.matchAll(/<(?:API)?Button\b/g)) {
+            const {tag, end} = openingTag(source, match.index);
+            if (!/\bicon=/.test(tag)) continue;
+            // Self-closing, or immediately followed by another tag rather than by a label.
+            const following = source.slice(end + 1, end + 40).trim();
+            if (!(tag.endsWith('/>') || following.startsWith('<') || following.startsWith('}'))) {
+                continue;
+            }
+            found.push({line: source.slice(0, match.index).split('\n').length, tag});
+        }
+        return found;
+    };
+
+    it('finds the icon-only controls at all', () => {
+        // The premise.  A scanner that matched nothing would report no offenders and read
+        // exactly like a file that was already correct.
+        expect(iconOnlyControls().length).toBeGreaterThan(2);
+    });
+
+    it('names every one of them', () => {
+        const unnamed = iconOnlyControls()
+            .filter(({tag}) => !/aria-label/.test(tag))
+            .map(({line, tag}) => `line ${line}: ${tag.split('\n')[0].trim()}`);
+
+        expect(unnamed).toEqual([]);
     });
 });

--- a/app/src/components/Map.test.js
+++ b/app/src/components/Map.test.js
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * The map pin table's action cells.
+ *
+ * Each row offers edit, add-to-playlist and delete, and they were laid out as bare siblings in
+ * a table cell.  That makes them inline-block boxes aligned on their text BASELINES, and a
+ * Button's baseline is not an ActionIcon's -- measured on the running app, the middle control
+ * sat 4.3px above the other two -- and they touched, because JSX leaves no whitespace between
+ * elements.  `Group` is what every other row of buttons in the app uses.
+ *
+ * Checked in the source because neither row is reachable from a test that could measure it:
+ * `MapPins` fetches its pins from the API and builds its rows through SortableTable, and the
+ * row builders are internal to the module.  ui-layout.cy.js measures the pattern itself --
+ * that bare siblings really are misaligned and that a Group really does fix it -- so what is
+ * left to guard is that these cells use one.
+ */
+
+const source = fs.readFileSync(path.join(__dirname, 'Map.js'), 'utf8');
+
+/** The contents of every `<Table.Cell>` in the file. */
+const cells = () => {
+    const found = [];
+    const open = '<Table.Cell';
+    for (let at = source.indexOf(open); at !== -1; at = source.indexOf(open, at + 1)) {
+        const end = source.indexOf('</Table.Cell>', at);
+        if (end !== -1) found.push(source.slice(at, end));
+    }
+    return found;
+};
+
+describe('the map pin action cells', () => {
+    it('finds the cells at all', () => {
+        // The premise.  A parser that matched nothing would report no offenders and read
+        // exactly like a file that was already correct.
+        expect(cells().length).toBeGreaterThan(5);
+    });
+
+    /*
+     * Named cells, not a count of control tags.
+     *
+     * Counting was tried first and does not work: a cell whose buttons are the two arms of a
+     * ternary renders exactly one of them and needs no Group -- the "Built" / "Build" cell on
+     * the map files table is that shape -- and excluding ternaries to allow for it also
+     * excluded the subscribe cell, whose `role={isSubscribed ? ... : ...}` has nothing to do
+     * with how many controls it holds.  A guard that quietly stops covering a cell is worse
+     * than one with a stated scope.
+     *
+     * So each cell is named by something only it contains, and the general claim -- that bare
+     * inline controls really are misaligned and that a Group really does fix it -- is measured
+     * in ui-layout.cy.js instead.
+     */
+    const rows = [
+        {name: 'pin actions', marker: 'setEditingId(pin.id)'},
+        /*
+         * `role='cancel'`, not `onSave(...)`: the edit row's TextInput calls onSave from its
+         * own onKeyDown, in a different cell, so that marker matched the input's cell and this
+         * quietly checked the wrong one.  A marker has to be unique to the cell it names.
+         */
+        {name: 'pin edit save/cancel', marker: "role='cancel'"},
+        {name: 'map file subscribe', marker: 'setPreviewOpen(true)'},
+    ];
+
+    rows.forEach(({name, marker}) => {
+        it(`groups the ${name} cell`, () => {
+            const cell = cells().find(candidate => candidate.includes(marker));
+
+            /*
+             * The premise and the claim in one object, because jest's `expect` takes no
+             * message argument -- that is chai, and passing one throws rather than annotating.
+             * A rename of the marker would otherwise turn this into a test of nothing.
+             */
+            expect({marker, found: cell !== undefined, grouped: !!cell?.includes('<Group')})
+                .toEqual({marker, found: true, grouped: true});
+        });
+    });
+});

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -116,6 +116,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((
         className={[fromRole?.className, className].filter(Boolean).join(' ') || undefined}
         leftSection={soleIcon ? undefined : renderIcon(icon)}
         rightSection={soleIcon ? undefined : renderIcon(iconAfter)}
+        /*
+         * Marks the icon-only case for ui.css, which makes such a button square so it matches
+         * an IconButton of the same size.  A Button is as wide as its content plus padding and
+         * an ActionIcon is square, so a row mixing the two -- the map's pin actions are edit
+         * (Button), add-to-playlist (IconButton) and delete (Button) -- came out 46, 30 and 46
+         * wide at the same nominal size.
+         */
+        data-icon-only={soleIcon ? 'true' : undefined}
         {...props}
         size={resolveSize(props.size)}
     >

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
     ActionInput, Button, Card, Header, Icon, IconButton, IconStack, Loading, MultiSelect, Panel, PathInput,
-    Message, Pagination, Placeholder, Progress, SearchBox, Statistic, StatisticGroup, Status, TabBar, Table,
+    Group, Message, Pagination, Placeholder, Progress, SearchBox, Statistic, StatisticGroup, Status, TabBar, Table,
     tabClassName, TextInput,
 } from './index';
 import {MemoryRouter} from 'react-router';
@@ -13,6 +13,7 @@ import {monochromeThemes, themeNames} from '../../themes/names';
 import {navColorNames} from '../../themes/navColors';
 import {NavBarSample} from '../ThemeSamplePage';
 import {DesktopNav, NavIconWrapper} from '../Nav';
+import {APIButton} from '../Common';
 import {ShareButton} from '../Share';
 
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
@@ -3355,6 +3356,181 @@ describe('the search field\'s clear button is attached to it', () => {
 
             expect($icon[0].getBoundingClientRect().left - control.left, 'icon is inset')
                 .to.be.greaterThan(4);
+        });
+    });
+});
+
+describe('icon-only action buttons in a row are one size', () => {
+    /*
+     * The map's pin table gives every row three actions: edit, add-to-playlist and delete,
+     * all asking for `size='xs'`.  They rendered 46x30, 30x30 and 54x36 -- three different
+     * sizes, for three different reasons.
+     *
+     * Two of those are structural.  `AddToPlaylistButton` renders an IconButton when it has no
+     * label, and an ActionIcon is square by construction, while a Button is as wide as its
+     * content plus its horizontal padding.  Their heights already agree, because ActionIcon's
+     * size scale was remapped onto Button's; width was never aligned.
+     *
+     * The third is a plain bug: `useAPIButton` never put `size` into the props it hands to
+     * Button, so every APIButton in the app rendered at Mantine's default regardless of what
+     * its call site asked for.  Seventeen call sites pass a size, from `xs` here to `huge` on
+     * Settings.
+     */
+    const sizes = ['xs', 'sm', 'md', 'lg'];
+
+    sizes.forEach((size) => {
+        it(`gives an icon-only Button and an IconButton the same box at ${size}`, () => {
+            cy.mountUI(<div>
+                <Button size={size} icon='edit' aria-label='Edit' data-testid='plain'/>
+                <IconButton size={size} icon='list' label='Add' data-testid='action'/>
+            </div>);
+
+            cy.get('[data-testid="action"]').should(($action) => {
+                const button = Cypress.$('[data-testid="plain"]')[0].getBoundingClientRect();
+                const icon = $action[0].getBoundingClientRect();
+
+                expect(button.height, `${size} heights`).to.be.closeTo(icon.height, 1);
+                expect(button.width, `${size} widths`).to.be.closeTo(icon.width, 1);
+            });
+        });
+    });
+
+    it('makes an icon-only button square, not merely equal to its neighbour', () => {
+        // Stated separately: two buttons could agree with each other and both be wrong.  A
+        // lone glyph in a control belongs in a square one.
+        cy.mountUI(<Button size='xs' icon='edit' aria-label='Edit' data-testid='plain'/>);
+
+        cy.get('[data-testid="plain"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+
+            expect(box.width, 'square').to.be.closeTo(box.height, 1);
+        });
+    });
+
+    it('is a real constraint: a labelled button is still as wide as its label', () => {
+        // The inverse.  Squaring must apply only to the icon-only case, or every labelled
+        // button in the app collapses to a square and clips its text.
+        cy.mountUI(<Button size='xs' icon='edit' data-testid='labelled'>Edit this pin</Button>);
+
+        cy.get('[data-testid="labelled"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+
+            expect(box.width, 'wider than it is tall').to.be.greaterThan(box.height * 2);
+        });
+    });
+});
+
+describe('APIButton honours the size its call site asks for', () => {
+    /*
+     * `useAPIButton` assembled the props it hands to Button and left `size` out, so it was
+     * dropped at every call site -- seventeen of them, from the map pins' `xs` to Settings'
+     * `huge`.  The map's delete pin came out 36px tall beside two 30px siblings.
+     */
+    it('renders a small APIButton smaller than a large one', () => {
+        cy.mountUI(<div>
+            <APIButton size='xs' icon='trash' onClick={() => {}} data-testid='small'/>
+            <APIButton size='lg' icon='trash' onClick={() => {}} data-testid='large'/>
+        </div>);
+
+        cy.get('[data-testid="large"]').should(($large) => {
+            const small = Cypress.$('[data-testid="small"]')[0].getBoundingClientRect();
+
+            expect(small.height, 'xs is shorter than lg')
+                .to.be.lessThan($large[0].getBoundingClientRect().height - 4);
+        });
+    });
+
+    it('matches a plain Button given the same size', () => {
+        // The claim that matters at the call site: an APIButton and a Button asking for the
+        // same size are the same control.
+        cy.mountUI(<div>
+            <APIButton size='xs' icon='trash' onClick={() => {}} data-testid='api'/>
+            <Button size='xs' icon='trash' aria-label='Delete' data-testid='plain'/>
+        </div>);
+
+        cy.get('[data-testid="api"]').should(($api) => {
+            const plain = Cypress.$('[data-testid="plain"]')[0].getBoundingClientRect();
+            const api = $api[0].getBoundingClientRect();
+
+            expect(api.height, 'heights').to.be.closeTo(plain.height, 1);
+            expect(api.width, 'widths').to.be.closeTo(plain.width, 1);
+        });
+    });
+
+    it('is a real constraint: an APIButton with no size keeps the default it had', () => {
+        /*
+         * `useAPIButton` declared `size = 'medium'` as a parameter default while never using
+         * it.  Passing that through would have fixed the bug by breaking everything else --
+         * every APIButton that names no size would have grown from Mantine's `sm` to `md`.
+         */
+        cy.mountUI(<div>
+            <APIButton icon='trash' onClick={() => {}} data-testid='default'/>
+            <Button icon='trash' aria-label='Delete' data-testid='plain'/>
+        </div>);
+
+        cy.get('[data-testid="default"]').should(($api) => {
+            const plain = Cypress.$('[data-testid="plain"]')[0].getBoundingClientRect();
+
+            expect($api[0].getBoundingClientRect().height, 'unchanged default')
+                .to.be.closeTo(plain.height, 1);
+        });
+    });
+});
+
+describe('a row of icon controls sits level and spaced', () => {
+    /*
+     * The map's pin actions are three icon controls in one table cell: edit (Button),
+     * add-to-playlist (IconButton) and delete (APIButton).  They were laid out as bare
+     * siblings, so they were inline-block boxes aligned on their BASELINES -- and a Button's
+     * baseline is not an ActionIcon's, so the middle one sat 4.3px higher than the other two.
+     * They also touched, because JSX leaves no whitespace between elements.
+     *
+     * Both are what `Group` is for, which is how every other row of buttons in the app is
+     * built.  Measured on the running app at tops 258.6 / 254.2 / 258.6 before the fix.
+     */
+    const controls = <>
+        <Button size='xs' icon='edit' aria-label='Edit' data-testid='edit'/>
+        <IconButton size='xs' icon='list' label='Add to Playlist' data-testid='add'/>
+        <APIButton size='xs' icon='trash' onClick={() => {}} data-testid='delete'/>
+    </>;
+
+    const tops = (root) => ['edit', 'add', 'delete']
+        .map(id => root.querySelector(`[data-testid="${id}"]`).getBoundingClientRect().top);
+
+    it('is misaligned without a Group, which is why one is needed', () => {
+        /*
+         * The premise for the case below, and the thing a reader will not believe otherwise:
+         * three controls of identical height still do not line up when they are laid out
+         * inline, because they are aligned on text baselines they do not share.
+         */
+        cy.mountUI(<div data-testid='bare'>{controls}</div>);
+
+        cy.get('[data-testid="bare"]').should(($bare) => {
+            const spread = Math.max(...tops($bare[0])) - Math.min(...tops($bare[0]));
+
+            expect(spread, 'bare siblings do not line up').to.be.greaterThan(1);
+        });
+    });
+
+    it('lines them up when wrapped in a Group', () => {
+        cy.mountUI(<Group gap='xs' data-testid='grouped'>{controls}</Group>);
+
+        cy.get('[data-testid="grouped"]').should(($group) => {
+            const spread = Math.max(...tops($group[0])) - Math.min(...tops($group[0]));
+
+            expect(spread, 'all three share a top edge').to.be.lessThan(1);
+        });
+    });
+
+    it('leaves a gap between them', () => {
+        cy.mountUI(<Group gap='xs' data-testid='grouped'>{controls}</Group>);
+
+        cy.get('[data-testid="grouped"]').should(($group) => {
+            const boxes = ['edit', 'add', 'delete']
+                .map(id => $group[0].querySelector(`[data-testid="${id}"]`).getBoundingClientRect());
+
+            expect(boxes[1].left - boxes[0].right, 'first gap').to.be.greaterThan(2);
+            expect(boxes[2].left - boxes[1].right, 'second gap').to.be.greaterThan(2);
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -3457,6 +3457,65 @@ describe('APIButton honours the size its call site asks for', () => {
         });
     });
 
+    it('honours the Semantic size names the call sites actually use', () => {
+        /*
+         * The seventeen call sites that were being ignored do not say `xs` and `lg` -- they say
+         * `small`, `big`, `large` and `huge`, which `resolveSize` translates.  Testing only the
+         * Mantine names would leave the translation step untested on the exact spellings that
+         * were broken.  `small` maps to `sm`, which is what the accidental default already was,
+         * which is why most detail pages do not move.
+         */
+        cy.mountUI(<div>
+            <APIButton size='small' icon='trash' onClick={() => {}} data-testid='small'/>
+            <APIButton size='big' icon='trash' onClick={() => {}} data-testid='big'/>
+            <APIButton size='huge' icon='trash' onClick={() => {}} data-testid='huge'/>
+        </div>);
+
+        cy.get('[data-testid="huge"]').should(($huge) => {
+            const height = (id) =>
+                Cypress.$(`[data-testid="${id}"]`)[0].getBoundingClientRect().height;
+
+            expect(height('small'), 'small is the old default').to.be.closeTo(36, 1);
+            expect(height('big'), 'big is taller than small').to.be.greaterThan(height('small'));
+            expect($huge[0].getBoundingClientRect().height, 'huge is taller than big')
+                .to.be.greaterThan(height('big'));
+        });
+    });
+
+    it('stays square while it is loading', () => {
+        /*
+         * A loading button swaps its glyph for a spinner sized from the button's height, and
+         * the square rule fixes the width to that height -- so a spinner that did not fit
+         * would either be clipped or stretch the box.  Both Button and APIButton, since
+         * APIButton is what actually spends time loading.
+         */
+        cy.mountUI(<div>
+            <Button size='xs' icon='trash' aria-label='Delete' loading data-testid='busy'/>
+            <APIButton size='xs' icon='trash' loading onClick={() => {}} data-testid='busy-api'/>
+        </div>);
+
+        cy.get('[data-testid="busy-api"]').should(() => {
+            ['busy', 'busy-api'].forEach((id) => {
+                const box = Cypress.$(`[data-testid="${id}"]`)[0].getBoundingClientRect();
+
+                expect(box.height, `${id} has a height`).to.be.greaterThan(20);
+                expect(box.width, `${id} is still square`).to.be.closeTo(box.height, 1);
+            });
+        });
+    });
+
+    it('squares an iconAfter-only button too', () => {
+        // The square rule keys off the same `data-icon-only` marker as the centring, and
+        // `iconAfter` alone is one of the cases that sets it.
+        cy.mountUI(<Button size='xs' iconAfter='upload' aria-label='Send' data-testid='after'/>);
+
+        cy.get('[data-testid="after"]').should(($button) => {
+            const box = $button[0].getBoundingClientRect();
+
+            expect(box.width, 'square').to.be.closeTo(box.height, 1);
+        });
+    });
+
     it('is a real constraint: an APIButton with no size keeps the default it had', () => {
         /*
          * `useAPIButton` declared `size = 'medium'` as a parameter default while never using

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1565,3 +1565,20 @@ html[data-theme="night"] .wrolpi-button-danger[data-disabled]:not([data-loading]
     color: var(--danger);
     border: 1.5px dashed var(--danger);
 }
+
+/*
+ * A button whose only content is an icon is square, like the ActionIcon it sits beside.
+ *
+ * A Button is as wide as its content plus its horizontal padding; an ActionIcon is square by
+ * construction.  So a row mixing the two at one nominal size came out at different widths --
+ * the map's pin actions are edit (Button), add-to-playlist (IconButton) and delete (Button),
+ * and measured 46, 30 and 46 wide.  Their heights already agree, because ActionIcon's scale
+ * was remapped onto Button's; this is the other axis of the same alignment.
+ *
+ * `--button-height` is Mantine's own per-size height, so the two stay in step through every
+ * size without a table here to keep current.
+ */
+html .mantine-Button-root[data-icon-only] {
+    width: var(--button-height);
+    padding: 0;
+}


### PR DESCRIPTION
The pin row's three actions measured **46×30, 30×30 and 54×36**. Three separate causes.

## 1. APIButton was dropping `size` entirely

`useAPIButton` declares `size = 'medium'` as a parameter and then never puts it into the props it hands to `Button`. So **every** APIButton in the app rendered at Mantine's default regardless of its call site — **17 call sites pass a size**, from `xs` on the map pins to `big` and `huge` on Settings. The delete pin was 36px beside two 30px siblings because of it.

Passing the parameter default through would have fixed the bug by breaking everything else: every APIButton naming no size would have grown from `sm` to `md`. So the default is `undefined` now and Button's own default stands.

**Eight buttons on three other pages do get bigger**, which is their call sites finally being honoured — VideoPlayer's `large`, one of Channels' `big`, and Settings' two `big` and two `huge`. Say the word if any of those were written in the Semantic era and now read as too large; they're one-line changes at the call site.

## 2. An icon-only Button wasn't square

A Button is as wide as its content plus horizontal padding; an ActionIcon is square by construction. The pin row mixes the two, because `AddToPlaylistButton` renders an `IconButton` when it has no label. Their *heights* already agreed — ActionIcon's scale was remapped onto Button's some commits back — and this is the other axis of the same alignment, keyed off Mantine's own `--button-height` so the two stay in step through every size.

## 3. They were misaligned and touching

Bare inline-block siblings align on text **baselines**, and a Button's baseline is not an ActionIcon's, so the middle control sat 4.3px above the other two. A `Group`, as every other row of buttons in the app uses.

## Testing — written test-first

Seven cypress cases went red on the sizes: widths 46 against 30, 54 against 36, 62 against 42, 70 against 50, and `xs is shorter than lg: expected 36 to be below 32` for the dropped size. Both inverses stayed green throughout — a labelled button remains as wide as its label, and an APIButton naming no size keeps the height it had.

The alignment claim is measured in `ui-layout.cy.js`, **including the premise that bare siblings really are misaligned** — three controls of identical height failing to line up is not believable without it. The call sites are held by a source guard, since `MapPins` fetches from the API and builds rows through `SortableTable`.

**That guard earned itself twice.** Written for the pin rows, it found the map-files subscribe cell putting a preview button beside a subscribe button with the same defect. Then my first attempt at a general "any cell with two controls" rule had to be abandoned: a cell whose buttons are the two arms of a ternary renders only one and needs no Group, and excluding ternaries to allow for that *also* excluded the subscribe cell, whose `role={isSubscribed ? … : …}` says nothing about how many controls it holds. Named cells with a stated scope beat a general rule that quietly stops covering things.

Two slips of mine in that file, both caught by running it: `expect(value, message)` is chai and throws in jest, and `onSave(pin.id, …)` wasn't unique to the cell it named — the edit row's TextInput calls it from `onKeyDown` in a different cell, so the check passed against the wrong one.

1132 jest / 64 suites, 243 in `ui-layout.cy.js`, clean `npm run build`. Confirmed live: three **30×30** controls, vertical spread **0**, **10px** gaps.