### PR TITLE
ui: let a confirmation choose its width

### DIFF
--- a/app/src/components/TaggedDeleteConfirmModal.js
+++ b/app/src/components/TaggedDeleteConfirmModal.js
@@ -4,6 +4,14 @@ import {Confirm, Icon, Table} from "./ui";
 export function TaggedDeleteConfirmModal({open, taggedFileGroups, onConfirm, onCancel}) {
     return <Confirm
         open={open}
+        /*
+         * Audited: `large` (620px).  The only confirmation that is not a one-line question --
+         * it lists file paths beside their tags, and `videos/Practical Engineering/Season
+         * 2024/` alone is 40 characters before the filename.  The table scrolls sideways in
+         * its own container, so the width decides how much of a path is readable at a glance;
+         * at Confirm's default 380px that was the first two directories.
+         */
+        size='large'
         title={<><Icon name='warning sign'/> Tagged Files Will Be Deleted</>}
         confirmLabel='Delete'
         destructive

--- a/app/src/components/TaggedDeleteConfirmModal.test.js
+++ b/app/src/components/TaggedDeleteConfirmModal.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {screen, fireEvent} from '@testing-library/react';
 import {renderWithProviders} from '../test-utils';
+import {Confirm} from './ui';
 import {TaggedDeleteConfirmModal} from './TaggedDeleteConfirmModal';
 
 describe('TaggedDeleteConfirmModal', () => {
@@ -77,6 +78,37 @@ describe('TaggedDeleteConfirmModal', () => {
             />
         );
         expect(screen.getAllByText(/Tagged Files Will Be Deleted/i).length).toBeGreaterThan(0);
+    });
+
+    it('is wider than a one-sentence confirmation, because it lists paths in a table', () => {
+        /*
+         * Every Confirm in the app was 380px, because Confirm hardcoded `size='tiny'` and
+         * accepted no size.  380px is right for the eleven that ask a one-line question and
+         * wrong for this one: two columns of file paths, and a path is long.  The table
+         * scrolls horizontally inside the modal rather than overflowing it, so the width
+         * decides how much of a path is readable without dragging.
+         */
+        /*
+         * Both in one render, and every modal root read: a modal is portalled to
+         * `document.body`, so two separate renders both land there and reading only the first
+         * root reports one modal's size twice.
+         *
+         * Paired with a plain confirmation so this cannot pass by Confirm having become wide
+         * for everyone -- the point is that this one asked and the rest did not.
+         */
+        const {baseElement} = renderWithProviders(<>
+            <TaggedDeleteConfirmModal
+                open={true}
+                taggedFileGroups={sampleGroups}
+                onConfirm={jest.fn()}
+                onCancel={jest.fn()}
+            />
+            <Confirm open title='Delete?'/>
+        </>);
+
+        const sizes = [...baseElement.querySelectorAll('.mantine-Modal-root')]
+            .map(root => (root.getAttribute('style') ?? '').match(/--modal-size:\s*([^;]+)/)?.[1]);
+        expect(sizes).toEqual(['var(--modal-size-lg)', 'var(--modal-size-sm)']);
     });
 
     it('falls back to name when primary_path is missing', () => {

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -146,6 +146,7 @@ let toastCounter = 0;
 export function ThemeSamplePage() {
     const {theme} = useContext(ThemeContext);
     const [confirmOpen, setConfirmOpen] = useState(false);
+    const [wideConfirmOpen, setWideConfirmOpen] = useState(false);
     const [comments, setComments] = useState(true);
     const [hotspot, setHotspot] = useState(true);
     const [dismissed, setDismissed] = useState(false);
@@ -929,7 +930,14 @@ export function ThemeSamplePage() {
                     <Button role='danger' icon='trash' onClick={() => setConfirmOpen(true)}>
                         Wipe download history
                     </Button>
+                    <Button role='danger' icon='trash' onClick={() => setWideConfirmOpen(true)}>
+                        Delete tagged files
+                    </Button>
                 </Row>
+                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
+                    A confirmation is 380px wide, which suits a question. One that has to show
+                    what it is about takes a size, in the same vocabulary as Modal.
+                </p>
             </Panel>
         </Section>
 
@@ -947,6 +955,36 @@ export function ThemeSamplePage() {
             <p style={{color: 'var(--muted)', marginBottom: 0}}>
                 videos/Wranglerstar/ (312 files) will not be deleted.
             </p>
+        </Confirm>
+
+        <Confirm
+            open={wideConfirmOpen}
+            size='large'
+            destructive
+            title={<><Icon name='warning sign'/> Tagged files will be deleted</>}
+            confirmLabel='Delete'
+            onConfirm={() => setWideConfirmOpen(false)}
+            onCancel={() => setWideConfirmOpen(false)}
+        >
+            <p style={{marginTop: 0}}>The following tagged files will be deleted:</p>
+            <Table>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell>File</Table.HeaderCell>
+                        <Table.HeaderCell>Tags</Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    <Table.Row>
+                        <Table.Cell>videos/Practical Engineering/Season 2024/Spillways.mp4</Table.Cell>
+                        <Table.Cell>favorite, water</Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                        <Table.Cell>archives/en.wikipedia.org/Sluice_gate.html</Table.Cell>
+                        <Table.Cell>water</Table.Cell>
+                    </Table.Row>
+                </Table.Body>
+            </Table>
         </Confirm>
     </div>
 }

--- a/app/src/components/ui/Overlays.tsx
+++ b/app/src/components/ui/Overlays.tsx
@@ -198,6 +198,11 @@ export interface ConfirmProps {
     /** Style the confirming button as destructive. */
     destructive?: boolean;
     loading?: boolean;
+    /**
+     * Same vocabulary as `Modal`, forwarded to it.  Defaults to `tiny`; widen it only when
+     * the confirmation shows something other than a question.
+     */
+    size?: string | number;
     onConfirm?: () => void;
     onCancel?: () => void;
 }
@@ -210,12 +215,23 @@ export function Confirm({
     cancelLabel = 'Cancel',
     destructive,
     loading,
+    size = 'tiny',
     onConfirm,
     onCancel,
 }: ConfirmProps) {
-    // `tiny`, not Mantine's raw `sm`.  Same 380px, but the audited vocabulary -- and the
-    // guard in ui.test.js exists to keep raw Mantine names out of call sites.
-    return <Modal opened={open} onClose={() => onCancel?.()} title={title} size='tiny'>
+    /*
+     * `tiny`, not Mantine's raw `sm`.  Same 380px, but the audited vocabulary -- and the
+     * guard in ui.test.js exists to keep raw Mantine names out of call sites.
+     *
+     * Default rather than fixed.  It was fixed, which made every confirmation in the app
+     * 380px whatever it held.  Eight of the nine call sites ask a one-line question, and so
+     * does every confirmation `useAPIButton` puts behind a `confirmContent` -- around thirty
+     * of them, all prose, which is why APIButton does not forward a size.  The ninth is
+     * TaggedDeleteConfirmModal, which lists file paths in a two-column table and had no way
+     * to say so.  The default stays narrow because a confirmation wider than its question
+     * reads as a bigger decision than it is.
+     */
+    return <Modal opened={open} onClose={() => onCancel?.()} title={title} size={size}>
         {children}
         <div style={{display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 18}}>
             <Button role='cancel' onClick={onCancel}>{cancelLabel}</Button>

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -1528,6 +1528,41 @@ describe('modal sizes', () => {
         });
     });
 
+    /**
+     * The size Mantine was actually handed for each open modal, in source order, read off the
+     * inline style it writes on the modal root (`--modal-size: var(--modal-size-lg)`).
+     *
+     * Read rather than restated so a call site that names a size the table cannot translate
+     * shows up as the raw string it passed instead of quietly resolving to the default.
+     *
+     * All roots, not the first: a modal is portalled to `document.body`, so two renders in
+     * one test both land there and `querySelector` on `baseElement` returns whichever opened
+     * first.  That is how the first version of this reported the default twice and looked like
+     * the size prop had no effect.
+     */
+    const renderedModalSizes = (baseElement) =>
+        [...baseElement.querySelectorAll('.mantine-Modal-root')]
+            .map(root => (root.getAttribute('style') ?? '').match(/--modal-size:\s*([^;]+)/)?.[1]);
+
+    it('gives Confirm the tiny width by default, and lets a call site widen it', () => {
+        /*
+         * Confirm hardcoded `size='tiny'` and its props interface accepted no size at all, so
+         * all twelve confirmations in the app were 380px whatever they contained -- including
+         * TaggedDeleteConfirmModal, which renders a two-column table of file paths.  No call
+         * site could do anything about it without editing this library.
+         *
+         * The default stays `tiny`: eleven of the twelve are one sentence, and a confirmation
+         * that is wider than its question reads as a bigger decision than it is.
+         */
+        const {baseElement} = renderUI(<>
+            <Confirm open title='Delete?'/>
+            <Confirm open size='large' title='Delete these?'/>
+        </>);
+
+        expect(renderedModalSizes(baseElement))
+            .toEqual(['var(--modal-size-sm)', 'var(--modal-size-lg)']);
+    });
+
     it('never lets a call site name a size the table does not know', () => {
         /*
          * Two different hazards, and neither announces itself.
@@ -1570,13 +1605,23 @@ describe('modal sizes', () => {
 
         const offenders = [];
         let scanned = 0;
+        let confirms = 0;
         for (const [file, source] of walk(path.join(__dirname, '..', '..'))) {
-            for (const match of source.matchAll(/<Modal\b/g)) {
+            /*
+             * `Confirm` as well as `Modal`, now that it takes a size: it forwards the name
+             * straight to Modal, so it is the same vocabulary and the same hazard.
+             *
+             * `(?![.\w])` because `<Modal\b` also matches `<Modal.Header` -- harmless while
+             * those never declare a size, but it inflated an earlier count of these tags to
+             * 243 and made the number useless as a premise check.
+             */
+            for (const match of source.matchAll(/<(Modal|Confirm)(?![.\w])/g)) {
                 const tag = openingTag(source, match.index);
                 // Quote-agnostic; a computed `size={...}` is the caller's business.
                 const declared = tag.match(/\bsize=["']([^"']+)["']/);
                 if (!declared) continue;
                 scanned += 1;
+                if (match[1] === 'Confirm') confirms += 1;
                 if (!known.has(declared[1])) {
                     offenders.push(`${path.basename(file)}: size='${declared[1]}'`);
                 }
@@ -1586,6 +1631,9 @@ describe('modal sizes', () => {
         // The premise.  A scanner that silently matched nothing would report no offenders
         // and read exactly like a clean codebase, which is how the first version passed.
         expect(scanned).toBeGreaterThan(50);
+        // And the premise for the half of the pattern that is new: at least one confirmation
+        // names a size, so widening the scan is doing something rather than matching nothing.
+        expect(confirms).toBeGreaterThan(0);
         expect(offenders).toEqual([]);
     });
 });


### PR DESCRIPTION
`Confirm` hardcoded `size='tiny'` and its props interface accepted no size, so every confirmation in the app was 380px whatever it held.

That is right for eight of the nine `<Confirm>` call sites, and for the ~30 prose confirmations `useAPIButton` renders behind a `confirmContent` — all one or two sentences, which is why `APIButton` does not forward a size. It is wrong for `TaggedDeleteConfirmModal`, which lists file paths beside their tags in a two-column table and had no way to say so.

`size` is now a default rather than a fixture, in the same vocabulary as `Modal`. One call site changes: `TaggedDeleteConfirmModal` → `large` (620px). The table scrolls sideways in its own container, so the width decides how much of a path is readable without dragging — at 380px that was the first two directories, and `videos/Practical Engineering/Season 2024/` is 40 characters before the filename.

The default stays narrow deliberately: a confirmation wider than its question reads as a bigger decision than it is.

### A correction to what I said earlier

I described the "Remove Share" confirmation on the Controller page as carrying a text input, a checkbox and a directory search. It does not — its whole body is `Remove the share "name"?`. Those controls belong to the *Add Samba Share* modal rendered directly below it, which is already `large`. So the table was the only cramped confirmation, not one of two.

### Tests, written first

- `Confirm` resolves to `sm` by default and `lg` when a call site asks — measured off the `--modal-size` custom property Mantine writes on the modal root, read rather than restated.
- `TaggedDeleteConfirmModal` renders at `lg` while a plain confirmation beside it stays `sm`, so it cannot pass by confirmations having become wide for everyone.
- The existing "never name a size the table does not know" guard now scans `<Confirm` as well as `<Modal`, with a premise check that at least one confirmation names a size.

Both new tests read **every** modal root, not the first. A modal is portalled to `document.body`, so two renders in one test both land there and `querySelector` returns whichever opened first — which is how the first version reported the default twice and read as though the size prop had no effect. Planted both regressions: reverting `size={size}` to `size='tiny'` fails 2, dropping `size='large'` fails 1.

### Gallery

The wide confirmation sits next to the narrow one in the Danger zone section of `/theme-sample`, so both are checkable in all four themes.

### Verification

- `1136 tests / 64 suites` pass (`--maxWorkers=2`)
- clean `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)