### PR TITLE
ui: widen a card's track by 25%

### DIFF
--- a/app/src/components/MapSearchView.js
+++ b/app/src/components/MapSearchView.js
@@ -119,7 +119,7 @@ export function MapSearchView() {
     }
 
     return <React.Fragment>
-        <CardGroup minWidth={220}>
+        <CardGroup minWidth={275}>
             {results.map((place, i) =>
                 <MapPlaceCard key={`${place.name}-${place.lat}-${place.lon}-${i}`} place={place} index={i}/>
             )}

--- a/app/src/components/ui/Surfaces.tsx
+++ b/app/src/components/ui/Surfaces.tsx
@@ -207,14 +207,19 @@ export function Card({media, title, meta, children, actions, onClick, color, cla
 
 export interface CardGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     /**
-     * The narrowest a card may be laid out.  `auto-fill` rather than `auto-fit`, so a group
-     * of two cards in a wide column keeps them card-sized instead of stretching each to half
-     * the page.
+     * The narrowest a card may be laid out, in px at the unscaled design size.  `auto-fill`
+     * rather than `auto-fit`, so a group of two cards in a wide column keeps them card-sized
+     * instead of stretching each to half the page.
+     *
+     * The default was 200 and is 250: a card wall read too dense, running five to a row at
+     * 1280px where the pre-migration build ran four, which left a video title about two words
+     * wide.  Raising the default rather than each page is the point of it being a default --
+     * videos, archives, docs, files and the gallery all take it.
      */
     minWidth?: number;
 }
 
-export function CardGroup({children, minWidth = 200, className, style, ...props}: CardGroupProps) {
+export function CardGroup({children, minWidth = 250, className, style, ...props}: CardGroupProps) {
     return <div
         className={['wrolpi-card-group', className].filter(Boolean).join(' ')}
         style={{

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -946,6 +946,22 @@ describe('CardGroup', () => {
         expect(screen.getByText('Three')).toBeInTheDocument();
     });
 
+    it('gives a card 250px of track by default', () => {
+        /*
+         * Was 200.  Raised 25% because a card wall was reading too dense: at 1280px the grid
+         * ran five cards to a row where the pre-migration build ran four, and a video title
+         * had about two words per line.  It is the default rather than a per-page choice
+         * because every card wall in the app -- videos, archives, docs, files, the gallery --
+         * takes it, which is the point of it being a default.
+         *
+         * A phone is unaffected: one column below about 570px of content width either way.
+         */
+        const {container} = renderUI(<CardGroup><Card title='One'/></CardGroup>);
+
+        expect(container.querySelector('.wrolpi-card-group'))
+            .toHaveStyle({gridTemplateColumns: 'repeat(auto-fill, minmax(15.625rem, 1fr))'});
+    });
+
     it('lays cards out on a track no narrower than minWidth, in rem so it scales', () => {
         /*
          * The default suits file results; a group of wide cards raises it.  If the value were


### PR DESCRIPTION
`CardGroup`'s default `minWidth` goes from **200 to 250**, and the one call site that names its own — the map's search results — from 220 to 275, keeping the 10% it sits above the default.

A card wall read too dense: at a 1280px window the grid ran **five** cards to a row where the pre-migration Semantic build ran **four**, which left a video title about two words per line. At 250 it runs four cards of 300px — and Semantic measured four cards of 290px at that width, so this lands on the old layout rather than near it.

Raising the default rather than each page is the point of it being a default: videos, archives, docs, files and the gallery all take it.

### Measured across the range

| grid width | cards/row | card width | poster side gap |
|---|---|---|---|
| 430 | 1 | 430 | 0 |
| 570 | 2 | 277 | 0 |
| 600 | 2 | 292 | 0 |
| 900 | 3 | 290 | 0 |
| 1245 | 4 | 300 | 0 |
| 1600 | 5 | 308 | 0 |

Nothing regresses. A phone is unaffected — one column below about 570px of content width either way — and the poster still fills the card at every width, since its cap is now a fraction of the card rather than a fixed height.

### Verification

- 1143 jest tests / 65 suites; clean `npm run build`
- Screenshotted at 1280px: four per row, titles on two lines instead of three
- Test written first, asserting the default track resolves to `15.625rem` (250px) so the value cannot drift silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)