### PR TITLE
ui: larger tags, tighter rows

### DIFF
--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -142,29 +142,41 @@ export function useTags() {
         </Group>
     }
 
+    /*
+     * The link carries no margin of its own.  It had `0.3em` either side, from when these were
+     * Semantic labels that had none -- but a tag already reserves a `margin-left` in ui.css for
+     * the point drawn outside its body, so that was 0.3em twice on top of the group's gap and
+     * the point's own room.  Two tags sat 34.7px apart where the point needs 18.4px.
+     */
     const TagLabelLink = ({name, props}) => {
         const to = getLocationStr({tag: name}, '/search');
-        const style = {marginLeft: '0.3em', marginRight: '0.3em'};
         try {
             // We prefer to use Link to avoid reloading the page, check if React Router is available, so we can use it.
             useNavigate();
-            return <Link to={to} style={style}>
+            return <Link to={to}>
                 <NameToTagLabel name={name} {...props}/>
             </Link>
         } catch {
             // React Router is not available, use anchor.
-            return <a href={to} style={style}>
+            return <a href={to}>
                 <NameToTagLabel name={name} {...props}/>
             </a>
         }
     }
 
-    const TagsLinkGroup = ({tagNames, ...props}) => {
+    const TagsLinkGroup = ({tagNames, style, ...props}) => {
         if (!tagNames || tagNames.length === 0) {
             return <React.Fragment/>;
         }
 
-        return <Group gap={6}>
+        /*
+         * `style` belongs to the group, not to each tag in it.  It used to go down with the rest
+         * of the props to every chip, so the dashboard's `marginTop` -- meant to space the row
+         * below its heading -- landed on all 34 tags and became 7.7px of extra space between
+         * every wrapped row.  The remaining props still reach the chips, which is how `onClick`
+         * gets there.
+         */
+        return <Group gap={6} style={style}>
             {tagNames.map(i => <TagLabelLink key={i} name={i} props={props}/>)}
         </Group>
     }

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -146,7 +146,11 @@ export function useTags() {
      * The link carries no margin of its own.  It had `0.3em` either side, from when these were
      * Semantic labels that had none -- but a tag already reserves a `margin-left` in ui.css for
      * the point drawn outside its body, so that was 0.3em twice on top of the group's gap and
-     * the point's own room.  Two tags sat 34.7px apart where the point needs 18.4px.
+     * the point's own room.  Two tags sat 34.7px apart, of which the point needs 18.7px.
+     *
+     * Those are rendered px, measured in the browser at the default interface scale -- which is
+     * what a user sees, and why they are the numbers worth recording.  The stylesheet states the
+     * same margin in design px, as `1.0625rem`; 17 x 1.1 is the 18.7 above.
      */
     const TagLabelLink = ({name, props}) => {
         const to = getLocationStr({tag: name}, '/search');
@@ -164,19 +168,24 @@ export function useTags() {
         }
     }
 
-    const TagsLinkGroup = ({tagNames, style, ...props}) => {
+    /*
+     * Props here have two possible targets, and which one they take is part of the contract:
+     *
+     *   `style` and `className` dress the ROW.  Everything else reaches each CHIP, which is how
+     *   `onClick` gets to a tag.
+     *
+     * `style` used to go down with the rest, so the dashboard's `marginTop` -- meant to space the
+     * row below its heading -- landed on all 34 tags and became 7.7px of extra space between
+     * every wrapped row of them.  `className` is named alongside it because it is the same kind
+     * of thing and would fail the same way; a Mantine `Group` prop (`gap`, `wrap`, `justify`) or
+     * a `data-*` meant for the row still would, so add it here rather than at a call site.
+     */
+    const TagsLinkGroup = ({tagNames, style, className, ...props}) => {
         if (!tagNames || tagNames.length === 0) {
             return <React.Fragment/>;
         }
 
-        /*
-         * `style` belongs to the group, not to each tag in it.  It used to go down with the rest
-         * of the props to every chip, so the dashboard's `marginTop` -- meant to space the row
-         * below its heading -- landed on all 34 tags and became 7.7px of extra space between
-         * every wrapped row.  The remaining props still reach the chips, which is how `onClick`
-         * gets there.
-         */
-        return <Group gap={6} style={style}>
+        return <Group gap={6} style={style} className={className}>
             {tagNames.map(i => <TagLabelLink key={i} name={i} props={props}/>)}
         </Group>
     }

--- a/app/src/Tags.test.js
+++ b/app/src/Tags.test.js
@@ -132,7 +132,10 @@ describe('a tag chip', () => {
  * A tag already carries a `margin-left` in ui.css, and that one is structural: the point is
  * drawn outside the body, so the margin is the room it needs and cannot be reclaimed.  Every
  * other gap in a row was decoration on top of it, and measured on the dashboard the tags were
- * 34.7px apart horizontally and 18.5px apart vertically -- of which only 18.4px was the point.
+ * 34.7px apart horizontally and 18.5px apart vertically -- of which only 18.7px was the point.
+ *
+ * Rendered px throughout, measured in the browser at the default interface scale.  ui.css states
+ * the same margin in design px, as `1.0625rem`.
  */
 describe('a row of tags', () => {
     beforeEach(() => {
@@ -149,7 +152,7 @@ describe('a row of tags', () => {
         /*
          * The link wrapper carried `0.3em` either side, from when these were Semantic labels
          * that had no margin of their own.  It is 0.3em twice, plus the group's gap, plus the
-         * structural margin -- so two tags sat 34.7px apart where the point needs 17.3px, and
+         * structural margin -- so two tags sat 34.7px apart where the point needs 18.7px, and
          * a wall of tags on the dashboard read as loose.
          */
         renderGroup(['Water', 'Archived']);
@@ -180,5 +183,25 @@ describe('a row of tags', () => {
         const group = tag.closest('.mantine-Group-root');
         expect(group).toBeTruthy();
         expect(group.style.marginTop).toBe('0.5em');
+    });
+
+    it('dresses the row with a className, and still hands the rest to each tag', async () => {
+        /*
+         * `className` goes the same way as `style`, and for the same reason: it describes the row.
+         * It is tested rather than only documented because the two halves of this contract are
+         * one destructure apart, and the `style` half was wrong for as long as it existed.
+         *
+         * `onClick` is the other half, asserted here so a later tidy-up cannot route everything
+         * to the group and leave a wall of tags that no longer responds to a click.
+         */
+        const onClick = jest.fn();
+        renderGroup(['Water', 'Archived'], {className: 'tag-row', onClick});
+
+        const tag = await awaitColored('Water', BRIGHT);
+        expect(tag.className).not.toContain('tag-row');
+        expect(tag.closest('.mantine-Group-root').className).toContain('tag-row');
+
+        tag.click();
+        expect(onClick).toHaveBeenCalled();
     });
 });

--- a/app/src/Tags.test.js
+++ b/app/src/Tags.test.js
@@ -39,6 +39,18 @@ const renderTag = (name, tags) => render(
     </QueryContext.Provider>
 );
 
+// The same, for the group -- which is where a row's spacing is decided.
+const GroupProbe = ({tagNames, ...props}) => {
+    const {TagsLinkGroup} = useTags();
+    return <TagsLinkGroup tagNames={tagNames} {...props}/>;
+};
+
+const renderGroup = (tagNames, props = {}) => render(
+    <QueryContext.Provider value={queryContextFixture()}>
+        <GroupProbe tagNames={tagNames} {...props}/>
+    </QueryContext.Provider>
+);
+
 const tagOf = (name) => screen.getByText(name);
 
 /*
@@ -111,5 +123,62 @@ describe('a tag chip', () => {
         renderTag('Water');
 
         expect(await screen.findByText('Water')).toBeInTheDocument();
+    });
+});
+
+/*
+ * How far apart a row of tags sits.
+ *
+ * A tag already carries a `margin-left` in ui.css, and that one is structural: the point is
+ * drawn outside the body, so the margin is the room it needs and cannot be reclaimed.  Every
+ * other gap in a row was decoration on top of it, and measured on the dashboard the tags were
+ * 34.7px apart horizontally and 18.5px apart vertically -- of which only 18.4px was the point.
+ */
+describe('a row of tags', () => {
+    beforeEach(() => {
+        getTags.mockResolvedValue({
+            tags: [
+                {id: 1, name: 'Water', color: BRIGHT},
+                {id: 2, name: 'Archived', color: DARK},
+            ],
+        });
+        getRecentTags.mockResolvedValue({tags: []});
+    });
+
+    it('adds no margin of its own around a linked tag', async () => {
+        /*
+         * The link wrapper carried `0.3em` either side, from when these were Semantic labels
+         * that had no margin of their own.  It is 0.3em twice, plus the group's gap, plus the
+         * structural margin -- so two tags sat 34.7px apart where the point needs 17.3px, and
+         * a wall of tags on the dashboard read as loose.
+         */
+        renderGroup(['Water', 'Archived']);
+
+        const tag = await awaitColored('Water', BRIGHT);
+        // The link has to exist first, or `null.style` would be the failure rather than a margin.
+        const link = tag.closest('a');
+        expect(link).toBeTruthy();
+        expect(link.style.marginLeft).toBe('');
+        expect(link.style.marginRight).toBe('');
+    });
+
+    it('applies the caller-given spacing to the group, not to every tag in it', async () => {
+        /*
+         * The dashboard passes `marginTop` to space the row below its heading.  `TagsLinkGroup`
+         * spread its props all the way down to each chip, so that margin landed on all 34 tags
+         * -- which is not a margin above the row, it is 7.7px added between every wrapped row
+         * of it.  The tags were the only thing on the page whose rows were further apart than
+         * the group's own gap.
+         */
+        renderGroup(['Water', 'Archived'], {style: {marginTop: '0.5em'}});
+
+        const tag = await awaitColored('Water', BRIGHT);
+        // Not on the chip ...
+        expect(tag.style.marginTop).toBe('');
+
+        // ... and on the group, so the spacing the caller asked for still happens.
+        const group = tag.closest('.mantine-Group-root');
+        expect(group).toBeTruthy();
+        expect(group.style.marginTop).toBe('0.5em');
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1249,6 +1249,29 @@ describe('a tag is legible in every theme, whatever color the user picked', () =
             expect($tag[0].getBoundingClientRect().height, 'height').to.be.at.least(26);
         });
     });
+
+    it("sets a tag's word within a fifth of the body text it sits beside", () => {
+        /*
+         * Matching Semantic was the wrong target for this one.  A tag is not an annotation on
+         * something else -- it is the whole content of its chip, and the thing a user scans a
+         * wall of them for -- so it wants to read as text, not as a footnote.  At 12.5px design
+         * against a 16px base it was 78% of the prose around it, and on the dashboard, where
+         * the tags ARE the content, that read as small.
+         *
+         * Expressed as a ratio rather than a pixel count so the assertion cannot be satisfied
+         * by the interface scale alone: 1.1 raised the tag to 13.75px and the prose to 17.6px
+         * at the same time, leaving the tag exactly as small next to it as before.
+         */
+        cy.mountUI(tags);
+
+        cy.get('.wrolpi-tag').first().should(($tag) => {
+            const tag = parseFloat(getComputedStyle($tag[0]).fontSize);
+            const body = parseFloat(getComputedStyle(Cypress.$('html')[0]).fontSize);
+            expect(tag / body, "the tag's share of body text").to.be.at.least(0.8);
+            // And is still a chip rather than prose in a colored box.
+            expect(tag / body, 'but not the same size as prose').to.be.at.most(0.95);
+        });
+    });
 });
 
 describe('a tag looks like a physical tag', () => {

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -784,8 +784,9 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
  * A tag is a label with a physical shape: a pointed left edge and an eyelet, like a tag
  * tied to a garment.  The point is a square rotated 45 degrees behind the left edge -- its
  * right half sits under the body in the same color and merges, leaving the left half
- * showing as the point.  At 20px a side its diagonal is 28px, which is the body's height,
- * so the two edges of the point meet the body exactly at its corners.
+ * showing as the point.  At 21px a side its diagonal is 29.7px, within half a pixel of the
+ * body's 30.2px height, so the two edges of the point meet the body at its corners.  (Design
+ * px throughout: the interface scale multiplies both, so the match holds at any size.)
  *
  * The eyelet is drawn in `currentColor`, so it reads as a hole punched through the tag on
  * any surface, filled or outlined, without needing to know what is behind it.
@@ -794,14 +795,24 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
 .wrolpi-tag {
     position: relative;
     /*
-     * Room for the point, which is drawn outside the body: half its diagonal (14.1px) plus
-     * the 1px it is nudged left, rounded up.
+     * Larger than a plain label, which is the one place the two part company.  A label
+     * annotates something else -- the count beside a tab's name, the page number in the CBZ
+     * viewer -- and wants to sit under the text it belongs to.  A tag is the whole content of
+     * its chip and the thing a wall of them is scanned for, so at 78% of body text it read as
+     * a footnote on the dashboard, where the tags are the page.
      */
-    margin-left: 1rem;
+    font-size: 0.875rem;
+    /*
+     * Room for the point, which is drawn outside the body: half its diagonal (14.85px), plus
+     * the 1px it is nudged left, plus the 1px border it is positioned inside of, rounded up.
+     * This is the one length here that grew: 16px covered the smaller point, and the larger
+     * one overhung it by a third of a pixel, which is enough to clip against the tag before it.
+     */
+    margin-left: 1.0625rem;
     /* Tags wrap, and a wrapped row was sitting on the row above it. */
     margin-bottom: 0.3125rem;
     /*
-     * The point is centred on the left edge, so its inner half covers the body's first 10px
+     * The point is centred on the left edge, so its inner half covers the body's first 10.5px
      * -- and a positioned pseudo-element paints above the parent's text, not behind it, so
      * without this the first letter is hidden under the point.  Semantic's tag label carried
      * the same asymmetry (`padding-left: 1.5em`) for the same reason.
@@ -814,8 +825,13 @@ html[data-theme="amber"] .wrolpi-path-input-control:focus-within {
     position: absolute;
     top: 50%;
     right: 100%;
-    width: 1.25rem;
-    height: 1.25rem;
+    /*
+     * Tied to the body's height, not chosen: the diagonal has to equal it or the point's two
+     * edges meet the body short of its corners.  So this grew with the font -- 21px a side for
+     * the 30.2px body, where 20px served the 28.2px body the tag had at 12.5px text.
+     */
+    width: 1.3125rem;
+    height: 1.3125rem;
     /*
      * Nudged 1px left of where `right: 100%` puts it.  That property positions against the
      * containing block's *padding* box, and the body carries a 1px border, so a square centred


### PR DESCRIPTION
Tags read small and sat loose.  The font is up 12%, the padding is untouched, and the gaps closed by about a third — but only two of the three numbers were a design decision.

## Size

A tag's word was 12.5px design against a 16px base — **78% of the body text beside it**.  That is right for a *label*: the count next to a tab's name, the page number in the CBZ viewer, things that annotate something else and want to sit under it.  It is wrong for a tag, which is the entire content of its chip and the thing a wall of them is scanned for.  On the dashboard, where the tags *are* the page, it read as a footnote.

Now 14px design — **87.5%**.  This is the one place labels and tags part company, so the size went on `.wrolpi-tag` and plain labels are unchanged.  Both appear in `/theme-sample`, in adjacent sections, and the difference reads as hierarchy rather than inconsistency.

The point had to grow with it.  Its diagonal *is* the body's height — 21px a side for the 30.2px body, where 20px served the 28.2px body — or the two edges meet the body short of its corners and it reads as a notch stuck on the side rather than one tag-shaped outline.  Which in turn made the margin reserving room for it a third of a pixel short, enough to clip against the tag before it, so that is the one length here that went **up**: 16px → 17px.

## Spacing

Neither gap was chosen:

- **The link wrapper carried `0.3em` either side**, left from when these were Semantic labels with no margin of their own.  A tag reserves its own `margin-left` for the point drawn outside its body, so this was 0.3em twice on top of the group's gap *and* the point's room.  Two tags sat **34.7px** apart where the point needs 18.4px.
- **`TagsLinkGroup` spread its props down to every chip**, so the dashboard's `marginTop` — meant to space the row below its heading — landed on all 34 tags.  That is not a margin above the row; it is 7.7px added between every wrapped row of it.  The tags were the only thing on the page whose rows were further apart than their group's own gap.

Measured on the dashboard, 34 tags:

| | before | after |
|---|---|---|
| font size | 13.75px | 15.4px |
| gap between tags | 34.7px | 25.3px |
| …of which is the point | 17.6px | 18.7px |
| visible space between them | ~17px | ~7px |
| gap between rows | 18.5px | 12.0px |
| rows needed | 4 | 4 (11 per row, was 9) |

## Tests

Written first.  Both margin tests fail on the real values — `0.3em` on the link, `0.5em` on the chip — rather than on something absent.

The size is asserted as a **ratio to body text**, not a pixel count, because a pixel floor here is satisfiable by accident: the 1.1 interface scale raised the tag to 13.75px and the prose to 17.6px at the same time, leaving the tag exactly as small beside it as before.  A ratio cannot pass that way.  It has an upper bound too, so a tag stays a chip rather than becoming prose in a colored box.

The existing geometry tests earned their keep — `reserves exactly the room the point takes` is what caught the third-of-a-pixel overhang, which no screenshot would have shown.

## Verification

- 1145 jest tests, 65 suites
- 252 cypress component tests in `ui-layout.cy.js`
- 50 cypress e2e tests
- clean `npm run build`
- all four themes in the browser, including **night**, where the point is drawn as two strokes rather than a solid diamond and so shows a corner mismatch plainly, and **amber**, which discards the user's fill

`Tags.cy.js`, `Channels.cy.js`, `Download.cy.js` and `Inventory.cy.js` fail — 12 tests — but they fail identically on `feature/custom-theme`, confirmed by running them there in a worktree.  `Tags.cy.js` is looking for `div.ui.label.large`, a Semantic selector that has not existed since the migration; the others are unmocked fetches.  Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)