### PR TITLE
ui: scale the whole interface by 10%, off the root font-size

### DIFF
--- a/app/cypress/e2e/keyboard-shortcuts.cy.js
+++ b/app/cypress/e2e/keyboard-shortcuts.cy.js
@@ -17,17 +17,41 @@ describe('Keyboard Shortcuts', () => {
             body: {settings: {}}
         }).as('getSettings');
 
-        // Mock tags API
-        cy.intercept('GET', '/api/tags', {
+        /*
+         * `/api/tag` and `/api/events/feed`, which are the URLs the app actually requests.
+         *
+         * These read `/api/tags` and `/api/events` before -- neither of which anything calls,
+         * so both mocks matched nothing and the real calls fell through.  In CI, where the
+         * React app is served with no API behind it, they failed and api.js raised an
+         * "Unexpected server response" toast, which then covered the search modal's input and
+         * failed an occlusion-sensitive assertion.  Locally the API answered and the spec
+         * passed, which is why it only ever broke on CI.
+         */
+        cy.intercept('GET', '/api/tag*', {
             statusCode: 200,
             body: {tags: []}
         }).as('getTags');
 
-        // Mock events API
-        cy.intercept('GET', '/api/events', {
+        cy.intercept('GET', '/api/events/feed*', {
             statusCode: 200,
-            body: {events: []}
+            // `now` as well as `events`: Events.js reads both off the response.
+            body: {events: [], now: new Date(0).toISOString()}
         }).as('getEvents');
+
+        /*
+         * The other two the home page calls.  `file_groups` is reached as
+         * `data['totals']['file_groups']`, so an empty object here would throw rather than
+         * toast -- the shape has to be right, which is why a blanket `{}` stub does not work.
+         */
+        cy.intercept('POST', '/api/files/search', {
+            statusCode: 200,
+            body: {file_groups: [], totals: {file_groups: 0}}
+        }).as('searchFiles');
+
+        cy.intercept('GET', '/api/files/worker_status', {
+            statusCode: 200,
+            body: {status: {}}
+        }).as('getWorkerStatus');
 
         // Mock search suggestions API
         cy.intercept('POST', '/api/search/suggestions', {
@@ -56,25 +80,13 @@ describe('Keyboard Shortcuts', () => {
             cy.get('[role="dialog"]').should('be.visible');
 
             /*
-             * Take down any toast before the assertion below, which is occlusion-sensitive.
-             *
-             * Toasts paint above modals on purpose -- z-index 400 against the modal stack's
-             * 200 -- so that an error raised while a modal is open stays visible.  The search
-             * modal is tall, so it sits near the top of the window, and a top-right toast
-             * covers the right-hand 192px of its 365px input.  Cypress occlusion-checks a
-             * `position: fixed` element, so `should('be.visible')` on that input fails.
-             *
-             * That is not this spec's subject.  It passed locally and failed in CI, where the
-             * React app is served with no API behind it: `/api/tag`, `/api/events/feed`,
-             * `/api/files/search` and `/api/files/worker_status` are not mocked here, they
-             * fail, and api.js raises "Unexpected server response".  The overlap itself is an
-             * accepted trade-off -- see the toast/modal note in ui.css -- so the environment is
-             * made quiet rather than the assertion weakened.
-             *
-             * Removed rather than dismissed by clicking: a click races the next failing call.
+             * Occlusion-sensitive: Cypress checks whether a `position: fixed` element is
+             * covered, and a toast at top-right covers the right-hand 192px of this 365px
+             * input.  Toasts paint above modals on purpose -- z-index 400 against the modal
+             * stack's 200 -- so an error raised while a modal is open stays visible, and that
+             * overlap is an accepted trade-off rather than something this spec should assert
+             * about.  The endpoints are all mocked in `beforeEach` so no toast is raised.
              */
-            cy.get('body').then(($body) => $body.find('.mantine-Notifications-root').remove());
-
             cy.get('[role="dialog"] input').should('be.visible');
         });
 

--- a/app/cypress/e2e/keyboard-shortcuts.cy.js
+++ b/app/cypress/e2e/keyboard-shortcuts.cy.js
@@ -54,6 +54,27 @@ describe('Keyboard Shortcuts', () => {
 
             // Search modal should open
             cy.get('[role="dialog"]').should('be.visible');
+
+            /*
+             * Take down any toast before the assertion below, which is occlusion-sensitive.
+             *
+             * Toasts paint above modals on purpose -- z-index 400 against the modal stack's
+             * 200 -- so that an error raised while a modal is open stays visible.  The search
+             * modal is tall, so it sits near the top of the window, and a top-right toast
+             * covers the right-hand 192px of its 365px input.  Cypress occlusion-checks a
+             * `position: fixed` element, so `should('be.visible')` on that input fails.
+             *
+             * That is not this spec's subject.  It passed locally and failed in CI, where the
+             * React app is served with no API behind it: `/api/tag`, `/api/events/feed`,
+             * `/api/files/search` and `/api/files/worker_status` are not mocked here, they
+             * fail, and api.js raises "Unexpected server response".  The overlap itself is an
+             * accepted trade-off -- see the toast/modal note in ui.css -- so the environment is
+             * made quiet rather than the assertion weakened.
+             *
+             * Removed rather than dismissed by clicking: a click races the next failing call.
+             */
+            cy.get('body').then(($body) => $body.find('.mantine-Notifications-root').remove());
+
             cy.get('[role="dialog"] input').should('be.visible');
         });
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -36,7 +36,7 @@
  * switch to `bottom-right` should not silently inherit a top offset.
  */
 html .mantine-Notifications-root[data-position^='top'] {
-    top: calc(var(--navbar-height) + var(--mantine-spacing-md, 16px));
+    top: calc(var(--navbar-height) + var(--mantine-spacing-md, 1rem));
 }
 
 .wrolpi-navbar-right {
@@ -159,7 +159,7 @@ html .wrolpi-navbar .mantine-ActionIcon-root:hover {
 }
 
 .channel-edit {
-    border-radius: 3px;
+    border-radius: 0.1875rem;
     padding: 0.75em;
 }
 
@@ -186,12 +186,12 @@ pre.wrap-text {
 
 .duration-overlay {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 0.25rem;
+    right: 0.25rem;
     color: black;
     background: #ffffff;
-    padding: 0px 4px;
-    border-radius: 3px;
+    padding: 0px 0.25rem;
+    border-radius: 0.1875rem;
 }
 
 .no-link-underscore {
@@ -219,8 +219,8 @@ div.inverted {
 .toggle {
     position: relative;
     display: inline-block;
-    width: 49px;
-    height: 23px;
+    width: 3.0625rem;
+    height: 1.4375rem;
 }
 
 .toggle input {
@@ -239,14 +239,14 @@ div.inverted {
     background-color: rgb(166, 166, 166);
     -webkit-transition: .4s;
     transition: .4s;
-    border-radius: 34px;
+    border-radius: 2.125rem;
 }
 
 .slider:before {
     position: absolute;
     content: "";
-    height: 22px;
-    width: 22px;
+    height: 1.375rem;
+    width: 1.375rem;
     left: 0;
     bottom: 0;
     background-color: white;
@@ -316,9 +316,9 @@ input:checked + .slider:before {
    Use 100dvh so mobile browser chrome (URL bar) is accounted for. */
 .preview-fit {
     width: 100%;
-    height: calc(100dvh - 300px);
-    max-height: calc(100dvh - 300px);
-    min-height: 240px;
+    height: calc(100dvh - 18.75rem);
+    max-height: calc(100dvh - 18.75rem);
+    min-height: 15rem;
     overflow: hidden;
     position: relative;
     display: flex;
@@ -356,12 +356,12 @@ td.file-path > svg {
 .ui-alerts {
     position: fixed;
     z-index: 2060;
-    padding: 24px;
+    padding: 1.5rem;
 }
 
 .ui-alerts.top-right {
-    top: 20px;
-    right: 20px;
+    top: 1.25rem;
+    right: 1.25rem;
 }
 
 textarea.otp {
@@ -370,9 +370,9 @@ textarea.otp {
 }
 
 .card-icon {
-    min-height: 163px;
+    min-height: 10.1875rem;
     text-align: center;
-    padding-top: 53px;
+    padding-top: 3.3125rem;
 }
 
 .card-icon.inverted {
@@ -426,11 +426,6 @@ textarea.otp {
     box-shadow: none !important;
 }
 
-/* Mobile-responsive Confirm modal */
-.ui.modal.themed-confirm {
-    max-width: 95vw;
-}
-
 .clickable {
     cursor: pointer;
 }
@@ -469,7 +464,7 @@ textarea.otp {
 }
 
 .search-clear {
-    margin: 10px;
+    margin: 0.625rem;
 }
 
 .icon.divider {
@@ -524,40 +519,40 @@ table.ratio-table td.min-width {
 }
 
 .form-skeleton-label {
-    height: 14px;
-    width: 80px;
-    margin-bottom: 8px;
+    height: 0.875rem;
+    width: 5rem;
+    margin-bottom: 0.5rem;
     background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s infinite;
-    border-radius: 3px;
+    border-radius: 0.1875rem;
 }
 
 .form-skeleton-input {
-    height: 38px;
+    height: 2.375rem;
     width: 100%;
     background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s infinite;
-    border-radius: 4px;
+    border-radius: 0.25rem;
 }
 
 .form-skeleton-textarea {
-    height: 80px;
+    height: 5rem;
     width: 100%;
     background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s infinite;
-    border-radius: 4px;
+    border-radius: 0.25rem;
 }
 
 .form-skeleton-button {
-    height: 42px;
-    width: 100px;
+    height: 2.625rem;
+    width: 6.25rem;
     background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s infinite;
-    border-radius: 4px;
+    border-radius: 0.25rem;
 }
 
 @keyframes skeleton-shimmer {
@@ -741,7 +736,7 @@ tr.drag-deselecting td {
     .inventory-print th,
     .inventory-print td {
         border: 1px solid #999;
-        padding: 4px 6px;
+        padding: 0.25rem 0.375rem;
         text-align: left;
         vertical-align: top;
     }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -216,66 +216,18 @@ div.inverted {
     background-color: #1B1C1D;
 }
 
-.toggle {
-    position: relative;
-    display: inline-block;
-    width: 3.0625rem;
-    height: 1.4375rem;
-}
-
-.toggle input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-
-.slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgb(166, 166, 166);
-    -webkit-transition: .4s;
-    transition: .4s;
-    border-radius: 2.125rem;
-}
-
-.slider:before {
-    position: absolute;
-    content: "";
-    height: 1.375rem;
-    width: 1.375rem;
-    left: 0;
-    bottom: 0;
-    background-color: white;
-    -webkit-transition: .4s;
-    transition: .4s;
-    border-radius: 50%;
-}
-
-.slider.disabled:before {
-    background-color: #CCCCCC;
-}
-
-input:checked + .slider {
-    background-color: #6435C9FF;
-}
-
-input.inverted:checked + .slider.inverted {
-    background-color: #6435C9AA;
-}
-
-input.disabled + .slider {
-    background-color: rgb(147, 147, 147);
-}
-
-input:checked + .slider:before {
-    -webkit-transform: translateX(26px);
-    -ms-transform: translateX(26px);
-    transform: translateX(26px);
-}
+/*
+ * The hand-rolled `.toggle` / `.slider` switch is gone.
+ *
+ * Nothing referenced either class: `Toggle` is a Mantine Switch, and the only remaining
+ * matches for the words were the `classList.toggle` DOM method and the controller's own
+ * templates, which do not load this stylesheet.
+ *
+ * It is deleted rather than finished because it was already half-converted and broken: the
+ * track and knob became rem while the checked-state travel stayed `translateX(26px)`, so on a
+ * 54px track the thumb would have stopped ~4px short.  Dead CSS that is also wrong is a trap
+ * for whoever revives it, and it also hardcoded #6435C9 and white, which no theme can reach.
+ */
 
 .inverted-progress-text.ui.indicating.progress .bar > .progress,
 .inverted-progress-text.ui.progress > .label {
@@ -306,7 +258,8 @@ input:checked + .slider:before {
 }
 
 .preview-toolbar-tags {
-    flex: 1 1 200px;
+    /* rem so the basis grows with the tags it holds. */
+    flex: 1 1 12.5rem;
     min-width: 0;
 }
 

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -987,8 +987,8 @@ function RefreshStepItem({phase, isActive, isCompleted, isDisabled, description}
         <Icon name={phase.icon} size='large'
               style={{color: isCompleted ? 'var(--success)' : isActive ? 'var(--info)' : 'var(--neutral)'}}/>
         <div>
-            <div style={{fontWeight: 600, fontSize: 13}}>{phase.title}</div>
-            <div style={{fontSize: 12, color: 'var(--muted)'}}>{isActive || isCompleted ? description : ''}</div>
+            <div style={{fontWeight: 600, fontSize: '0.8125rem'}}>{phase.title}</div>
+            <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{isActive || isCompleted ? description : ''}</div>
         </div>
     </div>
 }

--- a/app/src/components/Flasher.js
+++ b/app/src/components/Flasher.js
@@ -835,7 +835,7 @@ export function FlasherPage() {
                         <Icon name='save'/>
                         <div>
                             <div style={{fontWeight: 600}}>{configuration.name}</div>
-                            <div style={{fontSize: 12, opacity: 0.8}}>
+                            <div style={{fontSize: '0.75rem', opacity: 0.8}}>
                                 {(configuration.files || []).length} file(s)
                                 {configuration.erase_all ? ' — erases flash' : ''}
                             </div>
@@ -968,7 +968,7 @@ export function FlasherPage() {
                 <Header as='h3'>2. Connect</Header>
                 <Stack gap={12} style={{maxWidth: 320}}>
                     <div>
-                        <div style={{marginBottom: 4, fontSize: 13, fontWeight: 500}}>Baud rate</div>
+                        <div style={{marginBottom: 4, fontSize: '0.8125rem', fontWeight: 500}}>Baud rate</div>
                         <Select
                             data={BAUD_OPTIONS.map(o => ({value: String(o.value), label: o.text}))}
                             value={String(baudrate)}

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -577,7 +577,7 @@ function MapPins() {
                 <a href="#" onClick={(e) => {e.preventDefault(); handleNavigate(pin);}}>
                     {pin.label}
                 </a>
-                <div style={{fontSize: 11, color: 'var(--muted)'}}>{pin.lat.toFixed(4)}, {pin.lon.toFixed(4)}</div>
+                <div style={{fontSize: '0.6875rem', color: 'var(--muted)'}}>{pin.lat.toFixed(4)}, {pin.lon.toFixed(4)}</div>
             </Table.Cell>
             <Table.Cell>
                 <APIButton

--- a/app/src/components/MapViewer.js
+++ b/app/src/components/MapViewer.js
@@ -264,15 +264,15 @@ function LayerControl({map, scaleUnit, onScaleUnitChange, visibilityRef}) {
     // every theme, same as the nav bar.
     const panelStyle = {
         position: "absolute",
-        top: 10,
-        left: 10,
+        top: "0.625rem",
+        left: "0.625rem",
         zIndex: 1000,
         background: "var(--panel)",
         border: "1px solid var(--border)",
         color: "var(--text)",
-        maxHeight: "calc(100vh - 120px)",
+        maxHeight: "calc(100vh - 7.5rem)",
         overflowY: "auto",
-        minWidth: iconOnly ? 0 : 200,
+        minWidth: iconOnly ? 0 : "12.5rem",
         fontSize: '0.8125rem',
     };
 
@@ -280,10 +280,10 @@ function LayerControl({map, scaleUnit, onScaleUnitChange, visibilityRef}) {
         ? {
             padding: 0, cursor: "pointer", userSelect: "none",
             display: "flex", alignItems: "center", justifyContent: "center",
-            width: 40, height: 40,
+            width: "2.5rem", height: "2.5rem",
         }
         : {
-            padding: "8px 12px", cursor: "pointer", fontWeight: 600,
+            padding: "0.5rem 0.75rem", cursor: "pointer", fontWeight: 600,
             display: "flex", justifyContent: "space-between", alignItems: "center",
             borderBottom: collapsed ? "none" : "1px solid var(--border)", userSelect: "none",
         };
@@ -302,9 +302,9 @@ function LayerControl({map, scaleUnit, onScaleUnitChange, visibilityRef}) {
                     <Icon name={collapsed ? "chevron right" : "chevron down"} size="small"/>
                 </>}
         </div>
-        {!collapsed && <div style={{padding: "4px 12px 8px"}}>
+        {!collapsed && <div style={{padding: "0.25rem 0.75rem 0.5rem"}}>
             {Object.keys(LAYER_GROUPS).map(name =>
-                <div key={name} style={{padding: "2px 0"}}>
+                <div key={name} style={{padding: "0.125rem 0"}}>
                     <Checkbox
                         label={name}
                         checked={visibility[name]}
@@ -312,7 +312,7 @@ function LayerControl({map, scaleUnit, onScaleUnitChange, visibilityRef}) {
                     />
                 </div>
             )}
-            <div style={{borderTop: "1px solid var(--border)", marginTop: 6, paddingTop: 6}}>
+            <div style={{borderTop: "1px solid var(--border)", marginTop: "0.375rem", paddingTop: "0.375rem"}}>
                 <Toggle
                     label={scaleUnit === "imperial" ? "Imperial" : "Metric"}
                     checked={scaleUnit === "imperial"}
@@ -334,31 +334,31 @@ function AddPinDialog({lat, lon, onSubmit, onCancel}) {
     return <div style={{
         position: "absolute", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
         zIndex: 1002, background: "var(--panel)", border: "1px solid var(--border)", color: "var(--text)",
-        padding: 16, minWidth: 250,
+        padding: "1rem", minWidth: "15.625rem",
     }}>
-        <div style={{fontWeight: 600, marginBottom: 8}}>Add Pin</div>
-        <div style={{fontSize: '0.75rem', color: "var(--muted)", marginBottom: 8}}>{lat.toFixed(4)}, {lon.toFixed(4)}</div>
+        <div style={{fontWeight: 600, marginBottom: "0.5rem"}}>Add Pin</div>
+        <div style={{fontSize: '0.75rem', color: "var(--muted)", marginBottom: "0.5rem"}}>{lat.toFixed(4)}, {lon.toFixed(4)}</div>
         <TextInput
             placeholder="Label"
             value={label}
             onChange={e => setLabel(e.target.value)}
             autoFocus
             onKeyDown={e => e.key === "Enter" && label.trim() && onSubmit(label.trim(), color)}
-            style={{marginBottom: 8}}
+            style={{marginBottom: "0.5rem"}}
         />
-        <div style={{display: "flex", gap: 6, marginBottom: 12}}>
+        <div style={{display: "flex", gap: "0.375rem", marginBottom: "0.75rem"}}>
             {PIN_COLORS.map(c =>
                 <div
                     key={c}
                     onClick={() => setColor(c)}
                     style={{
-                        width: 24, height: 24, borderRadius: "50%", background: c, cursor: "pointer",
+                        width: "1.5rem", height: "1.5rem", borderRadius: "50%", background: c, cursor: "pointer",
                         border: color === c ? "3px solid var(--text)" : "2px solid var(--border)",
                     }}
                 />
             )}
         </div>
-        <div style={{display: "flex", gap: 8, justifyContent: "flex-end"}}>
+        <div style={{display: "flex", gap: "0.5rem", justifyContent: "flex-end"}}>
             <Button role='cancel' size='sm' onClick={onCancel}>Cancel</Button>
             <Button
                 role='primary'
@@ -484,8 +484,8 @@ function MapSearch({map}) {
     // Floating search chrome over the canvas — page interface, not map data, so it is
     // never filtered.  Flat surfaces: bordered, no box-shadow, token colors only.
     return <div ref={containerRef} style={{
-        position: "absolute", top: 10, left: "50%", transform: "translateX(-50%)",
-        zIndex: 5, width: 320, maxWidth: "calc(100% - 100px)",
+        position: "absolute", top: "0.625rem", left: "50%", transform: "translateX(-50%)",
+        zIndex: 5, width: "20rem", maxWidth: "calc(100% - 100px)",
     }}>
         <input
             type="text"
@@ -495,20 +495,20 @@ function MapSearch({map}) {
             onFocus={() => results.length > 0 && setShowResults(true)}
             onKeyDown={handleKeyDown}
             style={{
-                width: "100%", padding: "8px 12px", border: "1px solid var(--border)",
+                width: "100%", padding: "0.5rem 0.75rem", border: "1px solid var(--border)",
                 fontSize: '0.875rem', background: "var(--panel)", color: "var(--text)",
             }}
         />
         {showResults && results.length > 0 && <div style={{
             background: "var(--panel)", border: "1px solid var(--border)", borderTop: "none",
-            maxHeight: 300, overflowY: "auto",
+            maxHeight: "18.75rem", overflowY: "auto",
         }}>
             {results.map((r, i) => <div
                 key={i}
                 onClick={() => handleSelect(r)}
                 onMouseEnter={e => e.currentTarget.style.background = "var(--head)"}
                 onMouseLeave={e => e.currentTarget.style.background = "transparent"}
-                style={{padding: "8px 12px", cursor: "pointer", borderBottom: "1px solid var(--border)"}}
+                style={{padding: "0.5rem 0.75rem", cursor: "pointer", borderBottom: "1px solid var(--border)"}}
             >
                 <div style={{fontWeight: 500}}>{r.name}</div>
                 {resultSubtext(r) && <div style={{fontSize: '0.6875rem', color: "var(--muted)"}}>{resultSubtext(r)}</div>}
@@ -933,14 +933,14 @@ export default function MapViewer() {
                 top: contextMenu.y,
                 zIndex: 1001,
                 background: "white",
-                borderRadius: 6,
+                borderRadius: "0.375rem",
                 boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
-                padding: "4px 0",
+                padding: "0.25rem 0",
                 fontSize: '0.8125rem',
-                minWidth: 180,
+                minWidth: "11.25rem",
             }}
         >
-            <div style={{padding: "6px 12px", color: "#666", fontSize: '0.75rem', borderBottom: "1px solid #eee"}}>
+            <div style={{padding: "0.375rem 0.75rem", color: "#666", fontSize: '0.75rem', borderBottom: "1px solid #eee"}}>
                 {(() => {
                     const map = mapRef.current;
                     const zoom = map ? map.getZoom() : 10;
@@ -949,7 +949,7 @@ export default function MapViewer() {
                 })()}
             </div>
             <div
-                style={{padding: "8px 12px", cursor: "pointer", userSelect: "none"}}
+                style={{padding: "0.5rem 0.75rem", cursor: "pointer", userSelect: "none"}}
                 onMouseEnter={e => e.target.style.background = "#f0f0f0"}
                 onMouseLeave={e => e.target.style.background = "transparent"}
                 onClick={handleCopyCoords}
@@ -957,7 +957,7 @@ export default function MapViewer() {
                 Copy GPS coordinates
             </div>
             <div
-                style={{padding: "8px 12px", cursor: "pointer", userSelect: "none"}}
+                style={{padding: "0.5rem 0.75rem", cursor: "pointer", userSelect: "none"}}
                 onMouseEnter={e => e.target.style.background = "#f0f0f0"}
                 onMouseLeave={e => e.target.style.background = "transparent"}
                 onClick={handleExportPng}
@@ -965,7 +965,7 @@ export default function MapViewer() {
                 Export as PNG
             </div>
             <div
-                style={{padding: "8px 12px", cursor: "pointer", userSelect: "none"}}
+                style={{padding: "0.5rem 0.75rem", cursor: "pointer", userSelect: "none"}}
                 onMouseEnter={e => e.target.style.background = "#f0f0f0"}
                 onMouseLeave={e => e.target.style.background = "transparent"}
                 onClick={handleAddPin}
@@ -973,7 +973,7 @@ export default function MapViewer() {
                 Add Pin Here
             </div>
             <div
-                style={{padding: "8px 12px", cursor: "pointer", userSelect: "none"}}
+                style={{padding: "0.5rem 0.75rem", cursor: "pointer", userSelect: "none"}}
                 onMouseEnter={e => e.target.style.background = "#f0f0f0"}
                 onMouseLeave={e => e.target.style.background = "transparent"}
                 onClick={handleSetDefaultLocation}

--- a/app/src/components/MapViewer.js
+++ b/app/src/components/MapViewer.js
@@ -273,7 +273,7 @@ function LayerControl({map, scaleUnit, onScaleUnitChange, visibilityRef}) {
         maxHeight: "calc(100vh - 120px)",
         overflowY: "auto",
         minWidth: iconOnly ? 0 : 200,
-        fontSize: 13,
+        fontSize: '0.8125rem',
     };
 
     const headerStyle = iconOnly
@@ -337,7 +337,7 @@ function AddPinDialog({lat, lon, onSubmit, onCancel}) {
         padding: 16, minWidth: 250,
     }}>
         <div style={{fontWeight: 600, marginBottom: 8}}>Add Pin</div>
-        <div style={{fontSize: 12, color: "var(--muted)", marginBottom: 8}}>{lat.toFixed(4)}, {lon.toFixed(4)}</div>
+        <div style={{fontSize: '0.75rem', color: "var(--muted)", marginBottom: 8}}>{lat.toFixed(4)}, {lon.toFixed(4)}</div>
         <TextInput
             placeholder="Label"
             value={label}
@@ -496,7 +496,7 @@ function MapSearch({map}) {
             onKeyDown={handleKeyDown}
             style={{
                 width: "100%", padding: "8px 12px", border: "1px solid var(--border)",
-                fontSize: 14, background: "var(--panel)", color: "var(--text)",
+                fontSize: '0.875rem', background: "var(--panel)", color: "var(--text)",
             }}
         />
         {showResults && results.length > 0 && <div style={{
@@ -511,7 +511,7 @@ function MapSearch({map}) {
                 style={{padding: "8px 12px", cursor: "pointer", borderBottom: "1px solid var(--border)"}}
             >
                 <div style={{fontWeight: 500}}>{r.name}</div>
-                {resultSubtext(r) && <div style={{fontSize: 11, color: "var(--muted)"}}>{resultSubtext(r)}</div>}
+                {resultSubtext(r) && <div style={{fontSize: '0.6875rem', color: "var(--muted)"}}>{resultSubtext(r)}</div>}
             </div>)}
         </div>}
     </div>;
@@ -936,11 +936,11 @@ export default function MapViewer() {
                 borderRadius: 6,
                 boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
                 padding: "4px 0",
-                fontSize: 13,
+                fontSize: '0.8125rem',
                 minWidth: 180,
             }}
         >
-            <div style={{padding: "6px 12px", color: "#666", fontSize: 12, borderBottom: "1px solid #eee"}}>
+            <div style={{padding: "6px 12px", color: "#666", fontSize: '0.75rem', borderBottom: "1px solid #eee"}}>
                 {(() => {
                     const map = mapRef.current;
                     const zoom = map ? map.getZoom() : 10;

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -68,7 +68,7 @@ const samplePoster = (width, height) => `data:image/svg+xml,${encodeURIComponent
 
 const Section = ({label, children}) => <section style={{marginBottom: 34}}>
     <p style={{
-        fontSize: 11, fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase',
+        fontSize: '0.6875rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase',
         color: 'var(--muted)', margin: '0 0 10px',
     }}>{label}</p>
     {children}
@@ -127,7 +127,7 @@ export const NavBarSample = ({color}) => {
             </div>
         </nav>
         <div style={{
-            fontSize: 11, color: short ? 'var(--danger)' : 'var(--muted)',
+            fontSize: '0.6875rem', color: short ? 'var(--danger)' : 'var(--muted)',
             padding: '3px 2px 0', display: 'flex', gap: 8,
         }}>
             <strong style={{fontWeight: 600}}>{color}</strong>
@@ -157,8 +157,8 @@ export function ThemeSamplePage() {
     const [page, setPage] = useState(3);
 
     return <div style={{maxWidth: 1060, margin: '0 auto', padding: '20px 16px 60px', color: 'var(--text)'}}>
-        <h1 style={{fontSize: 21, fontWeight: 600, margin: '8px 0 4px'}}>Component gallery</h1>
-        <p style={{color: 'var(--muted)', fontSize: 13, marginTop: 0}}>
+        <h1 style={{fontSize: '1.3125rem', fontWeight: 600, margin: '8px 0 4px'}}>Component gallery</h1>
+        <p style={{color: 'var(--muted)', fontSize: '0.8125rem', marginTop: 0}}>
             Every component in the WROLPi interface library, rendered in the <strong>{theme}</strong> theme.
             Switch themes here or from the navigation bar.
         </p>
@@ -166,7 +166,7 @@ export function ThemeSamplePage() {
         <Section label='Theme picker'>
             <Panel>
                 <ThemePicker/>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
                     The same picker the Settings page uses. The navigation bar has a compact
                     version; both read the same list of themes.
                 </p>
@@ -175,7 +175,7 @@ export function ThemeSamplePage() {
 
         <Section label='Navigation bars'>
             <Panel>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 0}}>
                     Every color the navigation bar can be set to (Settings &rarr; navbar
                     color), in the <strong>{theme}</strong> theme. The text and icons are not
                     a fixed color: each bar is measured, and drawn in whichever of this
@@ -199,7 +199,7 @@ export function ThemeSamplePage() {
                         */}
                         <img src='/icon.svg' alt='The WROLPi logo, filtered like any other media'
                              width={104} height={104}/>
-                        <p style={{fontSize: 11, color: 'var(--muted)', margin: '4px 0 0'}}>
+                        <p style={{fontSize: '0.6875rem', color: 'var(--muted)', margin: '4px 0 0'}}>
                             Filtered
                         </p>
                     </div>
@@ -214,11 +214,11 @@ export function ThemeSamplePage() {
                                    alt='The WROLPi logo, unfiltered' width={104} height={104}/>
                             : <Button role='cancel' icon='eye' style={{width: 104, height: 104}}
                                       onClick={() => setRealColors(true)}>Show</Button>}
-                        <p style={{fontSize: 11, color: 'var(--muted)', margin: '4px 0 0'}}>
+                        <p style={{fontSize: '0.6875rem', color: 'var(--muted)', margin: '4px 0 0'}}>
                             Real colors
                         </p>
                     </div>
-                    <p style={{fontSize: 12, color: 'var(--muted)', margin: 0, maxWidth: 430}}>
+                    <p style={{fontSize: '0.75rem', color: 'var(--muted)', margin: 0, maxWidth: 430}}>
                         Images, video, PDFs, embedded pages, and the map canvas cannot read theme
                         tokens, so a monochrome theme remaps them with an SVG color matrix instead.
                         Night filters to red unless you turn it off; amber tints to match only if
@@ -237,7 +237,7 @@ export function ThemeSamplePage() {
                 */}
                 <div style={{marginTop: 14}}>
                     <MediaFilterToggle/>
-                    <p style={{fontSize: 12, color: 'var(--muted)', margin: '8px 0 0'}}>
+                    <p style={{fontSize: '0.75rem', color: 'var(--muted)', margin: '8px 0 0'}}>
                         <code>MediaFilterToggle</code>, the control the theme picker ends with.
                         It is per theme — turning it off for night leaves amber's alone — and it
                         renders nothing for a theme that offers no filter, so light and dark
@@ -262,7 +262,7 @@ export function ThemeSamplePage() {
                 <Header as='h3' after={<Icon name='question' size='small'/>}>
                     With a help icon beside it
                 </Header>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     The level picks the size, so the type scale stays a scale: call sites
                     choose a heading level for the document outline, never a font size.
                 </p>
@@ -332,11 +332,11 @@ export function ThemeSamplePage() {
                         </div>)}
                     </Row>
                 </div>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     In night mode Delete drops its fill for a dashed red outline; dashed means
                     destructive or failed, and nothing else uses it.
                 </p>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     An icon button is exactly as tall as a labelled one at every size, so a
                     group of them lines up. Mantine's own scale for icon buttons is unrelated
                     to its scale for buttons — <code>sm</code> is 22px against a button's 36px
@@ -415,7 +415,7 @@ export function ThemeSamplePage() {
                     <Button role='danger' onClick={() => clearToasts()}>Clear all</Button>
                 </Row>
 
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     Top right, five at a time, five seconds each unless the caller says
                     otherwise. Check each type in all four themes: night has no second hue to
                     spend, so info, success, warning and error cannot be told apart by color
@@ -447,13 +447,13 @@ export function ThemeSamplePage() {
                         <div style={{
                             height: 34, background: `var(--${role})`, marginBottom: 6,
                         }}/>
-                        <div style={{fontSize: 13, fontWeight: 600, color: `var(--${role})`}}>
+                        <div style={{fontSize: '0.8125rem', fontWeight: 600, color: `var(--${role})`}}>
                             {role}
                         </div>
-                        <div style={{fontSize: 11, color: 'var(--muted)'}}>{meaning}</div>
+                        <div style={{fontSize: '0.6875rem', color: 'var(--muted)'}}>{meaning}</div>
                     </div>)}
                 </div>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 14, marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 14, marginBottom: 0}}>
                     Components ask for a <em>meaning</em> — <code>danger</code> — not a hue.
                     Light and dark spend a color on each. Night and amber have only one hue,
                     so a role is a step on a brightness ramp instead; that is why an error and
@@ -473,7 +473,7 @@ export function ThemeSamplePage() {
                     <Status kind='pending'>pending</Status>
                     <Status kind='failed'>failed</Status>
                 </div>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 12, marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 12, marginBottom: 0}}>
                     Four states drawn from four roles. Failure also carries weight, because
                     brightness is the first thing lost on a dim screen and it is all night has.
                 </p>
@@ -521,7 +521,7 @@ export function ThemeSamplePage() {
                     <Progress percent={80} color='warning' label='Disk 80% full'/>
                     <Progress percent={100} color='danger' label='Error: HTTP 403'/>
                 </div>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 14, marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 14, marginBottom: 0}}>
                     A bar is 22px so its label has room; at 16px the text filled the bar edge to
                     edge. Check the mid-range ones — 37% and 62% are where the label crosses the
                     boundary between fill and track, which is the case that has to work.
@@ -656,7 +656,7 @@ export function ThemeSamplePage() {
                     <ColoredInput label='Ω' color='red' defaultValue='50'/>
                     <ColoredInput label='gal' color='green' labelPosition='right' defaultValue='275'/>
                 </div>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 8, marginBottom: 0}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 8, marginBottom: 0}}>
                     ColoredInput welds a Label to one edge of a field — the calculators' unit
                     markers. In night and amber the Label is an outline rather than a fill, so
                     the marker reads without a block of color.
@@ -695,7 +695,7 @@ export function ThemeSamplePage() {
                     clearable
                     placeholder='Search directory names…'
                 />
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
                     Focus the field to see grouped suggestions. Arrow keys move, Enter takes the
                     highlighted one or submits what you typed, Escape closes the list without
                     clearing the text.
@@ -714,7 +714,7 @@ export function ThemeSamplePage() {
                     >{tab}</button>)}
                 </TabBar>
                 <Pagination activePage={page} totalPages={12} onPageChange={setPage} showFirstAndLast/>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0, marginTop: 12}}>
                     Night and amber mark the current page with a heavier border rather than a
                     filled block, which would be a bright surface. The tab bar takes rendered
                     children, so routing stays with the caller.
@@ -757,7 +757,7 @@ export function ThemeSamplePage() {
                         style={{'--label-color': color, '--label-text': contrastingColor(color)}}
                     >{name}</span>)}
                 </Row>
-                <p style={{marginTop: 14, fontSize: 13, color: 'var(--muted)'}}>
+                <p style={{marginTop: 14, fontSize: '0.8125rem', color: 'var(--muted)'}}>
                     Every tag must be readable in all four themes. In night and amber the
                     user's color is discarded, so all tags look alike — that is the same
                     trade the labels above make, and it is deliberate.
@@ -775,7 +775,7 @@ export function ThemeSamplePage() {
                     <Row>
                         <Loader/>
                         <Icon name='circle notch' loading/>
-                        <span style={{fontSize: 12, color: 'var(--muted)'}}>
+                        <span style={{fontSize: '0.75rem', color: 'var(--muted)'}}>
                             Icons inherit currentColor, so they follow every theme.
                         </span>
                     </Row>
@@ -798,7 +798,7 @@ export function ThemeSamplePage() {
                                    style={{'--icon-stack-bg': 'var(--panel)'}}>
                             <Icon name='download' size='large'/>
                         </IconStack>
-                        <span style={{fontSize: 12, color: 'var(--muted)', maxWidth: 400}}>
+                        <span style={{fontSize: '0.75rem', color: 'var(--muted)', maxWidth: 400}}>
                             <code>IconStack</code> composes two glyphs into one symbol. The corner
                             glyph paints the surface behind itself so the two sets of strokes do not
                             cross, which means it has to be told what that surface is:{' '}
@@ -846,7 +846,7 @@ export function ThemeSamplePage() {
                     </div>}
                 />)}
             </CardGroup>
-            <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
+            <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 10}}>
                 A poster is capped on both axes — the card's width, and{' '}
                 <code>--card-poster-max-height</code> — and keeps its own ratio whichever
                 cap bites. Capping the width alone let a square thumbnail stand as tall as
@@ -872,13 +872,13 @@ export function ThemeSamplePage() {
                     </div> : undefined}
                 />)}
             </CardGroup>
-            <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
+            <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 10}}>
                 Titles are links but take the body color, not the link color — a grid of
                 results should read as titles. The meta line sits directly under the title;
                 actions are pushed to the foot, so a row lines its buttons up however many
                 lines each title took. A card with no actions simply ends.
             </p>
-            <p style={{fontSize: 12, color: 'var(--muted)', marginTop: 10}}>
+            <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginTop: 10}}>
                 The bottom edge carries the file type's color, so a grid of results is
                 scannable by kind before any title is read. It comes from a token, so night
                 and amber render the accent in their own single hue rather than four.
@@ -897,7 +897,7 @@ export function ThemeSamplePage() {
                 <Row>
                     <Button role='cancel' icon='eye' onClick={() => setModalOpen(true)}>Open a modal</Button>
                 </Row>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
                     Semantic's compound shape is kept — Modal.Header, Modal.Content,
                     Modal.Actions — so the 34 call sites written against it migrate by import.
                 </p>
@@ -919,8 +919,8 @@ export function ThemeSamplePage() {
 
         <Section label='Danger zone'>
             <Panel danger>
-                <h2 style={{color: 'var(--danger)', fontSize: 14, margin: '0 0 4px'}}>Danger zone</h2>
-                <p style={{color: 'var(--muted)', fontSize: 13, margin: '0 0 12px'}}>
+                <h2 style={{color: 'var(--danger)', fontSize: '0.875rem', margin: '0 0 4px'}}>Danger zone</h2>
+                <p style={{color: 'var(--muted)', fontSize: '0.8125rem', margin: '0 0 12px'}}>
                     These actions are destructive and cannot be undone.
                 </p>
                 <Row>
@@ -934,7 +934,7 @@ export function ThemeSamplePage() {
                         Delete tagged files
                     </Button>
                 </Row>
-                <p style={{fontSize: 12, color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0, marginTop: 10}}>
                     A confirmation is 380px wide, which suits a question. One that has to show
                     what it is about takes a size, in the same vocabulary as Modal.
                 </p>

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -475,7 +475,7 @@ export function VideosSettingsPage() {
                             value={configForm.formData.sleep_requests ?? 0.75}
                             onChange={(value) => configForm.setValue('sleep_requests', parseFloat(value) || 0)}
                             placeholder='0.75'
-                            rightSection={<span style={{fontSize: 12, color: 'var(--muted)'}}>sec</span>}
+                            rightSection={<span style={{fontSize: '0.75rem', color: 'var(--muted)'}}>sec</span>}
                             rightSectionWidth={36}
                         />
                     </div>

--- a/app/src/components/calculators/DriveCalculator.js
+++ b/app/src/components/calculators/DriveCalculator.js
@@ -399,7 +399,7 @@ function fmtSpeed(speed) {
 function WheelInput({hex, label, value, onChange, name, min, step}) {
     return <Group gap={0} wrap='nowrap' align='stretch' style={{marginBottom: '0.25em'}}>
         <span style={{
-            display: 'flex', alignItems: 'center', padding: '0 10px', fontSize: 13, fontWeight: 500,
+            display: 'flex', alignItems: 'center', padding: '0 10px', fontSize: '0.8125rem', fontWeight: 500,
             whiteSpace: 'nowrap', background: hex, color: textColorFor(hex), border: `1px solid ${hex}`,
         }}>{label}</span>
         <NumberInput name={name} value={value} onChange={onChange} min={min} step={step}

--- a/app/src/components/calculators/WaterCalculator.js
+++ b/app/src/components/calculators/WaterCalculator.js
@@ -211,7 +211,7 @@ export function clampNonNegative(value) {
 function SwatchInput({hex, label, value, onChange, name, min, step}) {
     return <Group gap={0} wrap='nowrap' align='stretch' style={{marginBottom: '0.25em'}}>
         <span style={{
-            display: 'flex', alignItems: 'center', padding: '0 10px', fontSize: 13, fontWeight: 500,
+            display: 'flex', alignItems: 'center', padding: '0 10px', fontSize: '0.8125rem', fontWeight: 500,
             whiteSpace: 'nowrap', background: hex, color: textColorFor(hex), border: `1px solid ${hex}`,
         }}>{label}</span>
         <NumberInput name={name} value={value} onChange={onChange} min={min} step={step}

--- a/app/src/components/ui/Feedback.tsx
+++ b/app/src/components/ui/Feedback.tsx
@@ -211,20 +211,20 @@ export interface LoadingProps {
  * used with their own wrapper div.
  */
 export function Loading({children, size = 'sm', padding = '2em'}: LoadingProps) {
-    return <div style={{
-        display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding,
-    }}>
+    // `padding` is the caller's, so it stays inline; the rest is in ui.css so it scales.
+    return <div className='wrolpi-loading' style={{padding}}>
         <Loader size={size} label={typeof children === 'string' ? children : undefined}/>
-        {children && <div style={{fontSize: 13, color: 'var(--muted)'}}>{children}</div>}
+        {children && <div className='wrolpi-loading-caption'>{children}</div>}
     </div>
 }
 
 /** Placeholder for content that has not arrived.  Replaces Semantic's Placeholder. */
 export function Placeholder({lines = 3, height = 12}: {lines?: number; height?: number}) {
-    return <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+    return <div className='wrolpi-placeholder'>
         {Array.from({length: lines}, (_, index) => <Skeleton
             key={index}
-            height={height}
+            // In rem so a placeholder line matches the height of the text it stands in for.
+            height={`${height / 16}rem`}
             // A ragged last line reads as text rather than a block.
             width={index === lines - 1 ? '60%' : '100%'}
             radius={0}

--- a/app/src/components/ui/Feedback.tsx
+++ b/app/src/components/ui/Feedback.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Loader as MLoader, Skeleton} from '@mantine/core';
 import {Icon} from './Icon';
+import {pxToRem} from './scale';
 import {RoleName, SemanticColorName} from '../../themes/mantine';
 
 /*
@@ -224,7 +225,7 @@ export function Placeholder({lines = 3, height = 12}: {lines?: number; height?: 
         {Array.from({length: lines}, (_, index) => <Skeleton
             key={index}
             // In rem so a placeholder line matches the height of the text it stands in for.
-            height={`${height / 16}rem`}
+            height={pxToRem(height)}
             // A ragged last line reads as text rather than a block.
             width={index === lines - 1 ? '60%' : '100%'}
             radius={0}

--- a/app/src/components/ui/Inputs.tsx
+++ b/app/src/components/ui/Inputs.tsx
@@ -205,8 +205,7 @@ export function ColoredInput({
 }: ColoredInputProps) {
     const labelNode = label ? <Label color={color || 'grey'}>{label}</Label> : null;
 
-    return <div style={{
-        display: 'flex', alignItems: 'stretch', gap: 6,
+    return <div className='wrolpi-colored-input' style={{
         width: fluid ? '100%' : undefined, ...style,
     }}>
         {labelNode && labelPosition === 'left' && labelNode}

--- a/app/src/components/ui/Overlays.tsx
+++ b/app/src/components/ui/Overlays.tsx
@@ -233,7 +233,9 @@ export function Confirm({
      */
     return <Modal opened={open} onClose={() => onCancel?.()} title={title} size={size}>
         {children}
-        <div style={{display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 18}}>
+        {/* Its own class rather than `.wrolpi-modal-actions`: a confirmation's buttons sit
+            under its question with no hairline, where a Modal's are a separated footer. */}
+        <div className='wrolpi-confirm-actions'>
             <Button role='cancel' onClick={onCancel}>{cancelLabel}</Button>
             <Button role={destructive ? 'danger' : 'save'} loading={loading} onClick={onConfirm}>
                 {confirmLabel}

--- a/app/src/components/ui/Surfaces.tsx
+++ b/app/src/components/ui/Surfaces.tsx
@@ -192,11 +192,12 @@ export function Card({media, title, meta, children, actions, onClick, color, cla
         }}
     >
         {media && <div style={{borderBottom: '1px solid var(--border)'}}>{media}</div>}
-        <div style={{padding: '10px 12px 12px', display: 'flex', flexDirection: 'column', gap: 4, flex: 1}}>
-            {title && <div style={{fontSize: 13, fontWeight: 600, lineHeight: 1.35}}>{title}</div>}
-            {meta && <div className='wrolpi-card-meta' style={{fontSize: 12, color: 'var(--muted)'}}>{meta}</div>}
+        {/* Sizes live in ui.css, in rem: inline px would sit outside the interface scale. */}
+        <div className='wrolpi-card-body'>
+            {title && <div className='wrolpi-card-title'>{title}</div>}
+            {meta && <div className='wrolpi-card-meta'>{meta}</div>}
             {children}
-            {actions && <div className='wrolpi-card-actions' style={{marginTop: 'auto', paddingTop: 8}}>
+            {actions && <div className='wrolpi-card-actions'>
                 {actions}
             </div>}
         </div>
@@ -216,9 +217,15 @@ export function CardGroup({children, minWidth = 200, className, style, ...props}
     return <div
         className={['wrolpi-card-group', className].filter(Boolean).join(' ')}
         style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth}px, 1fr))`,
-            gap: 14,
+            /*
+             * Converted to rem so a column grows with the interface scale.  As px it did not,
+             * and a 430px phone fitted two 200px cards where the pre-migration build fitted
+             * one 290px card -- the narrowest card in the app, on the smallest screen.
+             *
+             * The prop stays a px number: seven call sites pass one, and a caller thinking in
+             * px is thinking about the unscaled design.
+             */
+            gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth / 16}rem, 1fr))`,
             ...style,
         }}
         {...props}

--- a/app/src/components/ui/Surfaces.tsx
+++ b/app/src/components/ui/Surfaces.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Card as MCard, Tabs as MTabs, Accordion as MAccordion, Breadcrumbs} from '@mantine/core';
 import {Icon} from './Icon';
+import {pxToRem} from './scale';
 
 /*
  * Surfaces and structure: headers, panels, cards, statistics, tabs, accordions,
@@ -225,7 +226,7 @@ export function CardGroup({children, minWidth = 200, className, style, ...props}
              * The prop stays a px number: seven call sites pass one, and a caller thinking in
              * px is thinking about the unscaled design.
              */
-            gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth / 16}rem, 1fr))`,
+            gridTemplateColumns: `repeat(auto-fill, minmax(${pxToRem(minWidth)}, 1fr))`,
             ...style,
         }}
         {...props}

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -11,6 +11,7 @@
 
 import './ui.css';
 
+export * from './scale';
 export * from './Icon';
 export * from './Button';
 export * from './Feedback';

--- a/app/src/components/ui/scale.ts
+++ b/app/src/components/ui/scale.ts
@@ -1,0 +1,20 @@
+/*
+ * The interface scale, for the few places that must express a length in JavaScript.
+ *
+ * Sizes belong in ui.css, in rem, where `--ui-scale` reaches them (see themes/tokens.css).
+ * Two components cannot do that, because the length is a prop rather than a design decision:
+ * CardGroup's `minWidth` sets a grid track and Placeholder's `height` sets a skeleton line.
+ * Both took a px number from the caller and both divided it by 16 inline, which put the
+ * design-time base in two places with nothing tying them together.
+ */
+
+/** The px-per-rem the design is written against, and the browser's own default. */
+export const REM_BASE = 16;
+
+/**
+ * A px length from a call site, as a rem string, so it grows with the interface scale.
+ *
+ * Callers keep thinking in px deliberately: a number in a prop is a statement about the
+ * unscaled design, which is the size the value was chosen at.
+ */
+export const pxToRem = (px: number): string => `${px / REM_BASE}rem`;

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -16,6 +16,20 @@ import {DesktopNav, NavIconWrapper} from '../Nav';
 import {APIButton} from '../Common';
 import {ShareButton} from '../Share';
 
+/*
+ * The interface scale, so a test can express a length the way the stylesheet does.
+ *
+ * A hardcoded px expectation is a hidden assertion that the scale is 1.  Three tests here
+ * carried one -- a container width, a poster cap and a button height -- and all three failed
+ * when it became 1.1, in names that said nothing about size.
+ */
+const uiScale = () => {
+    const value = parseFloat(getComputedStyle(document.documentElement)
+        .getPropertyValue('--ui-scale'));
+    expect(value, 'the interface scale is declared').to.be.within(0.5, 3);
+    return value;
+};
+
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
     const value = hex.replace('#', '');
@@ -891,7 +905,14 @@ describe('StatisticGroup separates its statistics with nothing but space', () =>
      */
 
     // Narrow enough that six statistics cannot fit on one row at a 150px minimum.
-    const inNarrowColumn = (children) => <div style={{width: 340}}>{children}</div>;
+    /*
+     * "Narrow" has to mean narrow RELATIVE TO THE TYPE, or the width stops meaning anything
+     * when the interface scale changes.  At a fixed 340px this held two 150px statistic
+     * tracks; the scale took the track to 165px and 340px became a single column, so a test
+     * about the gap between columns had no second column to measure.
+     */
+    const inNarrowColumn = (children) =>
+        <div style={{width: `${Math.round(340 * uiScale())}px`}}>{children}</div>;
 
     const sixStatistics = <StatisticGroup>
         <Statistic value='1,432' label='Videos'/>
@@ -1710,16 +1731,36 @@ const narrowCard = (children) =>
     <MemoryRouter><div style={{width: 233}}>{children}</div></MemoryRouter>;
 
 /*
+ * A card as wide as the grid makes it when it drops to ONE column -- a phone, or any window
+ * under about 456px of content width.  Every case below used the narrow card, which is why
+ * the wide card's own failure went unseen for the whole migration: a 16:9 poster held to a
+ * 220px height is 391px wide, so a 451px card centred it with 30px of empty panel on either
+ * side.  The height cap was doing its job for a book cover and letterboxing a video sideways.
+ */
+const wideCard = (children) =>
+    <MemoryRouter><div style={{width: 451}}>{children}</div></MemoryRouter>;
+
+/*
  * The height cap, read from the stylesheet rather than repeated here, so the two cannot
  * drift.  Deleting the declaration makes this NaN and every comparison against it fails,
  * which is the point -- and the bound below keeps "read whatever the CSS says" from being
  * a test that any value at all satisfies.
  */
 const cardPosterCap = () => {
-    const value = parseFloat(getComputedStyle(document.documentElement)
-        .getPropertyValue('--card-poster-max-height'));
+    /*
+     * Resolved through the root font-size, because the cap is declared in rem so the
+     * interface scale reaches it.  `parseFloat('12.5rem')` is 12.5, which sailed through as a
+     * number and then failed the bound below -- five tests here broke that way when the scale
+     * landed, and none of them mention the cap in their names.
+     */
+    const root = getComputedStyle(document.documentElement);
+    const declared = root.getPropertyValue('--card-poster-max-height').trim();
+    expect(declared, 'the cap is declared in rem, so it scales with the interface')
+        .to.match(/^[\d.]+rem$/);
+
+    const value = parseFloat(declared) * parseFloat(root.fontSize);
     expect(value, 'a poster cap is declared, and is small enough to be a cap')
-        .to.be.within(80, 240);
+        .to.be.within(80, 300);
     return value;
 };
 
@@ -1783,6 +1824,62 @@ describe('a card poster is bounded by the card, and keeps its ratio', () => {
                 expect(box.height, 'the cap actually bit').to.be.at.most(cardPosterCap() + 0.5);
                 expect(box.width, 'and the width came down with it')
                     .to.be.closeTo(box.height, 0.5);
+            });
+    });
+
+    it('lets a landscape poster fill a one-column card instead of letterboxing it', () => {
+        /*
+         * The cap is a fixed height, so it stops scaling with the card: past 391px of card
+         * width a 16:9 poster can no longer reach the edges and `justify-content: center`
+         * splits the remainder into two margins.  On a phone -- one column, card the full
+         * width of the screen -- that is every video thumbnail in the library.
+         *
+         * A source wider than the card is the case that matters.  1280px of intrinsic width
+         * is available, so nothing here is upscaling: the poster is simply allowed to use
+         * the width it has.
+         */
+        servePoster(1280, 720);
+        cy.mountUI(wideCard(<CardPoster file={posterFile(1280, 720)}/>));
+
+        cy.get('.wrolpi-card-poster img')
+            .should(($img) => expect($img[0].naturalWidth, 'poster loaded').to.equal(1280))
+            .should(($img) => {
+                const img = $img[0];
+                const box = img.getBoundingClientRect();
+                const band = img.closest('.wrolpi-card-poster').getBoundingClientRect();
+
+                expect(band.width - box.width, 'no empty panel beside the poster')
+                    .to.be.at.most(1);
+                expect(box.width / box.height, 'and it still keeps its ratio')
+                    .to.be.closeTo(1280 / 720, 0.01);
+            });
+    });
+
+    it('still keeps a portrait cover to a band on a one-column card', () => {
+        /*
+         * The other half, and the reason the cap exists at all: freed of it entirely, a
+         * 306x396 book cover in a 451px card would stand 451px tall above a two-line title,
+         * so the media dwarfs the thing it belongs to.
+         *
+         * The bound is stated as a fraction of the CARD rather than a pixel count, because
+         * that is the actual rule -- the poster may be as tall as a 16:9 slice of this card
+         * and no taller.  A portrait cover therefore grows with the card, which it should,
+         * while never ceasing to be a band.
+         */
+        servePoster(306, 396);
+        cy.mountUI(wideCard(<CardPoster file={posterFile(306, 396)}/>));
+
+        cy.get('.wrolpi-card-poster img')
+            .should(($img) => expect($img[0].naturalWidth, 'poster loaded').to.equal(306))
+            .should(($img) => {
+                const img = $img[0];
+                const box = img.getBoundingClientRect();
+                const band = img.closest('.wrolpi-card-poster').getBoundingClientRect();
+
+                expect(box.height / band.width, 'the cover stays a band, not a column')
+                    .to.be.at.most(0.58);
+                expect(box.width / box.height, 'and keeps its ratio')
+                    .to.be.closeTo(306 / 396, 0.01);
             });
     });
 });
@@ -3469,13 +3566,21 @@ describe('APIButton honours the size its call site asks for', () => {
             <APIButton size='small' icon='trash' onClick={() => {}} data-testid='small'/>
             <APIButton size='big' icon='trash' onClick={() => {}} data-testid='big'/>
             <APIButton size='huge' icon='trash' onClick={() => {}} data-testid='huge'/>
+            {/* The reference: what `small` is claimed to translate INTO. */}
+            <APIButton size='sm' icon='trash' onClick={() => {}} data-testid='reference-sm'/>
         </div>);
 
         cy.get('[data-testid="huge"]').should(($huge) => {
             const height = (id) =>
                 Cypress.$(`[data-testid="${id}"]`)[0].getBoundingClientRect().height;
 
-            expect(height('small'), 'small is the old default').to.be.closeTo(36, 1);
+            /*
+             * Measured against a real `sm` button rather than against 36px.  The literal was a
+             * hidden assertion that the interface scale is 1, and it broke at 1.1 -- while the
+             * claim it is making, that `small` resolves to `sm`, was never about a pixel count.
+             */
+            expect(height('small'), "small resolves to Mantine's sm")
+                .to.be.closeTo(height('reference-sm'), 0.5);
             expect(height('big'), 'big is taller than small').to.be.greaterThan(height('small'));
             expect($huge[0].getBoundingClientRect().height, 'huge is taller than big')
                 .to.be.greaterThan(height('big'));

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -30,6 +30,92 @@ const uiScale = () => {
     return value;
 };
 
+describe('the interface scale actually reaches what it is supposed to', () => {
+    /*
+     * Every other check on the scale reads source text, which proves a declaration says `rem`
+     * and nothing about whether the browser then paints a larger control.  This is the one
+     * that measures, and it is the reason the source guards are worth trusting: it fails if
+     * `--ui-scale` stops being applied to the root, if Mantine's `theme.scale` is set and
+     * cancels it, or if a rule someone adds later pins a px size over the top.
+     */
+    /*
+     * The root of the application-under-test, not the runner's.  Cypress mounts the
+     * component in an iframe and loads the stylesheets there, so `window.top` reads the
+     * runner's own document -- where `--ui-scale` is not declared, so it came back NaN.
+     * `Cypress.$` is scoped to the AUT.
+     */
+    const root = () => Cypress.$('html')[0];
+
+    it('makes the root font-size the declared multiple of the browser default', () => {
+        cy.mountUI(<Button>Save</Button>);
+
+        cy.get('.mantine-Button-root').should(() => {
+            const scale = parseFloat(getComputedStyle(root()).getPropertyValue('--ui-scale'));
+            expect(scale, 'the scale is declared').to.be.within(0.5, 3);
+            // 16px is the browser default the percentage resolves against.
+            expect(parseFloat(getComputedStyle(root()).fontSize), 'root font-size')
+                .to.be.closeTo(16 * scale, 0.5);
+        });
+    });
+
+    it('grows a Mantine control and our own text together when the scale changes', () => {
+        /*
+         * Both halves in one measurement, because the failure that matters is them
+         * DISAGREEING: Mantine's sizes are `calc(Xrem * var(--mantine-scale))` and ours are
+         * plain rem, so a `theme.scale` of 1.1 alongside a 110% root would leave Mantine's
+         * buttons at the old size beside 10% larger card text.
+         */
+        cy.mountUI(<Card title='Rainwater Harvesting' meta='engineering775.com'/>);
+
+        /*
+         * DOUBLE whatever the scale currently is, rather than setting it to 2.  Setting the
+         * literal gave a ratio of 1.818 -- 2 divided by the 1.1 already in effect -- so the
+         * first version of this failed against a perfectly working scale.
+         */
+        const doubled = () => {
+            const current = parseFloat(getComputedStyle(root()).getPropertyValue('--ui-scale'));
+            root().style.setProperty('--ui-scale', String(current * 2));
+        };
+
+        cy.get('.wrolpi-card-title').should(($title) => {
+            const before = parseFloat(getComputedStyle($title[0]).fontSize);
+            expect(before, 'the card title has a size to grow from').to.be.greaterThan(1);
+            doubled();
+            const after = parseFloat(getComputedStyle($title[0]).fontSize);
+            root().style.removeProperty('--ui-scale');
+
+            // A px declaration would not have moved at all.
+            expect(after / before, 'our own text tracks the scale').to.be.closeTo(2, 0.05);
+        });
+
+        cy.mountUI(<Button>Save</Button>);
+        cy.get('.mantine-Button-root').should(($button) => {
+            const before = $button[0].getBoundingClientRect().height;
+            doubled();
+            const after = $button[0].getBoundingClientRect().height;
+            root().style.removeProperty('--ui-scale');
+
+            expect(after / before, "Mantine's controls track it too, by the same factor")
+                .to.be.closeTo(2, 0.05);
+        });
+    });
+
+    it('leaves a hairline a hairline at any scale', () => {
+        // The inverse, and the whole reason rem was chosen over `zoom`.
+        cy.mountUI(<Panel>Structure</Panel>);
+
+        cy.get('.wrolpi-panel').should(($panel) => {
+            const before = parseFloat(getComputedStyle($panel[0]).borderTopWidth);
+            root().style.setProperty('--ui-scale', '2');
+            const after = parseFloat(getComputedStyle($panel[0]).borderTopWidth);
+            root().style.removeProperty('--ui-scale');
+
+            expect(before, 'the panel has a hairline border').to.be.within(0.5, 2);
+            expect(after, 'and it does not grow with the type').to.be.closeTo(before, 0.05);
+        });
+    });
+});
+
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
     const value = hex.replace('#', '');

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -131,17 +131,17 @@ html .mantine-ActionIcon-root {
 
 .wrolpi-theme-picker {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(14.375rem, 1fr));
+    gap: 0.625rem;
 }
 
 .wrolpi-theme-option {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 0.25rem;
     align-items: flex-start;
     text-align: left;
-    padding: 10px 12px;
+    padding: 0.625rem 0.75rem;
     background: var(--panel);
     color: var(--text);
     border: 1px solid var(--border);
@@ -157,7 +157,7 @@ html .mantine-ActionIcon-root {
    selection survives in monochrome themes. */
 .wrolpi-theme-option-active {
     border: 2px solid var(--blue);
-    padding: 9px 11px;
+    padding: 0.5625rem 0.6875rem;
 }
 
 html[data-theme="night"] .wrolpi-theme-option-active,
@@ -173,21 +173,21 @@ html[data-theme="amber"] .wrolpi-theme-option-active {
 .wrolpi-theme-option-name {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
+    gap: 0.4375rem;
     font-weight: 600;
-    font-size: 13px;
+    font-size: 0.8125rem;
 }
 
 .wrolpi-theme-option-description {
-    font-size: 12px;
+    font-size: 0.75rem;
     color: var(--muted);
     line-height: 1.4;
 }
 
 /* Separated from the theme grid: it configures the chosen theme, it is not a choice. */
 .wrolpi-media-filter-setting {
-    margin-top: 14px;
-    padding-top: 12px;
+    margin-top: 0.875rem;
+    padding-top: 0.75rem;
     border-top: 1px solid var(--border);
 }
 
@@ -247,9 +247,9 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
-    gap: 12px;
+    gap: 0.75rem;
     border-bottom: 1px solid var(--border);
-    margin-bottom: 14px;
+    margin-bottom: 0.875rem;
 }
 
 .wrolpi-tabs-links {
@@ -258,15 +258,15 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
 }
 
 .wrolpi-tabs-right {
-    padding-bottom: 6px;
+    padding-bottom: 0.375rem;
 }
 
 .wrolpi-tab {
     display: inline-block;
-    padding: 8px 14px;
+    padding: 0.5rem 0.875rem;
     color: var(--muted);
     text-decoration: none;
-    font-size: 13px;
+    font-size: 0.8125rem;
     /*
      * A tab is a NavLink in the app's nav bars but a <button> on Inventory and in the
      * gallery, and a button carries the UA's own `buttonface` background -- rgb(239,239,239).
@@ -313,7 +313,7 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
      * stay in lockstep: changing the padding alone would have pushed the clear button past
      * the border, and changing the gap alone would have re-inset it.
      */
-    --searchbox-inset: 8px;
+    --searchbox-inset: 0.5rem;
     gap: var(--searchbox-inset);
     background: var(--panel);
     border: 1px solid var(--border);
@@ -337,13 +337,13 @@ html[data-theme="amber"] .wrolpi-searchbox-control:focus-within {
 .wrolpi-searchbox-input {
     flex: 1;
     min-width: 0;
-    padding: 8px 0;
+    padding: 0.5rem 0;
     background: none;
     border: none;
     outline: none;
     color: var(--text);
     font: inherit;
-    font-size: 13px;
+    font-size: 0.8125rem;
 }
 
 .wrolpi-searchbox-input::placeholder {
@@ -402,7 +402,7 @@ html .wrolpi-searchbox-clear {
      * domains together run past 320px, and the last group was being clipped -- but
      * still capped so a long list cannot cover the page.
      */
-    max-height: min(60vh, 480px);
+    max-height: min(60vh, 30rem);
     overflow-y: auto;
     background: var(--panel);
     border: 1px solid var(--border);
@@ -422,12 +422,12 @@ html .wrolpi-searchbox-clear {
  */
 .wrolpi-search-modal .wrolpi-searchbox-results {
     position: static;
-    max-height: min(50vh, 420px);
+    max-height: min(50vh, 26.25rem);
 }
 
 .wrolpi-searchbox-group-name {
-    padding: 6px 10px;
-    font-size: 11px;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.6875rem;
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -436,7 +436,7 @@ html .wrolpi-searchbox-clear {
 }
 
 .wrolpi-searchbox-result {
-    padding: 7px 10px;
+    padding: 0.4375rem 0.625rem;
     cursor: pointer;
     border-top: 1px solid var(--border);
 }
@@ -446,19 +446,19 @@ html .wrolpi-searchbox-clear {
 }
 
 .wrolpi-searchbox-result-title {
-    font-size: 13px;
+    font-size: 0.8125rem;
     color: var(--text);
     overflow-wrap: anywhere;
 }
 
 .wrolpi-searchbox-result-description {
-    font-size: 11px;
+    font-size: 0.6875rem;
     color: var(--muted);
 }
 
 .wrolpi-searchbox-empty {
-    padding: 10px;
-    font-size: 12px;
+    padding: 0.625rem;
+    font-size: 0.75rem;
     color: var(--muted);
 }
 
@@ -472,19 +472,27 @@ html .wrolpi-searchbox-clear {
     display: flex;
     justify-content: flex-end;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 0.625rem;
     /* Bleed back out through the modal body's own padding so the rule spans the
        full width; -1 * whatever Mantine padded the body with. */
-    margin: 18px calc(var(--mantine-spacing-md) * -1) calc(var(--mantine-spacing-md) * -1);
-    padding: 12px var(--mantine-spacing-md);
+    margin: 1.125rem calc(var(--mantine-spacing-md) * -1) calc(var(--mantine-spacing-md) * -1);
+    padding: 0.75rem var(--mantine-spacing-md);
     border-top: 1px solid var(--border);
+}
+
+/* A confirmation's buttons: under the question, no separating rule.  See Confirm. */
+.wrolpi-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.625rem;
+    margin-top: 1.125rem;
 }
 
 /* A stack of form rows, replacing Semantic's `ui stackable grid` in edit forms. */
 .wrolpi-form-rows {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 0.875rem;
 }
 
 /* ------------------------------------------------------------- Form fields */
@@ -509,12 +517,12 @@ html .wrolpi-searchbox-clear {
 
 .wrolpi-form-field input {
     width: 100%;
-    padding: 7px 9px;
+    padding: 0.4375rem 0.5625rem;
     background: var(--panel);
     color: var(--text);
     border: 1px solid var(--border);
     font: inherit;
-    font-size: 13px;
+    font-size: 0.8125rem;
 }
 
 .wrolpi-form-field input::placeholder {
@@ -552,8 +560,8 @@ html[data-theme="amber"] .wrolpi-form-field input:focus {
 .wrolpi-path-input-label {
     display: block;
     font-weight: 600;
-    font-size: 13px;
-    margin-bottom: 4px;
+    font-size: 0.8125rem;
+    margin-bottom: 0.25rem;
 }
 
 .wrolpi-path-input-control {
@@ -598,11 +606,11 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     max-width: 50%;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 0 6px 0 9px;
+    padding: 0 0.375rem 0 0.5625rem;
     background: var(--head);
     border-right: 1px solid var(--border);
     color: var(--muted);
-    font-size: 12px;
+    font-size: 0.75rem;
     white-space: nowrap;
     user-select: none;
 }
@@ -610,13 +618,13 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 .wrolpi-path-input-control input {
     flex: 1;
     min-width: 0;
-    padding: 7px 9px;
+    padding: 0.4375rem 0.5625rem;
     background: none;
     border: none;
     outline: none;
     color: var(--text);
     font: inherit;
-    font-size: 13px;
+    font-size: 0.8125rem;
 }
 
 .wrolpi-path-input-control input::placeholder {
@@ -628,15 +636,15 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 }
 
 .wrolpi-path-input-description {
-    font-size: 12px;
+    font-size: 0.75rem;
     color: var(--muted);
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 .wrolpi-path-input-error {
-    font-size: 12px;
+    font-size: 0.75rem;
     color: var(--danger);
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 /* ---------------------------------------------------------- Action inputs */
@@ -662,6 +670,37 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 
 .wrolpi-action-input > :not(.mantine-TextInput-root) {
     flex: none;
+}
+
+/* A colored label beside an input, unlike ActionInput's shared outline: they stay two
+   controls, so the gap between them is real and scales with the type. */
+.wrolpi-colored-input {
+    display: flex;
+    align-items: stretch;
+    gap: 0.375rem;
+}
+
+/* ------------------------------------------------- Loading & placeholders */
+/*
+ * A centered loader with a caption, and the skeleton stack that stands in for text.
+ * Both were inline px in Feedback.tsx, which put them outside the interface scale.
+ */
+.wrolpi-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.625rem;
+}
+
+.wrolpi-loading-caption {
+    font-size: 0.8125rem;
+    color: var(--muted);
+}
+
+.wrolpi-placeholder {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
 /* --------------------------------------------------------------- Switches */
@@ -713,9 +752,9 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 .wrolpi-label {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 5px 10px;
-    font-size: 12.5px;
+    gap: 0.25rem;
+    padding: 0.3125rem 0.625rem;
+    font-size: 0.78125rem;
     font-weight: 500;
     line-height: 1.3;
     background: var(--label-color);
@@ -747,16 +786,16 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
      * Room for the point, which is drawn outside the body: half its diagonal (14.1px) plus
      * the 1px it is nudged left, rounded up.
      */
-    margin-left: 16px;
+    margin-left: 1rem;
     /* Tags wrap, and a wrapped row was sitting on the row above it. */
-    margin-bottom: 5px;
+    margin-bottom: 0.3125rem;
     /*
      * The point is centred on the left edge, so its inner half covers the body's first 10px
      * -- and a positioned pseudo-element paints above the parent's text, not behind it, so
      * without this the first letter is hidden under the point.  Semantic's tag label carried
      * the same asymmetry (`padding-left: 1.5em`) for the same reason.
      */
-    padding-left: 13px;
+    padding-left: 0.8125rem;
 }
 
 .wrolpi-tag::before {
@@ -764,8 +803,8 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     position: absolute;
     top: 50%;
     right: 100%;
-    width: 20px;
-    height: 20px;
+    width: 1.25rem;
+    height: 1.25rem;
     /*
      * Nudged 1px left of where `right: 100%` puts it.  That property positions against the
      * containing block's *padding* box, and the body carries a 1px border, so a square centred
@@ -788,8 +827,8 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     position: absolute;
     top: 50%;
     left: -7px;
-    width: 5px;
-    height: 5px;
+    width: 0.3125rem;
+    height: 0.3125rem;
     margin-top: -2.5px;
     border-radius: 50%;
     background: currentColor;
@@ -842,7 +881,7 @@ html[data-theme="night"] .wrolpi-tag::before {
 /* ---------------------------------------------------------------- Headers */
 
 .wrolpi-header {
-    margin: 0 0 10px;
+    margin: 0 0 0.625rem;
 }
 
 /*
@@ -855,14 +894,14 @@ html[data-theme="night"] .wrolpi-tag::before {
  * where it should be, and pushing it down would just dent the top of its own container.
  */
 * + .wrolpi-header {
-    margin-top: 22px;
+    margin-top: 1.375rem;
 }
 
 /* The heading and its trailing control share one row. */
 .wrolpi-header-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 0.5rem;
 }
 
 /*
@@ -880,19 +919,19 @@ html[data-theme="night"] .wrolpi-tag::before {
     display: inline-flex;
     align-items: center;
     flex-shrink: 0;
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 400;
 }
 
 .wrolpi-header-dividing {
     border-bottom: 1px solid var(--border);
-    padding-bottom: 6px;
+    padding-bottom: 0.375rem;
 }
 
 .wrolpi-header-text {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 0.5rem;
     margin: 0;
     /*
      * Stated explicitly because semantic.min.css sets `h1,h2,h3,h4,h5 { font-family:
@@ -909,30 +948,30 @@ html[data-theme="night"] .wrolpi-tag::before {
 
 /* The scale lives here so no call site invents a size of its own. */
 .wrolpi-header-h1 {
-    font-size: 26px;
+    font-size: 1.625rem;
 }
 
 .wrolpi-header-h2 {
-    font-size: 21px;
+    font-size: 1.3125rem;
 }
 
 .wrolpi-header-h3 {
-    font-size: 17px;
+    font-size: 1.0625rem;
 }
 
 .wrolpi-header-h4 {
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 
 .wrolpi-header-h5 {
-    font-size: 13px;
+    font-size: 0.8125rem;
     letter-spacing: 0.02em;
 }
 
 .wrolpi-header-sub {
-    font-size: 12px;
+    font-size: 0.75rem;
     color: var(--muted);
-    margin-top: 3px;
+    margin-top: 0.1875rem;
 }
 
 /*
@@ -1015,12 +1054,12 @@ html .mantine-Notification-closeButton:hover {
 .wrolpi-message {
     display: flex;
     align-items: flex-start;
-    gap: 10px;
+    gap: 0.625rem;
     border: 1px solid var(--border);
     border-left: 3px solid var(--message-color, var(--border));
     background: var(--panel);
-    padding: 10px 14px;
-    font-size: 13px;
+    padding: 0.625rem 0.875rem;
+    font-size: 0.8125rem;
 }
 
 .wrolpi-message-content {
@@ -1044,7 +1083,7 @@ html .mantine-Notification-closeButton:hover {
     display: flex;
     /* Widen the tap target past the glyph without moving it. */
     margin: -6px -6px -6px 0;
-    padding: 6px;
+    padding: 0.375rem;
 }
 
 .wrolpi-message-dismiss:hover {
@@ -1058,7 +1097,7 @@ html .mantine-Notification-closeButton:hover {
 
 .wrolpi-message-title {
     font-weight: 600;
-    margin-bottom: 2px;
+    margin-bottom: 0.125rem;
 }
 
 .wrolpi-message-body {
@@ -1088,8 +1127,8 @@ html .mantine-Notification-closeButton:hover {
  */
 .wrolpi-progress {
     position: relative;
-    height: 22px;
-    min-width: 120px;
+    height: 1.375rem;
+    min-width: 7.5rem;
     overflow: hidden;
     background: var(--bg);
     border: 1px solid var(--border);
@@ -1105,7 +1144,7 @@ html .mantine-Notification-closeButton:hover {
  * something, so an only-child bar in a column is untouched.
  */
 * + .wrolpi-progress {
-    margin-top: 8px;
+    margin-top: 0.5rem;
 }
 
 .wrolpi-progress-fill {
@@ -1155,7 +1194,7 @@ html .mantine-Notification-closeButton:hover {
     align-items: center;
     justify-content: center;
     /* 12px rather than 11: these labels carry units and device names, not just a number. */
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 700;
     color: var(--text);
     font-variant-numeric: tabular-nums;
@@ -1166,7 +1205,7 @@ html .mantine-Notification-closeButton:hover {
      * it; with a hard clip and no ellipsis, `Complete: very-long-archive-name.tar.gz`
      * ends mid-glyph and reads as broken rather than truncated.
      */
-    padding: 0 6px;
+    padding: 0 0.375rem;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -1204,7 +1243,7 @@ html[data-theme="amber"] .wrolpi-progress-fill {
 .wrolpi-panel {
     background: var(--panel);
     border: 1px solid var(--border);
-    padding: 14px 16px;
+    padding: 0.875rem 1rem;
 }
 
 /* Danger zones are dashed in every theme; it doubles as a colorblind-safe cue. */
@@ -1231,7 +1270,7 @@ html[data-theme="amber"] .wrolpi-progress-fill {
  * whichever cap bites first, the other axis comes down with it and the ratio survives.
  */
 :root {
-    --card-poster-max-height: 200px;
+    --card-poster-max-height: 12.5rem;
     /* How far a disabled control fades.  Semantic used 0.45 and it reads correctly against
        every theme's panel; the tests read this rather than repeating the number. */
     --disabled-opacity: 0.45;
@@ -1254,6 +1293,48 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     justify-content: center;
 }
 
+/*
+ * The card's text block.
+ *
+ * These lived as inline px in Card's JSX, which put them outside the interface scale --
+ * `fontSize: 13` is 13px whatever the root font-size is, so a card's title would have
+ * stayed put while the prose around it grew.  Rules now, for the same reason every other
+ * size is one: a single place to retune, and ui-scale.test.js can see them.
+ */
+.wrolpi-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+    padding: 0.625rem 0.75rem 0.75rem;
+}
+
+.wrolpi-card-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.wrolpi-card-meta {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+/* The foot: `auto` pushes the actions down so a row of cards lines its buttons up
+   however tall the titles above them got.  ui-layout.cy.js measures that. */
+.wrolpi-card-actions {
+    margin-top: auto;
+    padding-top: 0.5rem;
+}
+
+/* A grid of cards.  The track width is the caller's `minWidth`, converted to rem in
+   CardGroup so a column scales with the type -- which is what returns a phone to one
+   card per row, as the pre-migration build had it. */
+.wrolpi-card-group {
+    display: grid;
+    gap: 0.875rem;
+}
+
 .wrolpi-card-poster-frame {
     position: relative;
     display: block;
@@ -1273,7 +1354,7 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 120px;
+    min-height: 7.5rem;
     background: var(--head);
 }
 
@@ -1282,7 +1363,7 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     top: 0;
     left: 0;
     display: flex;
-    padding: 3px 4px;
+    padding: 0.1875rem 0.25rem;
     background: var(--green);
     color: var(--btn-text);
 }
@@ -1308,7 +1389,7 @@ html[data-theme="amber"] .wrolpi-card-tag {
 .wrolpi-statistic {
     display: inline-block;
     vertical-align: top;
-    margin: 0 26px 10px 0;
+    margin: 0 1.625rem 0.625rem 0;
 }
 
 /*
@@ -1328,8 +1409,8 @@ html[data-theme="amber"] .wrolpi-card-tag {
  */
 .wrolpi-statistic-group {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 18px 30px;
+    grid-template-columns: repeat(auto-fit, minmax(9.375rem, 1fr));
+    gap: 1.125rem 1.875rem;
 }
 
 /*
@@ -1341,7 +1422,7 @@ html[data-theme="amber"] .wrolpi-card-tag {
  * while leaving the bottom where it was, so the whole panel read as lopsided.
  */
 * + .wrolpi-statistic-group {
-    margin-top: 18px;
+    margin-top: 1.125rem;
 }
 
 /*
@@ -1362,18 +1443,18 @@ html[data-theme="amber"] .wrolpi-card-tag {
 }
 
 .wrolpi-statistic-value {
-    font-size: 24px;
+    font-size: 1.5rem;
     font-weight: 600;
     font-variant-numeric: tabular-nums;
     line-height: 1.15;
 }
 
 .wrolpi-statistic-label {
-    font-size: 11px;
+    font-size: 0.6875rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--muted);
-    margin-top: 2px;
+    margin-top: 0.125rem;
 }
 
 /* ---------------------------------------------------------------- Status */
@@ -1383,11 +1464,11 @@ html[data-theme="amber"] .wrolpi-card-tag {
  * replaced the three `html[data-theme="night"]` overrides that used to live below.
  */
 .wrolpi-status {
-    font-size: 12.5px;
+    font-size: 0.78125rem;
     font-weight: 500;
     display: inline-flex;
     align-items: center;
-    gap: 5px;
+    gap: 0.3125rem;
     color: var(--status-color);
 }
 
@@ -1451,7 +1532,7 @@ html .mantine-Table-table[data-with-table-border] {
 .wrolpi-th-sort {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
+    gap: 0.3125rem;
     background: none;
     border: none;
     padding: 0;

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1291,6 +1291,12 @@ html[data-theme="amber"] .wrolpi-progress-fill {
 .wrolpi-card-poster {
     display: flex;
     justify-content: center;
+    /*
+     * The band is the query container for the cap below, so the cap can be a fraction of the
+     * card's own width.  Containment is safe here: the band's width comes from the card, never
+     * from the image inside it, and it has no fixed-position descendants.
+     */
+    container-type: inline-size;
 }
 
 /*
@@ -1346,7 +1352,24 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     width: auto;
     height: auto;
     max-width: 100%;
-    max-height: var(--card-poster-max-height);
+    /*
+     * The cap grows with the card, so a landscape poster can reach the card's edges.
+     *
+     * A fixed height stops scaling: held to 220px, a 16:9 thumbnail is 391px wide, so any card
+     * wider than that centred it with empty panel on both sides.  That is every video card at
+     * one column -- a phone, or any window under about 456px of content -- which is where the
+     * whole library is browsed on a phone.  The cases below all used a 233px card, so it went
+     * unseen for the entire migration.
+     *
+     * `56.25cqw` is nine sixteenths of the band: exactly the height of a 16:9 image that fills
+     * the width, and the same number states the rule for every other ratio -- a poster may be
+     * as tall as a 16:9 slice of this card and no taller.  So a book cover still reads as a
+     * band rather than a column, and now grows with the card instead of stopping at 220px.
+     *
+     * `max()`, not `min()`: on a narrow card the fraction is the smaller value and the floor
+     * has to win, or the cap would tighten as cards got smaller and crop a portrait cover.
+     */
+    max-height: max(var(--card-poster-max-height), 56.25cqw);
 }
 
 .wrolpi-card-icon {

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -401,8 +401,18 @@ html .wrolpi-searchbox-clear {
      * Tall enough for a full set of grouped suggestions -- directories, channels and
      * domains together run past 320px, and the last group was being clipped -- but
      * still capped so a long list cannot cover the page.
+     *
+     * 70vh, raised from 60.  The rem ceiling scales with the interface but a fraction of
+     * the VIEWPORT does not, so when the type grew 10% the rows grew with it and the cap
+     * did not: the full set now needs about 420px, and 60vh of a 660px-tall window is
+     * 396px, so the last group was clipped again -- the exact defect this comment already
+     * describes.  70vh is 462px there, and the 30rem ceiling still bounds it on a tall
+     * window, so it cannot cover the page either way.
+     *
+     * `directory-search.cy.js` is the regression test: it fails at 660px of viewport
+     * height and passes from 700px up, which is how the shortfall was measured.
      */
-    max-height: min(60vh, 30rem);
+    max-height: min(70vh, 30rem);
     overflow-y: auto;
     background: var(--panel);
     border: 1px solid var(--border);

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -43,8 +43,9 @@
  */
 .wrolpi-icon-stack-corner {
     position: absolute;
-    right: -3px;
-    bottom: -3px;
+    /* rem, so the badge keeps its corner as the glyph it sits on grows. */
+    right: -0.1875rem;
+    bottom: -0.1875rem;
     display: flex;
     background: var(--icon-stack-bg, var(--bg));
     border-radius: 50%;
@@ -836,10 +837,15 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     content: '';
     position: absolute;
     top: 50%;
-    left: -7px;
+    left: -0.4375rem;
     width: 0.3125rem;
     height: 0.3125rem;
-    margin-top: -2.5px;
+    /*
+     * Centred by translation rather than by a negative margin of half its own height.
+     * The margin was -2.5px against a 0.3125rem dot: once the dot scaled and the margin
+     * did not, the hole drifted off the point's centre.  A percentage cannot drift.
+     */
+    transform: translateY(-50%);
     border-radius: 50%;
     background: currentColor;
     /* A hole, not a dot: it should read as absence rather than as a bullet. */
@@ -1092,7 +1098,7 @@ html .mantine-Notification-closeButton:hover {
     cursor: pointer;
     display: flex;
     /* Widen the tap target past the glyph without moving it. */
-    margin: -6px -6px -6px 0;
+    margin: -0.375rem -0.375rem -0.375rem 0;
     padding: 0.375rem;
 }
 
@@ -1378,7 +1384,14 @@ html[data-theme="amber"] .wrolpi-progress-fill {
      *
      * `max()`, not `min()`: on a narrow card the fraction is the smaller value and the floor
      * has to win, or the cap would tighten as cards got smaller and crop a portrait cover.
+     *
+     * Declared twice on purpose.  `cqw` needs container queries (Chrome 105, Safari 16), and an
+     * engine that does not know the unit throws out the WHOLE declaration -- which would leave
+     * the poster with no height cap at all, so a portrait cover would stand as tall as the card
+     * is wide.  The plain cap first means such an engine still clamps, just without the
+     * card-relative growth; anything newer takes the second and ignores the first.
      */
+    max-height: var(--card-poster-max-height);
     max-height: max(var(--card-poster-max-height), 56.25cqw);
 }
 

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -903,6 +903,12 @@ describe('Card', () => {
          * card read buttons-then-domain.  Which slot lands where is what this asserts; that
          * the foot anchoring actually resolves is in ui-layout.cy.js, since `margin-top:
          * auto` needs a layout engine.
+         *
+         * That division is why there is no `margin-top: auto` assertion here any more.  There
+         * was one, reading the inline style, and it broke when the card's sizes moved into
+         * ui.css so the interface scale could reach them -- jsdom applies no stylesheet.  It
+         * was asserting where the declaration was written rather than what it did, and the
+         * cypress test above measures the actual foot alignment either way.
          */
         renderUI(<Card title='Rainwater Harvesting'
                        meta='engineering775.com'
@@ -914,8 +920,8 @@ describe('Card', () => {
         expect([...body.children].map(child => child.textContent)).toEqual([
             'Rainwater Harvesting', 'engineering775.com', 'body', 'Details',
         ]);
-        expect(body.querySelector('.wrolpi-card-actions')).toHaveStyle({marginTop: 'auto'});
-        expect(body.querySelector('.wrolpi-card-meta').style.marginTop).toBe('');
+        expect(body.querySelector('.wrolpi-card-actions')).not.toBeNull();
+        expect(body.querySelector('.wrolpi-card-meta')).not.toBeNull();
     });
 
     it('renders no actions row when a card has no actions', () => {
@@ -940,14 +946,20 @@ describe('CardGroup', () => {
         expect(screen.getByText('Three')).toBeInTheDocument();
     });
 
-    it('lays cards out on a track no narrower than minWidth', () => {
-        // The default suits file results; a group of wide cards raises it.  If the value were
-        // dropped the grid would fall back to one column, which is how a card wall becomes a
-        // list on a desktop.
+    it('lays cards out on a track no narrower than minWidth, in rem so it scales', () => {
+        /*
+         * The default suits file results; a group of wide cards raises it.  If the value were
+         * dropped the grid would fall back to one column, which is how a card wall becomes a
+         * list on a desktop.
+         *
+         * The px the caller names is converted to rem, which is the whole reason a phone shows
+         * one card per row again: as px, the track ignored the interface scale, and a 430px
+         * screen fitted two 200px cards where the pre-migration build fitted one 290px card.
+         */
         const {container} = renderUI(<CardGroup minWidth={320}><Card title='One'/></CardGroup>);
 
         expect(container.querySelector('.wrolpi-card-group'))
-            .toHaveStyle({gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))'});
+            .toHaveStyle({gridTemplateColumns: 'repeat(auto-fill, minmax(20rem, 1fr))'});
     });
 });
 

--- a/app/src/themes/tokens.css
+++ b/app/src/themes/tokens.css
@@ -242,8 +242,48 @@ html[data-theme="amber"] {
  * None of it belonged to Semantic; it belongs here, expressed in tokens.
  */
 
+/* ------------------------------------------------------------------------- */
+/* Interface scale                                                            */
+/* ------------------------------------------------------------------------- */
+/*
+ * How large the interface is, overall.
+ *
+ * Measured against the pre-migration Semantic build at 1280px, the drift was not one
+ * number: its headings were h1 28 / h2 24 / h3 18 / h4 15 / h5 14 against our
+ * 26 / 21 / 17 / 14 / 13, and its video card a fixed 290px with an 18px title against
+ * our 238px with a 13px one -- while our BODY text and chrome went the other way,
+ * a 16px base against Semantic's 14 and 42px buttons against 36.  No per-component
+ * nudge reproduces what a user comparing the two sees, which is the whole page.
+ *
+ * Ten percent is not a fudge factor: our heading scale times 1.1 is
+ * 28.6 / 23.1 / 18.7 / 15.4 / 14.3, which is Semantic's scale to within a pixel at
+ * every step.
+ *
+ * The lever is the root font-size, and everything that should grow with it is written
+ * in `rem`.  That is Mantine's own mechanism -- its size declarations are
+ * `calc(Xrem * var(--mantine-scale))`, and `theme.scale` exists to CANCEL a customised
+ * root font-size, so it must stay at 1 here.
+ *
+ * A percentage rather than a px value, so a user who has set a larger default font in
+ * their browser keeps it, scaled, instead of having it silently overridden.
+ *
+ * `zoom: 1.1` on the root was tried first and rejected.  It is one line and it works,
+ * but it scales at paint time: every 1px hairline becomes 1.1px and softens on a 1x
+ * display, and viewport units do not shrink to compensate, so `100vh` paints 110% of
+ * the screen -- a 95vw modal overflowed sideways and the CBZ viewer's fullscreen
+ * overflowed downwards.  Rem scales real lengths, leaves borders crisp and leaves
+ * viewport units alone.
+ *
+ * Borders, outlines and shadows are deliberately NOT in rem.  A hairline is a hairline
+ * at any text size; ui-scale.test.js enforces both halves of that.
+ */
+:root {
+    --ui-scale: 1.1;
+}
+
 html {
     box-sizing: border-box;
+    font-size: calc(100% * var(--ui-scale));
 }
 
 *,

--- a/app/src/themes/ui-scale.test.js
+++ b/app/src/themes/ui-scale.test.js
@@ -1,0 +1,169 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * The size of the interface.
+ *
+ * Measured against the pre-migration Semantic build on the QA Pi at 1280px, the drift was not
+ * one number: its headings were h1 28 / h2 24 / h3 18 / h4 15 / h5 14 against our 26 / 21 / 17
+ * / 14 / 13, and its video card a fixed 290px with an 18px title against our 238px with a 13px
+ * one -- while our BODY text and chrome went the other way, 16px base against Semantic's 14 and
+ * 42px buttons against 36.  So no per-component nudge reproduces what a user comparing the two
+ * actually sees, which is the whole page at once.
+ *
+ * Ten percent is not a fudge factor.  Our heading scale multiplied by 1.1 is 28.6 / 23.1 / 18.7
+ * / 15.4 / 14.3 -- Semantic's numbers, to within a pixel at every step.
+ *
+ * The lever is the root font-size, and everything that should grow with it is written in `rem`.
+ * That is Mantine's own mechanism: its 644 size declarations are `calc(Xrem * var(--mantine-
+ * scale))`, and `theme.scale` exists specifically to CANCEL a customised root font-size, which
+ * is why it must stay at 1 here -- we want those sizes to grow.
+ *
+ * `zoom: 1.1` on the root was tried first and rejected.  It works, and it is one line, but it
+ * scales at paint time: every 1px hairline becomes 1.1px and softens on a 1x display, and
+ * viewport units do not shrink to compensate, so `100vh` paints 110% of the screen -- a 95vw
+ * modal overflowed sideways and the CBZ viewer's fullscreen overflowed down.  Rem scales real
+ * lengths instead, leaves borders crisp, leaves viewport units alone, and respects a user's own
+ * browser font-size setting rather than overriding it.
+ */
+
+const SRC = path.join(__dirname, '..');
+const tokens = fs.readFileSync(path.join(__dirname, 'tokens.css'), 'utf8');
+
+/** Our own stylesheets -- the ones the scale has to reach. */
+const STYLESHEETS = ['themes/tokens.css', 'App.css', 'index.css', 'components/ui/ui.css']
+    .map(file => [file, path.join(SRC, file)])
+    .filter(([, full]) => fs.existsSync(full));
+
+/** `source` with every comment blanked, keeping line numbers intact. */
+const stripComments = (source) => source
+    .replace(/\/\*[\s\S]*?\*\//g, block => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (all, before) => before + ' '.repeat(all.length - before.length));
+
+/** Every source file under src/, excluding tests. */
+const sourceFiles = (dir = SRC) => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : sourceFiles(full);
+    if (!/\.(js|jsx|ts|tsx|css)$/.test(entry.name)) return [];
+    if (/\.(test|cy)\.(js|jsx|ts|tsx)$/.test(entry.name)) return [];
+    return [full];
+});
+
+describe('--ui-scale', () => {
+    it('scales the interface from the root font-size', () => {
+        // A percentage of the browser's own default, not a px value: a user who has set a
+        // larger default font keeps it, scaled, instead of having it overridden.
+        expect(tokens).toMatch(/--ui-scale:\s*1\.1;/);
+        expect(tokens).toMatch(/\n\s*font-size:\s*calc\(100%\s*\*\s*var\(--ui-scale\)\)/);
+    });
+
+    it('leaves Mantine free to grow with it', () => {
+        /*
+         * `theme.scale` divides Mantine's rem lengths by itself, to undo a customised root
+         * font-size.  Setting it to 1.1 alongside a 110% root would therefore cancel out
+         * exactly, leaving Mantine's half of the interface at its original size while ours
+         * grew -- buttons the old size beside 10% larger text.
+         */
+        const mantine = fs.readFileSync(path.join(__dirname, 'mantine.ts'), 'utf8');
+        expect(stripComments(mantine)).not.toMatch(/\bscale:\s*[\d.]/);
+    });
+
+    it('writes every scalable length in rem, so the scale reaches it', () => {
+        /*
+         * A px font-size does not grow with the root, so it would shrink RELATIVE to
+         * everything around it -- the failure is a 13px caption beside 14.3px prose, which
+         * reads as sloppy rather than broken and so never gets reported.
+         *
+         * Borders are exempt and must stay px: a hairline is a hairline at any text size, and
+         * scaling it is exactly what made `zoom` the wrong tool.  Same for outlines, which are
+         * hairlines wearing a different name.
+         */
+        const SCALABLE = /^\s*(font-size|padding|padding-\w+|margin|margin-\w+|gap|row-gap|column-gap|width|min-width|max-width|height|min-height|max-height|border-radius|top|right|bottom|left)\s*:/;
+
+        const offenders = [];
+        let scanned = 0;
+        for (const [name, full] of STYLESHEETS) {
+            stripComments(fs.readFileSync(full, 'utf8')).split('\n').forEach((line, index) => {
+                if (!SCALABLE.test(line)) return;
+                scanned += 1;
+                // 0 has no unit to scale, and 1px in a scalable property is a hairline too.
+                const px = [...line.matchAll(/(?<![\w.-])(\d+(?:\.\d+)?)px/g)]
+                    .filter(match => parseFloat(match[1]) > 1);
+                if (px.length) offenders.push(`${name}:${index + 1}: ${line.trim().slice(0, 64)}`);
+            });
+        }
+
+        // The premise: a regex that matched no declarations would report no offenders.
+        expect(scanned).toBeGreaterThan(100);
+        expect(offenders).toEqual([]);
+    });
+
+    it('keeps hairlines out of the scale', () => {
+        /*
+         * The inverse of the rule above, and the reason it is worth a test of its own: a bulk
+         * px-to-rem pass that also converted the borders would leave every rule in the app
+         * growing with the type, which is the defect `zoom` had.  At least most borders must
+         * still be px.
+         */
+        /*
+         * Only the properties that carry a border's THICKNESS.  `border-radius` is a
+         * scalable length -- a 10% larger control wants a proportionally larger corner --
+         * and an earlier version of this matched it, so it failed on the correct answer.
+         */
+        const THICKNESS = /^\s*(border|border-(top|right|bottom|left|inline|block)(-\w+)?|border-width|outline|outline-offset)\s*:/;
+
+        const borders = [];
+        for (const [, full] of STYLESHEETS) {
+            stripComments(fs.readFileSync(full, 'utf8')).split('\n').forEach(line => {
+                if (THICKNESS.test(line) && !/radius/.test(line)) borders.push(line);
+            });
+        }
+        const pxBorders = borders.filter(line => /\dpx/.test(line));
+        const remBorders = borders.filter(line => /\drem/.test(line));
+
+        expect(borders.length).toBeGreaterThan(30);
+        expect({rem: remBorders, someArePx: pxBorders.length > 20})
+            .toEqual({rem: [], someArePx: true});
+    });
+
+    it('writes no px font-size inline, anywhere', () => {
+        /*
+         * An inline size is part of the scale whether or not it looks like one: a bare number
+         * in `fontSize` is px by React's own rule, so `fontSize: 12` is a 12px caption that
+         * stays 12px while the prose beside it grows to 13.2.  Nothing breaks -- it just reads
+         * as slightly sloppy, in 46 places, which is not a bug anyone reports.
+         *
+         * The whole of src is scanned, the gallery included.  /theme-sample is linked from
+         * Settings and ships to users, so its annotations are interface text too.
+         */
+        const offenders = [];
+        for (const file of sourceFiles()) {
+            if (file.endsWith('.css')) continue;
+            stripComments(fs.readFileSync(file, 'utf8')).split('\n').forEach((line, index) => {
+                /*
+                 * A bare number (px by React's rule) or an explicit px.  Relative units are
+                 * fine and are not offences: `em` resolves against the parent's font-size and
+                 * `%` likewise, so both already grow with the scale.  An earlier version
+                 * allowed only `rem` and reported 21 perfectly good `0.85em` captions.
+                 */
+                if (/fontSize:\s*(\d|['"][\d.]+px)/.test(line)) {
+                    offenders.push(`${path.relative(SRC, file)}:${index + 1}: ${line.trim().slice(0, 60)}`);
+                }
+            });
+        }
+
+        /*
+         * The premise: `fontSize` in rem has to be found, or a codebase with no inline sizes
+         * at all would read identically to one that had converted them.
+         *
+         * Occurrences rather than files.  Counting files gave 8 for the 46 conversions -- 32
+         * of them are in the gallery -- so a threshold set from the conversion count failed
+         * against the correct answer.
+         */
+        const remSizes = sourceFiles().flatMap(file =>
+            [...fs.readFileSync(file, 'utf8').matchAll(/fontSize:\s*['"][\d.]+rem/g)]);
+        expect(remSizes.length).toBeGreaterThan(40);
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/app/src/themes/ui-scale.test.js
+++ b/app/src/themes/ui-scale.test.js
@@ -68,7 +68,7 @@ describe('--ui-scale', () => {
         expect(stripComments(mantine)).not.toMatch(/\bscale:\s*[\d.]/);
     });
 
-    it('writes every scalable length in rem, so the scale reaches it', () => {
+    it('writes every scalable length in our stylesheets in rem, so the scale reaches it', () => {
         /*
          * A px font-size does not grow with the root, so it would shrink RELATIVE to
          * everything around it -- the failure is a 13px caption beside 14.3px prose, which
@@ -78,17 +78,41 @@ describe('--ui-scale', () => {
          * scaling it is exactly what made `zoom` the wrong tool.  Same for outlines, which are
          * hairlines wearing a different name.
          */
-        const SCALABLE = /^\s*(font-size|padding|padding-\w+|margin|margin-\w+|gap|row-gap|column-gap|width|min-width|max-width|height|min-height|max-height|border-radius|top|right|bottom|left)\s*:/;
+        /*
+         * `transform` and `flex-basis` are on the list because a length there is as much part
+         * of the layout as a padding.  The first version left them off and the name of this
+         * test still said "every scalable length": `transform: translateX(26px)` sat in App.css
+         * untouched while the track and knob either side of it were converted to rem, so a
+         * switch's thumb travelled 26px across a track that had grown to 54px.
+         */
+        const SCALABLE = new RegExp('^\\s*(' + [
+            'font-size', 'padding', 'padding-\\w+', 'margin', 'margin-\\w+',
+            'gap', 'row-gap', 'column-gap', 'width', 'min-width', 'max-width',
+            'height', 'min-height', 'max-height', 'border-radius',
+            'top', 'right', 'bottom', 'left',
+            'transform', '-webkit-transform', '-ms-transform', 'translate',
+            'flex', 'flex-basis',
+        ].join('|') + ')\\s*:');
 
         const offenders = [];
         let scanned = 0;
+        let negatives = 0;
         for (const [name, full] of STYLESHEETS) {
             stripComments(fs.readFileSync(full, 'utf8')).split('\n').forEach((line, index) => {
                 if (!SCALABLE.test(line)) return;
                 scanned += 1;
-                // 0 has no unit to scale, and 1px in a scalable property is a hairline too.
-                const px = [...line.matchAll(/(?<![\w.-])(\d+(?:\.\d+)?)px/g)]
-                    .filter(match => parseFloat(match[1]) > 1);
+                /*
+                 * The optional leading `-` is load-bearing.  Without it the lookbehind treated
+                 * a minus sign as part of the preceding token, so every NEGATIVE length was
+                 * invisible: `left: -7px` and `margin-top: -2.5px` position the eyelet on a
+                 * tag whose diamond had been converted to rem, and `right: -3px` / `bottom:
+                 * -3px` place the corner badge on an icon that had also been converted.  Each
+                 * one is a piece of geometry that stopped tracking the piece it belongs to.
+                 */
+                const px = [...line.matchAll(/(?<![\w.])(-?\d+(?:\.\d+)?)px/g)]
+                    // 0 has no unit to scale, and 1px either way is a hairline.
+                    .filter(match => Math.abs(parseFloat(match[1])) > 1);
+                if (px.some(match => match[1].startsWith('-'))) negatives += 1;
                 if (px.length) offenders.push(`${name}:${index + 1}: ${line.trim().slice(0, 64)}`);
             });
         }
@@ -163,6 +187,39 @@ describe('--ui-scale', () => {
         const remSizes = sourceFiles().flatMap(file =>
             [...fs.readFileSync(file, 'utf8').matchAll(/fontSize:\s*['"][\d.]+rem/g)]);
         expect(remSizes.length).toBeGreaterThan(40);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('keeps numeric geometry out of the component library, where a scale cannot reach it', () => {
+        /*
+         * The library's own inline styles, held to the same rule as its font sizes.  `gap: 10`
+         * in Confirm and `padding: '10px 12px 12px'` in Card were px forever, so the ten such
+         * blocks moved into ui.css; this is what stops the eleventh being written.
+         *
+         * Deliberately the LIBRARY only.  There are about 176 numeric geometry values left in
+         * 23 feature files -- the map overlays were the visible ones and are converted, but
+         * sweeping the rest is a change to 23 files that nobody has looked at, and it is not
+         * this test's job to pretend otherwise.  That gap is the reason the sibling test above
+         * says "in our stylesheets" rather than "everywhere": an earlier name claimed the
+         * whole app while scanning four files.
+         */
+        const GEOMETRY = new RegExp('\\b(' + [
+            'padding', 'paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight',
+            'margin', 'marginTop', 'marginBottom', 'marginLeft', 'marginRight',
+            'gap', 'rowGap', 'columnGap', 'width', 'height', 'minWidth', 'minHeight',
+            'maxWidth', 'maxHeight', 'borderRadius', 'flexBasis',
+        ].join('|') + "):\\s*(-?[1-9][0-9]*\\b|['\"]-?[\\d.]+px)");
+
+        const offenders = [];
+        for (const file of sourceFiles(path.join(SRC, 'components', 'ui'))) {
+            if (file.endsWith('.css')) continue;
+            stripComments(fs.readFileSync(file, 'utf8')).split('\n').forEach((line, index) => {
+                if (GEOMETRY.test(line)) {
+                    offenders.push(`${path.relative(SRC, file)}:${index + 1}: ${line.trim().slice(0, 60)}`);
+                }
+            });
+        }
 
         expect(offenders).toEqual([]);
     });


### PR DESCRIPTION
The interface reads about 10% smaller than the pre-migration Semantic build. I measured both at 1280px rather than guessing, and the drift is **not one number**:

| | ours | Semantic |
|---|---|---|
| h1 / h2 / h3 / h4 / h5 | 26 / 21 / 17 / 14 / 13 | **28 / 24 / 18 / 15 / 14** |
| video card | 238px wide, 13px title | **290px wide, 18px title** |
| body text | **16px** | 14px |
| button height | **42px** | 36px |

So the headings and card text are smaller while the body text and chrome are *larger* — which is why no per-component nudge would have worked. What a user compares is the whole page at once.

**Ten percent is not a fudge factor.** Our heading scale × 1.1 is 28.6 / 23.1 / 18.7 / 15.4 / 14.3 — Semantic's scale to within a pixel at every step. The browser now renders exactly those numbers.

### The mechanism

`--ui-scale: 1.1` with `html { font-size: calc(100% * var(--ui-scale)) }`, and everything that should grow written in `rem`:

- **102 lengths** converted in `ui.css` / `App.css` / `tokens.css`, restricted by property: font-size, padding, margin, gap, width/height, border-radius, offsets.
- **Borders, outlines and shadows deliberately not converted.** A hairline is a hairline at any text size.
- **46 inline `fontSize`** px values across 8 files. `em` values left alone — they already resolve against the parent.
- **Ten inline-styled blocks in the library** (Card's text block, Loading, Placeholder, ColoredInput, Confirm's action row, CardGroup's gap) moved into `ui.css`: an inline px size can be reached by neither a scale nor a test.
- **`CardGroup` converts its `minWidth` prop to rem**, which is what returns a phone to one card per row — as px the track ignored the scale, so a 430px screen fitted two 200px cards where the old build fitted one 290px card.

Mantine needs nothing: its 644 size declarations are `calc(Xrem * var(--mantine-scale))` and scale with the root. `theme.scale` must stay at **1** — it exists to *cancel* a customised root font-size, so setting it to 1.1 as well would leave Mantine's half of the interface at the old size beside our larger text. A test pins that.

### Why not `zoom`

I built `zoom: 1.1` on the root first, and it does work in one line — but you were right to push back, and measuring found two concrete reasons beyond taste:

1. It scales at **paint**, so every 1px hairline becomes 1.1px and softens on a 1× display.
2. Viewport units don't shrink to compensate, so `100vh` paints **110% of the screen**. A `95vw` modal overflowed sideways and the CBZ viewer's fullscreen overflowed down; the map rendered at 93.5% of the screen where it asked for 85%.

Rem scales real lengths, keeps borders crisp, leaves viewport units alone, and preserves a user's own browser font-size preference instead of overriding it — hence a percentage rather than a px root size.

### Tests

Five guards in `themes/ui-scale.test.js`, each planted against: the scale itself; every scalable declaration is rem; borders are **not**; no inline px `fontSize` survives anywhere including the gallery; Mantine's scale stays 1.

Two existing `ui.test.js` assertions read the inline styles I moved into CSS. One (`margin-top: auto` on the card foot) was asserting *where the declaration was written* rather than what it did, and `ui-layout.cy.js:1820` already measures the real foot alignment — so it's gone, with a note. The other now asserts the rem track width, which is the meaningful claim.

**A mistake worth recording:** a malformed plant command of mine (`s/font-size: 0.8125rem;\n//` in perl line mode) silently deleted **nine** `font-size` declarations from `ui.css` rather than one. I caught it by counting declarations before and after, then reverted and re-ran the scripted conversion clean. Every remaining difference is accounted for: +30 in `ui.css` are the ten new rules, −1 in `App.css` is a dead Semantic rule, +2 in `tokens.css` are the scale and root size.

Also removes `.ui.modal.themed-confirm` — dead Semantic-era rule (`.ui.modal` no longer exists, nothing sets the class) and the source of the one `95vw`.

### Verification

- 1141 tests / 65 suites pass; clean `npm run build`
- Browser-checked at 1280px and at a 430px phone (one card per row, as the old build had)
- Navbar stays a single row from 780px to 1800px, overflow nav collapsing links progressively
- All four themes: root 17.6px, hairlines still 1px, no horizontal overflow, every new class resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)