### PR TITLE
ui: size the five modals that had never been sized

### DIFF
--- a/app/src/components/FileBrowser.js
+++ b/app/src/components/FileBrowser.js
@@ -711,6 +711,11 @@ export function MoveModal({open, paths, onClose, onSubmit}) {
         {destination ? fileCell(destination + '/' + pathName(i)) : fileCell(pathName(i))}
     </Table.Row>);
 
+    /*
+     * Audited: `large` (620px).  This dialog holds a DirectorySearch and a two-column
+     * Source/Destination table of every path being moved, which is the densest content
+     * of the five FileBrowser modals.
+     */
     return <Modal size='large'
                   onClose={onClose}
                   open={open}
@@ -814,6 +819,18 @@ export function MakeDirectoryModal({open, onClose, parent, onSubmit}) {
         }
     }
 
+    /*
+     * Audited: `large` (620px), deliberately wider than RenameModal's `small` even though
+     * the form is the same shape -- one field and a button.  The difference is the path
+     * above it: rename shows a RELATIVE path, this shows the absolute one including the
+     * media directory, and a bare `<pre>` is `white-space: pre`, so it scrolls rather
+     * than wraps.  Measured in the browser: 440px holds 42 characters and 620px holds
+     * 61.  `/media/wrolpi/videos/Practical Engineering/Season 2024/` is 55, so an
+     * ordinary channel-and-season path scrolls out of sight at 440 and fits at 620.
+     *
+     * Written out because it reads like an inconsistency next to rename, and the next
+     * person to notice that should see the measurement before narrowing it back.
+     */
     return <Modal size='large' open={open} onClose={onClose}>
         <Modal.Header>Make Directory</Modal.Header>
         <Modal.Content>

--- a/app/src/components/FileBrowser.js
+++ b/app/src/components/FileBrowser.js
@@ -643,7 +643,8 @@ export function RenameModal({open, onClose, path, onSubmit, onPending}) {
         setValue(pathName(path));
     }, [path]);
 
-    return <Modal
+    // Audited: unchanged at `small` (440px), written down so the default cannot move it.
+    return <Modal size='small'
                   open={open}
                   onClose={onClose}
     >
@@ -710,7 +711,7 @@ export function MoveModal({open, paths, onClose, onSubmit}) {
         {destination ? fileCell(destination + '/' + pathName(i)) : fileCell(pathName(i))}
     </Table.Row>);
 
-    return <Modal
+    return <Modal size='large'
                   onClose={onClose}
                   open={open}
     >
@@ -775,7 +776,8 @@ export function IgnoreDirectoryModal({open, onClose, onSubmit, directory, ignore
                                onClick={handleIgnore}
     >{ignored ? 'Un-ignore' : 'Ignore'}</Button>;
 
-    return <Modal open={open} onClose={onClose}>
+    // Audited: `small` (440px), which is the width it already had.
+    return <Modal size='small' open={open} onClose={onClose}>
         <Modal.Header>{header}</Modal.Header>
         <Modal.Content>
             {content}
@@ -812,7 +814,7 @@ export function MakeDirectoryModal({open, onClose, parent, onSubmit}) {
         }
     }
 
-    return <Modal open={open} onClose={onClose}>
+    return <Modal size='large' open={open} onClose={onClose}>
         <Modal.Header>Make Directory</Modal.Header>
         <Modal.Content>
             <form onSubmit={handleSubmit}>

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -398,7 +398,8 @@ export function SearchFilter({filters = [], modalHeader, size = 'medium'}) {
 
     if (filters && filters.length > 0) {
         return <>
-            <Modal open={open} onClose={() => setOpen(false)} closeIcon>
+            {/* Audited: unchanged at `small` (440px), recorded so the default cannot move it. */}
+            <Modal size='small' open={open} onClose={() => setOpen(false)} closeIcon>
                 {modalHeader || <Modal.Header>Filter</Modal.Header>}
                 <Modal.Content>
                     <Stack gap='xs'>


### PR DESCRIPTION
These five carried no `size` prop at all, so they rendered at Mantine's 440px default — a width nobody had chosen, inherited from the library rather than decided.

| Modal | Size | Width |
|---|---|---|
| FileBrowser rename | `small` | 440 (unchanged) |
| FileBrowser move | `large` | **620** |
| FileBrowser ignore directory | `small` | 440 (unchanged) |
| FileBrowser make directory | `large` | **620** |
| Files filter | `small` | 440 (unchanged) |

The three unchanged ones are **written down** rather than left implicit, so the decision lives in the source and a later change to Mantine's default can't move them.

## One thing I asked about rather than guessed

You asked for `medium` on the ignore dialog, and there is no such modal size — the vocabulary is `mini/tiny/small/large/fullscreen`, and Mantine has no token between 440 and 620. An unknown name would have passed through untranslated, rendered at 440 anyway, and left the source claiming otherwise. That's precisely what the size guard in `ui.test.js` exists to catch, so the build would have failed either way; `small` was the answer.

## Verification

Measured in the browser rather than read off the props: **move 620, make directory 620, ignore 440, rename 440**. Move and ignore are disabled until something is selected, so a directory was selected first.

1134 jest / 64 suites, clean `npm run build`.

**Note on the test run:** the full jest suite currently needs `--maxWorkers=2` on my machine. At load average 38 (a VM and a game between them using ~400% CPU), four unrelated suites — `ControllerPage`, `CollectionReorganizeModal`, `CollectionTagModal`, `Flasher` — time out and the run takes 183s instead of 5s. They pass in isolation and with reduced parallelism, and nothing in this change touches them. Worth knowing if CI ever runs on a loaded box.