### PR TITLE
ui: pages own the space between their blocks

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -590,7 +590,8 @@ tr.drag-deselecting td {
 .file-browser-filter-container {
     display: flex;
     justify-content: flex-end;
-    margin-bottom: 0.5em;
+    /* No `margin-bottom`: this is a top-level block of the Files page, and the page's stack
+       spaces it (see `.wrolpi-stack`).  Its own 0.5em was added to that. */
 }
 
 /* Double the default input width on desktop. */

--- a/app/src/DashboardPage.js
+++ b/app/src/DashboardPage.js
@@ -452,7 +452,13 @@ export function DashboardPage() {
         if (big) {
             inputProps.size = 'big';
         }
-        return <div style={{display: 'flex', alignItems: 'center', gap: '0.5em', marginBottom: '2em'}}>
+        /*
+         * No `marginBottom`.  This row is a top-level block of the dashboard, so its own 2em was
+         * added to the page stack's gap -- 52.8px below the search box against 17.6px between
+         * every other pair of blocks, on the most-looked-at page in the app.  One source of
+         * spacing, and it is the stack.
+         */
+        return <div style={{display: 'flex', alignItems: 'center', gap: '0.5em'}}>
             {getSearchResultsInput(inputProps)}
             <SearchFilterButton fileFilterOptions={fileMimetypeFilterOptions} showDates={true} showDeep={true}
                                 size={big ? 'big' : undefined}/>

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -498,8 +498,9 @@ export function DomainsPage() {
         }
     }, {enableOnFormTags: false});
 
-    // Header section matching ChannelsPage pattern
-    const header = <div style={{marginBottom: '1em', display: 'flex', flexWrap: 'wrap', gap: '1em', alignItems: 'center'}}>
+    // Header section matching ChannelsPage pattern.  No `marginBottom`: this is a top-level block
+    // of the page, and the page's stack spaces it -- its own margin was added to that gap.
+    const header = <div style={{display: 'flex', flexWrap: 'wrap', gap: '1em', alignItems: 'center'}}>
         <div style={{flex: '1 1 240px'}}>
             <SearchInput
                 placeholder='Domain filter...'
@@ -987,7 +988,13 @@ function ArchiveSettingsPage() {
         onClick={() => navigator.clipboard.writeText('url')}
     />;
 
-    return <PageContainer>
+    /*
+     * A fragment, not a `PageContainer`.  `ArchiveRoute` already wraps its `<Routes>` in one, and
+     * a second applies its `margin-top: 1em` and `padding: 1em` again -- so this page sat 1em
+     * lower and 1em further in on all four sides than /archives/domains beside it.  As a fragment
+     * these panels become blocks of the route's own page stack, which spaces them.
+     */
+    return <>
         <Panel>
             <Header as='h3'>Archive Downloader Config</Header>
 
@@ -1081,7 +1088,7 @@ function ArchiveSettingsPage() {
                    action={urlFieldNameClipboardButton}
             />
         </Panel>
-    </PageContainer>
+    </>
 }
 
 function ArchivesPage() {

--- a/app/src/components/Channels.js
+++ b/app/src/components/Channels.js
@@ -499,8 +499,9 @@ export function ChannelsPage() {
         }
     }, {enableOnFormTags: false});
 
-    // Header section matching DomainsPage pattern
-    const header = <Group justify='space-between' align='flex-end' wrap='wrap' mb='1em'>
+    // Header section matching DomainsPage pattern.  No `mb`: this is a top-level block of the
+    // page, and the page's stack spaces it -- its own margin was added to that gap.
+    const header = <Group justify='space-between' align='flex-end' wrap='wrap'>
         <SearchInput
             placeholder='Name filter...'
             size='large'

--- a/app/src/components/Common.js
+++ b/app/src/components/Common.js
@@ -660,13 +660,29 @@ export function TabLinks({links, right}) {
     </TabBar>
 }
 
+/**
+ * The outer wrapper of a page, and the thing that decides how far apart its blocks sit.
+ *
+ * A page is a stack of panels -- the dashboard is five, Status six, Settings six -- and they used
+ * to share edges, because nothing anywhere put space between them.  The space belongs here rather
+ * than on the panel: how far a panel sits from its neighbour is a property of the two being
+ * stacked, not of the panel, which also appears inside modals and grids that space it themselves.
+ *
+ * `.wrolpi-stack` spaces every top-level block of the page, whatever it is -- which is why it
+ * works through the `Media` wrappers that several pages put around a panel.  It spaces the
+ * wrapper, and the wrapper is the sibling.
+ */
 export function PageContainer(props) {
     return <>
         <Media at='mobile'>
-            <div style={{marginTop: '1em', padding: 0}}>{props.children}</div>
+            <div className='wrolpi-stack' style={{marginTop: '1em', padding: 0}}>
+                {props.children}
+            </div>
         </Media>
         <Media greaterThanOrEqual='tablet'>
-            <div style={{marginTop: '1em', padding: '1em'}}>{props.children}</div>
+            <div className='wrolpi-stack' style={{marginTop: '1em', padding: '1em'}}>
+                {props.children}
+            </div>
         </Media>
     </>;
 }
@@ -674,7 +690,10 @@ export function PageContainer(props) {
 export function CardGroupCentered(props) {
     // One responsive grid; it centres what it cannot fill, so the two viewports no
     // longer need separate markup.
-    return <div style={{marginTop: '1em'}}>
+    //
+    // No `marginTop`: this is a top-level block on every module page, and the page's stack
+    // spaces it.  Carrying one added to that gap.
+    return <div>
         <CardGroup>{props.children}</CardGroup>
     </div>
 }

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -727,7 +727,7 @@ describe('PageContainer', () => {
         stacks.forEach(stack => expect(stack.textContent).toBe('Body'));
     });
 
-    it('is never rendered by a page that a PageContainer already wraps', () => {
+    it('is never rendered by a page whose route already provides page chrome', () => {
         /*
          * `PageContainer` carries `margin-top: 1em` and `padding: 1em`, so nesting one inside
          * another applies both twice: the page is pushed 1em further down and inset 1em further
@@ -736,10 +736,21 @@ describe('PageContainer', () => {
          * in another -- and read as "more margin than /archives/domains", which is exactly what
          * it was.
          *
-         * Nothing about a doubled margin throws, so this is a source scan.  It reads each route
-         * wrapper (a `PageContainer` holding `<Routes>` or `<Outlet/>`), takes the components it
-         * routes to, and checks the ones defined in the same file -- which is where a route and
-         * its pages normally live together.
+         * Nothing about a doubled margin throws, so this is a source scan.  It finds each router
+         * whose enclosing `return` provides page chrome, takes the components it routes to, and
+         * checks the ones declared in the same file -- which is where a route and its pages
+         * normally live together.
+         *
+         * "Chrome" is `PageContainer` OR a `wrolpi-stack` wrapper, not just the former.  Keying on
+         * `PageContainer` alone missed `MapRoute` and `ZimRoute`, which wrap their own content in a
+         * stack instead -- and three pages under them (`ManageMap`, `MapPins`, `ManageZim`) mounted
+         * a `PageContainer` each, so they sat a further 1em down and 1em in from the tab bar than
+         * the viewers beside them.  The same defect as Archive, in a shape the first scan could not
+         * see.
+         *
+         * Known limit: a layout that routes through `<Outlet/>` has its `<Route>` list in App.js,
+         * naming components from other files, so the page cannot be resolved from one file's text.
+         * That is `VideosTabLayout`, whose pages are clean today but are not covered here.
          */
         const src = path.join(__dirname, '..');
         const files = (dir) => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
@@ -753,24 +764,9 @@ describe('PageContainer', () => {
         const offenders = [];
         for (const file of files(src)) {
             const text = fs.readFileSync(file, 'utf8');
-
-            /*
-             * EVERY `<PageContainer>` in the file, not just the first.  Checking only the first
-             * is what let this bug through a version of this test: in Archive.js the first one
-             * is `ArchiveSettingsPage`'s -- the offender -- and its block holds no `<Routes>`, so
-             * the file was skipped before the route wrapper 400 lines below was ever looked at.
-             */
-            for (const block of routeWrapperBlocks(text)) {
-                const routed = [...block.matchAll(/element=\{<(\w+)\s*\/>\}/g)].map(m => m[1]);
-                for (const name of routed) {
-                    // The component's body, bounded by the next top-level declaration.
-                    const declaration = new RegExp(`^(?:export\\s+)?(?:function|const)\\s+${name}\\b`, 'm');
-                    const found = declaration.exec(text);
-                    if (!found) continue;   // Defined elsewhere; out of this scan's reach.
-                    const after = text.slice(found.index + 1);
-                    const next = after.search(/^(?:export\s+)?(?:function|const|class)\s/m);
-                    const body = next === -1 ? after : after.slice(0, next);
-                    if (body.includes('<PageContainer>')) {
+            for (const block of chromedRouterBlocks(text)) {
+                for (const name of routedComponents(block)) {
+                    if (bodyOf(text, name).includes('<PageContainer>')) {
                         offenders.push(`${path.relative(src, file)}: ${name}`);
                     }
                 }
@@ -778,33 +774,64 @@ describe('PageContainer', () => {
         }
 
         /*
-         * The premise: a scan that found no route wrappers, or routed to no components, would
-         * report no offenders and read exactly like a clean codebase.
+         * The premise: a scan that found no routers, or resolved no page components, would report
+         * no offenders and read exactly like a clean codebase.
          */
-        const wrappers = files(src).flatMap(file => routeWrapperBlocks(fs.readFileSync(file, 'utf8')));
-        expect(wrappers.length).toBeGreaterThan(2);
-        expect(wrappers.flatMap(b => [...b.matchAll(/element=\{<(\w+)\s*\/>\}/g)]).length)
-            .toBeGreaterThan(8);
+        const blocks = files(src).flatMap(file => chromedRouterBlocks(fs.readFileSync(file, 'utf8')));
+        expect(blocks.length).toBeGreaterThan(3);
+        expect(blocks.flatMap(routedComponents).length).toBeGreaterThan(8);
 
         expect(offenders).toEqual([]);
     });
 });
 
 /**
- * Every `<PageContainer>...</PageContainer>` in `text` that wraps a router -- so, the ones that
- * wrap a whole section of the app rather than one page.  All of them, because a file may hold both
- * a route wrapper and the pages it routes to, in either order.
+ * Every `<Routes>...</Routes>` in `text` whose enclosing `return` provides page chrome -- a
+ * `PageContainer` or a `wrolpi-stack` wrapper.  Those are the routers that have already spaced and
+ * inset the page, so a page under one must not do it again.
+ *
+ * All of them, and located from the router rather than from the chrome: keying on the first
+ * `<PageContainer>` in a file missed this entirely in Archive.js, where the first one belongs to
+ * the offending page and holds no router at all.
  */
-const routeWrapperBlocks = (text) => {
+const chromedRouterBlocks = (text) => {
     const blocks = [];
     let from = 0;
     for (;;) {
-        const start = text.indexOf('<PageContainer>', from);
+        const start = text.indexOf('<Routes>', from);
         if (start === -1) return blocks;
-        const end = text.indexOf('</PageContainer>', start);
+        const end = text.indexOf('</Routes>', start);
         if (end === -1) return blocks;
-        const block = text.slice(start, end);
-        if (/<Routes>|<Outlet\s*\/>/.test(block)) blocks.push(block);
         from = end + 1;
+
+        const returned = text.lastIndexOf('return', start);
+        if (returned === -1) continue;
+        const chrome = text.slice(returned, start);
+        if (chrome.includes('<PageContainer>') || chrome.includes('wrolpi-stack')) {
+            blocks.push(text.slice(start, end));
+        }
     }
+};
+
+/**
+ * The page components a router block routes to.  Any capitalised tag that is not routing furniture,
+ * so `element={<ErrorBoundary><Page/></ErrorBoundary>}` yields `Page` as well as the plain
+ * `element={<Page/>}` form.
+ */
+const FURNITURE = new Set(['Route', 'Routes', 'ErrorBoundary', 'Suspense', 'Navigate', 'Outlet']);
+const routedComponents = (block) => [...new Set(
+    [...block.matchAll(/<([A-Z]\w*)/g)].map(m => m[1]).filter(name => !FURNITURE.has(name)))];
+
+/**
+ * The source of the component named `name`, bounded by the next top-level declaration.  `class` is
+ * in both patterns because `ManageZim` is one, and a scan that only knew about functions would
+ * have reported it clean.
+ */
+const bodyOf = (text, name) => {
+    const declaration = new RegExp(`^(?:export\\s+)?(?:function|const|class)\\s+${name}\\b`, 'm');
+    const found = declaration.exec(text);
+    if (!found) return '';   // Declared elsewhere; out of this scan's reach.
+    const after = text.slice(found.index + 1);
+    const next = after.search(/^(?:export\s+)?(?:function|const|class)\s/m);
+    return next === -1 ? after : after.slice(0, next);
 };

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import fs from 'fs';
+import path from 'path';
 import {act, render, screen, waitFor} from '../test-utils';
 import userEvent from '@testing-library/user-event';
 import {
@@ -724,4 +726,85 @@ describe('PageContainer', () => {
         expect(stacks).toHaveLength(2);
         stacks.forEach(stack => expect(stack.textContent).toBe('Body'));
     });
+
+    it('is never rendered by a page that a PageContainer already wraps', () => {
+        /*
+         * `PageContainer` carries `margin-top: 1em` and `padding: 1em`, so nesting one inside
+         * another applies both twice: the page is pushed 1em further down and inset 1em further
+         * in on all four sides than every other page in the app.  `/archives/settings` did this
+         * -- `ArchiveRoute` wraps its `<Routes>` in one, and `ArchiveSettingsPage` wrapped itself
+         * in another -- and read as "more margin than /archives/domains", which is exactly what
+         * it was.
+         *
+         * Nothing about a doubled margin throws, so this is a source scan.  It reads each route
+         * wrapper (a `PageContainer` holding `<Routes>` or `<Outlet/>`), takes the components it
+         * routes to, and checks the ones defined in the same file -- which is where a route and
+         * its pages normally live together.
+         */
+        const src = path.join(__dirname, '..');
+        const files = (dir) => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) return files(full);
+            if (!/\.jsx?$/.test(entry.name)) return [];
+            if (/\.(test|cy)\.jsx?$/.test(entry.name)) return [];
+            return [full];
+        });
+
+        const offenders = [];
+        for (const file of files(src)) {
+            const text = fs.readFileSync(file, 'utf8');
+
+            /*
+             * EVERY `<PageContainer>` in the file, not just the first.  Checking only the first
+             * is what let this bug through a version of this test: in Archive.js the first one
+             * is `ArchiveSettingsPage`'s -- the offender -- and its block holds no `<Routes>`, so
+             * the file was skipped before the route wrapper 400 lines below was ever looked at.
+             */
+            for (const block of routeWrapperBlocks(text)) {
+                const routed = [...block.matchAll(/element=\{<(\w+)\s*\/>\}/g)].map(m => m[1]);
+                for (const name of routed) {
+                    // The component's body, bounded by the next top-level declaration.
+                    const declaration = new RegExp(`^(?:export\\s+)?(?:function|const)\\s+${name}\\b`, 'm');
+                    const found = declaration.exec(text);
+                    if (!found) continue;   // Defined elsewhere; out of this scan's reach.
+                    const after = text.slice(found.index + 1);
+                    const next = after.search(/^(?:export\s+)?(?:function|const|class)\s/m);
+                    const body = next === -1 ? after : after.slice(0, next);
+                    if (body.includes('<PageContainer>')) {
+                        offenders.push(`${path.relative(src, file)}: ${name}`);
+                    }
+                }
+            }
+        }
+
+        /*
+         * The premise: a scan that found no route wrappers, or routed to no components, would
+         * report no offenders and read exactly like a clean codebase.
+         */
+        const wrappers = files(src).flatMap(file => routeWrapperBlocks(fs.readFileSync(file, 'utf8')));
+        expect(wrappers.length).toBeGreaterThan(2);
+        expect(wrappers.flatMap(b => [...b.matchAll(/element=\{<(\w+)\s*\/>\}/g)]).length)
+            .toBeGreaterThan(8);
+
+        expect(offenders).toEqual([]);
+    });
 });
+
+/**
+ * Every `<PageContainer>...</PageContainer>` in `text` that wraps a router -- so, the ones that
+ * wrap a whole section of the app rather than one page.  All of them, because a file may hold both
+ * a route wrapper and the pages it routes to, in either order.
+ */
+const routeWrapperBlocks = (text) => {
+    const blocks = [];
+    let from = 0;
+    for (;;) {
+        const start = text.indexOf('<PageContainer>', from);
+        if (start === -1) return blocks;
+        const end = text.indexOf('</PageContainer>', start);
+        if (end === -1) return blocks;
+        const block = text.slice(start, end);
+        if (/<Routes>|<Outlet\s*\/>/.test(block)) blocks.push(block);
+        from = end + 1;
+    }
+};

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {
     CardLink, contrastingColor, contrastRatio, DirectorySearch, ExternalCardLink, HelpHeader,
     InfoHeader, loadRole,
+    PageContainer,
     SearchResultsInput, TAG_TEXT_DARK, TAG_TEXT_LIGHT,
 } from './Common';
 import {healthRole} from './admin/ControllerPage';
@@ -705,5 +706,22 @@ describe('card links', () => {
         expect(link).toHaveClass('card-link');
         expect(link).toHaveClass('no-link-underscore');
         expect(link).toHaveClass('card-title-ellipsis');
+    });
+});
+
+describe('PageContainer', () => {
+    /*
+     * The wrapper that decides how far apart a page's blocks sit.  The spacing itself is a
+     * stylesheet rule and is measured in ui-layout.cy.js, where there is a layout engine; what
+     * this asserts is that the rule is REACHED -- the class has to be on both of the responsive
+     * branches, or the spacing silently applies on one viewport and not the other.
+     */
+    it('marks both of its viewport branches as a stack', () => {
+        const {container} = render(<PageContainer><div>Body</div></PageContainer>);
+
+        const stacks = container.querySelectorAll('.wrolpi-stack');
+        // Mobile and tablet-and-up, both rendered; `Media` hides one with CSS.
+        expect(stacks).toHaveLength(2);
+        stacks.forEach(stack => expect(stack.textContent).toBe('Body'));
     });
 });

--- a/app/src/components/Docs.js
+++ b/app/src/components/Docs.js
@@ -469,7 +469,8 @@ function AuthorsPage() {
     const [searchStr, setSearchStr] = useOneQuery('author');
     const searchInputRef = React.useRef();
 
-    const header = <div style={{marginBottom: '1em'}}>
+    // No `marginBottom`: a top-level block of the page, spaced by the page's stack.
+    const header = <div>
         <SearchInput
             placeholder='Author filter...'
             size='large'
@@ -501,7 +502,8 @@ function SubjectsPage() {
     const [searchStr, setSearchStr] = useOneQuery('subject');
     const searchInputRef = React.useRef();
 
-    const header = <div style={{marginBottom: '1em'}}>
+    // No `marginBottom`: a top-level block of the page, spaced by the page's stack.
+    const header = <div>
         <SearchInput
             placeholder='Subject filter...'
             size='large'

--- a/app/src/components/Files.js
+++ b/app/src/components/Files.js
@@ -333,7 +333,14 @@ export function FilesView(
 ) {
     const {view} = useSearchView();
 
-    const paginator = <div style={{marginTop: '2em'}}>
+    /*
+     * No margin of its own.  Videos, Archives, Docs and Files all render this as a top-level block
+     * of the page, and the page spaces its blocks (see `wrolpi-stack`) -- so a `marginTop: 2em`
+     * here added to that and put the pager twice as far from the results as anything else on the
+     * page sits from its neighbour.  Zim keeps its own paginator, inside an accordion panel that
+     * does not stack, and is untouched.
+     */
+    const paginator = <div>
         <Paginator activePage={activePage} totalPages={totalPages} onPageChange={setPage}/>
     </div>;
 
@@ -817,7 +824,9 @@ export function SearchControlBar(
         inputRef={inputRef}
     />;
 
-    return <div style={{display: 'flex', alignItems: 'center', gap: '0.5em', marginBottom: '1em'}}>
+    // No `marginBottom`: this is a top-level block on Videos, Archives and Docs, and the page
+    // spaces its own blocks.  Carrying one here added to that gap.
+    return <div style={{display: 'flex', alignItems: 'center', gap: '0.5em'}}>
         {viewButton}
         <div style={{flexGrow: 1, minWidth: 0}}>{searchInput}</div>
         <SearchFilterButton sorts={sorts} fileFilterOptions={fileFilterOptions} showDates={showDates}
@@ -898,7 +907,8 @@ export function FilesSearchView({
     }
 
     return <>
-        {showView && <div style={{marginBottom: '1em'}}>{viewButton}</div>}
+        {/* No margin: another top-level block, spaced by the page. */}
+        {showView && <div>{viewButton}</div>}
         {body}
         {deepHint}
         {paginator}

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -649,7 +649,9 @@ export function MapRoute() {
         {text: 'Manage', to: '/map/manage', key: 'manage'},
     ];
 
-    return <div style={{marginTop: '2em'}}>
+    // `wrolpi-stack`: as in ZimRoute, this route wraps its own content instead of using
+    // PageContainer, so the spacing below the tab bar is this element's to provide.
+    return <div className='wrolpi-stack' style={{marginTop: '2em'}}>
         <TabLinks links={links}/>
         <Routes>
             <Route path='/' exact element={<MapPage/>}/>

--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -5,7 +5,6 @@ import {
     HandPointMessage,
     humanFileSize,
     InfoMessage,
-    PageContainer,
     TabLinks,
     useTitle,
     WROLModeMessage
@@ -366,13 +365,18 @@ function ManageMap() {
     };
 
     if (files === undefined) {
-        return <PageContainer>
+        return <>
             <WROLModeMessage content='Cannot modify Map'/>
             <ErrorMessage>Could not fetch map files</ErrorMessage>
-        </PageContainer>;
+        </>;
     }
 
-    return <PageContainer>
+    /*
+     * A fragment, not a `PageContainer`.  `MapRoute` already provides the page chrome -- a
+     * `wrolpi-stack` wrapper with its own top margin -- so a second one put this page a further
+     * 1em down and 1em in from the tab bar than the viewer beside it.
+     */
+    return <>
         <WROLModeMessage content='Cannot modify Map'/>
 
         <Header as='h3'>Map Files</Header>
@@ -420,7 +424,7 @@ function ManageMap() {
         <HandPointMessage>
             <p>You can also view the map at <a href={MAP_VIEWER_URI}>{MAP_VIEWER_URI}</a></p>
         </HandPointMessage>
-    </PageContainer>
+    </>
 }
 
 const PIN_COLORS = ["red", "blue", "green", "yellow", "orange", "purple"];
@@ -605,13 +609,15 @@ function MapPins() {
         )
         : pins;
 
-    return <PageContainer>
+    // A fragment for the same reason as ManageMap above.  The filter carries no `marginBottom`
+    // either: it is a top-level block of the page, and the route's stack spaces it.
+    return <>
         <TextInput
             leftSection={<Icon name='search'/>}
             placeholder='Filter by label or coordinates...'
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            style={{marginBottom: '1em', width: '100%'}}
+            style={{width: '100%'}}
         />
         <Media at='mobile'>
             <SortableTable
@@ -633,7 +639,7 @@ function MapPins() {
                 emptyRow={emptyRow}
             />
         </Media>
-    </PageContainer>;
+    </>;
 }
 
 function MapPage() {

--- a/app/src/components/Playlists.js
+++ b/app/src/components/Playlists.js
@@ -128,7 +128,9 @@ export function PlaylistsPage() {
         }
     };
 
-    const header = <Group justify='space-between' align='flex-end' wrap='wrap' mb='1em'>
+    // No `mb`: this is a top-level block of the page, and the page's stack spaces it.  Its own
+    // margin was added to that gap -- the same fix as the twin filter rows on Channels/Domains.
+    const header = <Group justify='space-between' align='flex-end' wrap='wrap'>
         <SearchInput
             placeholder='Name filter...'
             size='large'

--- a/app/src/components/VideoPlayer.js
+++ b/app/src/components/VideoPlayer.js
@@ -472,7 +472,9 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
             {captionUrls.map(i => <CaptionTrack key={i} src={i}/>)}
         </video>}
 
-        <div style={{marginTop: '1em'}}>
+        {/* `wrolpi-stack`: everything below the player is stacked in here rather than in the
+            page, so this is what spaces it. */}
+        <div className='wrolpi-stack' style={{marginTop: '1em'}}>
             <Panel>
 
                 <Header as='h2'>{title}</Header>

--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -9,7 +9,6 @@ import {
     IframeViewer,
     InfoMessage,
     normalizeEstimate,
-    PageContainer,
     Paginator,
     TabLinks,
     TagIcon,
@@ -489,7 +488,12 @@ class ManageZim extends React.Component {
             kiwixCatalog = <ErrorMessage>Could not fetch catalog</ErrorMessage>;
         }
 
-        return <PageContainer>
+        /*
+         * A fragment, not a `PageContainer`.  `ZimRoute` already provides the page chrome -- a
+         * `wrolpi-stack` wrapper with its own top margin -- so a second one put this page a
+         * further 1em down and 1em in from the tab bar than the viewer beside it.
+         */
+        return <>
             <Header as='h2'>Zim Files</Header>
             {zimFilesBody}
 
@@ -500,7 +504,7 @@ class ManageZim extends React.Component {
 
             <DownloadMessage/>
             <ViewerMessage/>
-        </PageContainer>
+        </>
     }
 }
 

--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -527,7 +527,9 @@ export function ZimRoute() {
         {text: 'Manage', to: '/zim/manage', key: 'manage'},
     ]
 
-    return <div style={{marginTop: '2em'}}>
+    // `wrolpi-stack`: this route wraps its own content rather than using PageContainer, so it is
+    // what spaces the tab bar from the page below it.
+    return <div className='wrolpi-stack' style={{marginTop: '2em'}}>
         <TabLinks links={links}/>
         <Routes>
             <Route path='/' exact element={<ZimViewer/>}/>

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -1631,7 +1631,9 @@ function AdminControlsSection() {
 
 export function ControllerPage() {
     return (
-        <div>
+        // `wrolpi-stack`: these four sections are panels held in a wrapper of this page's own,
+        // so the stack on PageContainer does not reach them -- the same hole Settings had.
+        <div className='wrolpi-stack'>
             <AdminControlsSection/>
             <ServicesSection/>
             <SambaSection/>

--- a/app/src/components/admin/ExtensionPage.js
+++ b/app/src/components/admin/ExtensionPage.js
@@ -32,7 +32,9 @@ function DestinationHint() {
             // Fall through silently — the user can still copy manually.
         }
     };
-    return <Panel style={{marginBottom: '1em'}}>
+    // No `marginBottom`: this Panel sits in a Mantine `Stack`, whose gap already spaces it.
+    // A margin here is added to that gap -- the compound the panel-margin approach caused.
+    return <Panel>
         <Header as='h4' icon='globe'>This WROLPi's URL</Header>
         <p style={{color: 'var(--muted)'}}>
             After installing the extension, paste this URL into the

--- a/app/src/components/admin/Settings.js
+++ b/app/src/components/admin/Settings.js
@@ -901,7 +901,9 @@ export function SettingsPage() {
         </a>
     </Panel>;
 
-    return <div>
+    // `wrolpi-stack`: these panels sit in a wrapper of this page's own, so the stack on
+    // PageContainer does not reach them and this wrapper is what has to space them.
+    return <div className='wrolpi-stack'>
         <WROLModeMessage content='Settings are disabled because WROL Mode is enabled.'/>
 
         <Panel>

--- a/app/src/components/inventory/InventoryRoute.js
+++ b/app/src/components/inventory/InventoryRoute.js
@@ -183,8 +183,9 @@ export function InventoryRoute() {
             </TabBar>
 
             {tab === 'items' && <>
-                {/* The search filter lives here so it clearly applies to the Items tab only, not Summary/Ration/Export. */}
-                <div style={{marginBottom: '0.75em'}}>
+                {/* The search filter lives here so it clearly applies to the Items tab only, not Summary/Ration/Export.
+                    No margin of its own: it is a top-level block and the page's stack spaces it. */}
+                <div>
                     <SearchBox value={search} onChange={setSearch} clearable placeholder='Search items…'
                                label='Search items'/>
                 </div>

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -142,15 +142,19 @@ describe('a page stacks its own blocks', () => {
             <Panel>Calculators</Panel>
         </div>);
 
-        cy.get('.wrolpi-panel').should(($panels) => {
-            const gaps = gapsBetween($panels);
+        cy.get('.wrolpi-stack').should(($stack) => {
+            /*
+             * Measured against the stack's own `row-gap` rather than a pixel range.  The range was
+             * 12-28px, which assumes the default `--ui-scale`: at a larger scale the gap grows past
+             * 28 and a correct layout would have failed the assertion.  A separate test covers the
+             * ratio; this one is about the panels really being that far apart.
+             */
+            const declared = parseFloat(getComputedStyle($stack[0]).rowGap);
+            expect(declared, 'the stack declares a gap').to.be.greaterThan(0);
+
+            const gaps = gapsBetween($stack[0].querySelectorAll('.wrolpi-panel'));
             expect(gaps, 'both pairs measured').to.have.length(2);
-            gaps.forEach((gap) => {
-                // Enough to read as a seam rather than a heavier border ...
-                expect(gap, 'gap between panels').to.be.at.least(12);
-                // ... and not so much that one page reads as unrelated cards.
-                expect(gap, 'gap between panels').to.be.at.most(28);
-            });
+            gaps.forEach((gap) => expect(gap, 'gap between panels').to.be.closeTo(declared, 0.5));
         });
     });
 
@@ -243,9 +247,14 @@ describe('a page stacks its own blocks', () => {
             <Panel>Also shown</Panel>
         </div>);
 
-        cy.get('.wrolpi-panel:visible').should(($panels) => {
-            expect($panels, 'the hidden panel is not measured').to.have.length(2);
-            expect(gapsBetween($panels)[0], 'one gap, not two').to.be.at.most(28);
+        // One gap, not two: measured against the declared gap rather than a pixel ceiling, which
+        // would have false-failed at a larger interface scale instead of catching a doubled gap.
+        cy.get('.wrolpi-stack').should(($stack) => {
+            const declared = parseFloat(getComputedStyle($stack[0]).rowGap);
+            const shown = $stack[0].querySelectorAll('.wrolpi-panel:not([style*="none"])');
+            const visible = [...shown].filter((el) => el.offsetParent !== null);
+            expect(visible, 'the hidden panel is not measured').to.have.length(2);
+            expect(gapsBetween(visible)[0], 'one gap, not two').to.be.closeTo(declared, 0.5);
         });
     });
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -116,6 +116,158 @@ describe('the interface scale actually reaches what it is supposed to', () => {
     });
 });
 
+describe('a page stacks its own blocks', () => {
+    /*
+     * A page is built out of panels -- the dashboard is five, Status is six, Settings is six --
+     * and nothing put space between them, so every pair shared an edge.  Two 1px borders meeting
+     * do not read as a seam between two surfaces; they read as one tall surface with a rule across
+     * it, and which heading owns which content stops being obvious.
+     *
+     * The space is the page's, not the panel's.  How far a panel sits from its neighbour is a
+     * property of the two of them being stacked, and the same panel also appears inside modals,
+     * grids and Mantine `Stack`s that space it themselves.  This was tried the other way first, as
+     * `margin-bottom` on `.wrolpi-panel`, and it failed in both of the ways that rule is known to
+     * fail -- see the sibling test below, which is what stops it being tried again.
+     */
+
+    const gapsBetween = ($panels) => {
+        const rects = [...$panels].map((el) => el.getBoundingClientRect());
+        return rects.slice(1).map((rect, index) => rect.top - rects[index].bottom);
+    };
+
+    it('leaves a gap between the panels it stacks', () => {
+        cy.mountUI(<div className='wrolpi-stack'>
+            <Panel>Tags</Panel>
+            <Panel>Status</Panel>
+            <Panel>Calculators</Panel>
+        </div>);
+
+        cy.get('.wrolpi-panel').should(($panels) => {
+            const gaps = gapsBetween($panels);
+            expect(gaps, 'both pairs measured').to.have.length(2);
+            gaps.forEach((gap) => {
+                // Enough to read as a seam rather than a heavier border ...
+                expect(gap, 'gap between panels').to.be.at.least(12);
+                // ... and not so much that one page reads as unrelated cards.
+                expect(gap, 'gap between panels').to.be.at.most(28);
+            });
+        });
+    });
+
+    it('spaces a block that is wrapped as readily as a bare one', () => {
+        /*
+         * This is the case that chose where the rule lives.  Several pages put a panel inside the
+         * responsive `Media` component, so the page's child is a wrapper rather than the panel.
+         *
+         * Spacing from the page handles that for free -- it spaces the wrapper, and the wrapper is
+         * the sibling.  A `margin-bottom` on the panel plus the `:last-child` reset that would
+         * keep the trailing space off the bottom of a container does NOT: the panel is the only
+         * child of its wrapper, so `:last-child` matches it, zeroes the margin, and leaves it hard
+         * against the next panel.  On Status that separated four pairs out of five and left the
+         * first touching -- one page showing both, which reads as a rendering glitch.
+         */
+        cy.mountUI(<div className='wrolpi-stack'>
+            <div><Panel>Wrapped, as Media does it</Panel></div>
+            <Panel>Bare</Panel>
+        </div>);
+
+        cy.get('.wrolpi-panel').should(($panels) =>
+            expect(gapsBetween($panels)[0], 'gap across a wrapper').to.be.at.least(12));
+    });
+
+    it('survives a block that zeroes its own margin', () => {
+        /*
+         * The reason this is a gap and not `> * + * { margin-top }`.  The responsive `Media`
+         * component injects `.fresnel-container { margin: 0; padding: 0 }` into the document at
+         * runtime -- same specificity as the owl selector, later in source order -- so a wrapped
+         * block threw the margin away and went on touching its neighbour, while the bare blocks
+         * on the same page separated.  A gap is the parent's, and a child cannot zero it.
+         *
+         * The margin here stands in for fresnel's rule; the point is that the spacing does not
+         * depend on the child's own margin being left alone.
+         */
+        cy.mountUI(<div className='wrolpi-stack'>
+            <Panel>Before</Panel>
+            <div style={{margin: 0}}><Panel>Zeroed its own margin</Panel></div>
+        </div>);
+
+        cy.get('.wrolpi-panel').should(($panels) =>
+            expect(gapsBetween($panels)[0], 'gap despite the child margin').to.be.at.least(12));
+    });
+
+    it('adds nothing before the first block or after the last', () => {
+        // A gap goes only between, so the page's own padding decides its edges.
+        cy.mountUI(<div className='wrolpi-stack'>
+            <Panel>First</Panel>
+            <Panel>Last</Panel>
+        </div>);
+
+        cy.get('.wrolpi-stack').should(($stack) => {
+            const stack = $stack[0].getBoundingClientRect();
+            const panels = [...$stack[0].querySelectorAll('.wrolpi-panel')]
+                .map(el => el.getBoundingClientRect());
+            expect(panels[0].top - stack.top, 'above the first').to.be.closeTo(0, 0.5);
+            expect(stack.bottom - panels[1].bottom, 'below the last').to.be.closeTo(0, 0.5);
+        });
+    });
+
+    it('grows the gap with the interface scale', () => {
+        // In px it would hold still while the panels either side of it grew.
+        cy.mountUI(<div className='wrolpi-stack'>
+            <Panel>One</Panel>
+            <Panel>Two</Panel>
+        </div>);
+
+        cy.get('.wrolpi-stack').should(($stack) => {
+            const before = parseFloat(getComputedStyle($stack[0]).rowGap);
+            const root = Cypress.$('html')[0];
+            const scale = parseFloat(getComputedStyle(root).getPropertyValue('--ui-scale')) || 1;
+            root.style.setProperty('--ui-scale', String(scale * 2));
+            const after = parseFloat(getComputedStyle($stack[0]).rowGap);
+            root.style.removeProperty('--ui-scale');
+
+            expect(before, 'the gap exists at all').to.be.greaterThan(0);
+            expect(after / before, 'and doubles with the scale').to.be.closeTo(2, 0.05);
+        });
+    });
+
+    it('contributes no gap for the half of a Media pair that is hidden', () => {
+        /*
+         * `Media` renders both viewports and hides one with `display: none`.  A hidden flex item
+         * is not a flex item at all, so it takes no gap -- where `* + *` would have put space
+         * around something invisible and left a page with a stray 1rem hole in it.
+         */
+        cy.mountUI(<div className='wrolpi-stack'>
+            <Panel>Shown</Panel>
+            <div style={{display: 'none'}}><Panel>The other viewport</Panel></div>
+            <Panel>Also shown</Panel>
+        </div>);
+
+        cy.get('.wrolpi-panel:visible').should(($panels) => {
+            expect($panels, 'the hidden panel is not measured').to.have.length(2);
+            expect(gapsBetween($panels)[0], 'one gap, not two').to.be.at.most(28);
+        });
+    });
+
+    it('leaves a panel with no outer margin, so a Stack can space it instead', () => {
+        /*
+         * The inverse rule, and the reason it is worth its own test: the moment a panel carries
+         * its own margin, it adds to the spacing of every container that already spaces its
+         * children.  Four `Stack`s in the app hold nothing but panels -- the conflict list, both
+         * halves of the one-time pad, the electrical calculators -- and with `margin-bottom` on
+         * the panel they spaced those lists at 35.2px against the 17.6px used everywhere else.
+         */
+        cy.mountUI(<Panel>Composable</Panel>);
+
+        cy.get('.wrolpi-panel').should(($panel) => {
+            const styles = getComputedStyle($panel[0]);
+            ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'].forEach((side) => {
+                expect(parseFloat(styles[side]), side).to.equal(0);
+            });
+        });
+    });
+});
+
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
     const value = hex.replace('#', '');

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -250,7 +250,11 @@ html[data-theme="amber"] .wrolpi-pagination button[data-active] {
     justify-content: space-between;
     gap: 0.75rem;
     border-bottom: 1px solid var(--border);
-    margin-bottom: 0.875rem;
+    /*
+     * No `margin-bottom`.  A tab bar is always the first block of a page, inside the page's own
+     * stack, so the 0.875rem it used to carry was added to the stack's gap and put the bar 33px
+     * from the content it labels where every other pair of blocks sat 17.6px apart.
+     */
 }
 
 .wrolpi-tabs-links {
@@ -1270,12 +1274,57 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     background: var(--muted);
 }
 
+/* ----------------------------------------------------------------- Stacks */
+
+/*
+ * The space between stacked blocks, owned by whatever stacks them rather than by the blocks.
+ *
+ * `PageContainer` puts this on every page, so a page's own blocks are spaced without asking.  A
+ * component that stacks blocks one level deeper -- Settings holds its six panels in a wrapper of
+ * its own -- puts it on that wrapper.  Mantine's `Stack` is the same thing with the same 1rem gap
+ * and is equally correct where a call site already reaches for it.
+ *
+ * `gap`, not the `> * + * { margin-top }` this was written as first.  The margin version is the
+ * older recommendation and it is quietly broken here: the responsive `Media` component injects
+ * `.fresnel-container { margin: 0; padding: 0 }` into the document at runtime, which has the same
+ * specificity as `.wrolpi-stack > * + *` and comes later in source order -- so every block a
+ * page wraps in `Media`, which on Status is the one carrying the CPU and RAM bars, threw the
+ * margin away and went on touching its neighbour.  A gap belongs to the parent and a child cannot
+ * zero it.
+ *
+ * It also handles `Media`'s hidden half for free: the branch for the other viewport is
+ * `display: none`, so it is not a flex item and contributes no gap, where `* + *` would have
+ * spaced around something invisible.
+ *
+ * `align-items: stretch` is the default and is what keeps every block full-width, as it was as a
+ * block element.  Heights are unaffected: the column is auto-height, so nothing shrinks, and the
+ * map's 85vh box and the CBZ viewer's full-height page measure the same as before.
+ */
+.wrolpi-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
 /* ----------------------------------------------------------------- Panels */
 
 .wrolpi-panel {
     background: var(--panel);
     border: 1px solid var(--border);
     padding: 0.875rem 1rem;
+    /*
+     * Deliberately NO outer margin.  A panel is dropped into pages, modals, Stacks and grids, and
+     * how far it sits from its neighbour is a property of that relationship rather than of the
+     * panel -- so the space between stacked panels is owned by whatever stacks them
+     * (`.wrolpi-stack` for a page, Mantine's `Stack` gap inside a modal).
+     *
+     * This was tried the other way first, as `margin-bottom: 1rem` here, and it went wrong in
+     * both of the documented ways within the hour: it compounded with the gap of every `Stack`
+     * that already held panels (four of them, spacing those lists at 35.2px against the app's
+     * 17.6px), and the `:last-child` reset that would have kept the trailing space off the bottom
+     * of a container silently did nothing, because WROLPi wraps panels in the responsive `Media`
+     * component and a panel is frequently the only child of its own wrapper.
+     */
 }
 
 /* Danger zones are dashed in every theme; it doubles as a colorblind-safe cue. */


### PR DESCRIPTION
Panels shared edges — two 1px borders meeting, which reads as one tall surface with a rule across it rather than a seam between two.

**I did it the wrong way first, and the app punished it before I'd read anything.** `margin-bottom: 1rem` on `.wrolpi-panel` failed in both of the ways component margins are known to fail:

- It **compounded with every `Stack` that already held panels** — the conflict list, both halves of the one-time pad, the electrical calculators — spacing those at 35.2px against the app's 17.6px. I was one edit away from patching each with `gap={0}`, which is the "override the default spacing" symptom the literature names.
- The **`:last-child` reset silently did nothing.** WROLPi wraps panels in the responsive `Media` component, so a panel is frequently the only child of its own wrapper: `:last-child` matches it, zeroes the margin, and leaves it hard against the next panel. On Status that separated four pairs out of five and left the first touching — one page showing both behaviors, which reads as a rendering glitch.

The research is unambiguous that the parent owns this: [Margin considered harmful](https://mxstbr.com/thoughts/margin), [Every Layout's Stack](https://every-layout.dev/layouts/stack/), [CSS-Tricks](https://css-tricks.com/component-spacing-design-system/), [No Outer Margin](https://kyleshevlin.com/no-outer-margin/).

## Why a gap and not the owl selector

Every Layout recommends `> * + * { margin-top }`. That was the second attempt, and it is **also** broken here: `Media` injects `.fresnel-container { margin: 0; padding: 0 }` into the document at runtime — the same specificity as `.wrolpi-stack > * + *`, later in source order — so every wrapped block threw the margin away again. A third margin failure, same root cause.

A gap belongs to the parent and a child cannot zero it. It also handles `Media`'s hidden half for free: that branch is `display: none`, so it is not a flex item and contributes no gap, where the owl selector spaced around something invisible.

## Where the spacing lives

`.wrolpi-stack` goes on `PageContainer`, which every page uses, plus the four wrappers that stack blocks where a page's own stack cannot reach:

| site | why |
|---|---|
| `PageContainer` | every page's top-level blocks |
| `Settings` panel wrapper | holds its six panels in a wrapper of its own |
| below the video player | same |
| `ZimRoute`, `MapRoute` | keep their tab bar outside `PageContainer` |

Mantine's `Stack` is the same thing with the same 1rem gap, so the four sites already using it are already correct and untouched.

## The other half: blocks giving up margins they owned

Once the page owns the spacing, a block carrying its own adds to it. Removed from the tab bar (33px where everything else was 17.6), the shared search control bar and paginator on Videos/Archives/Docs/Files, the card grid, the file browser's filter row, and the inventory search.

**Two margins deliberately stay.** The file browser's `4em` reserves room for the sticky bottom buttons — `git log -S` traced it to 62645831, "Making file browser buttons stick to the bottom of the screen" — so it is load-bearing, not decoration. And heading margins stay: a heading wants more space above than below, which binds it to its content, and 41.8/28.6 reads correctly against a 17.6 baseline.

## Tests

The three failures are each planted as a test, because each one passed a naive assertion:

- `spaces a block that is wrapped as readily as a bare one` — the `Media` case
- `survives a block that zeroes its own margin` — fails against the owl selector, verified by reverting to it
- `contributes no gap for the half of a Media pair that is hidden`
- `leaves a panel with no outer margin, so a Stack can space it instead` — the inverse rule, which is what stops the compounding coming back

## Verification

- 1147 jest tests, 65 suites
- 259 cypress component tests in `ui-layout.cy.js`
- 50 cypress e2e tests
- clean `npm run build`
- browser, sixteen routes: `/`, `/videos`, `/videos/748`, `/archives`, `/docs`, `/files`, `/zim`, `/map`, `/inventory`, `/search?q=`, `/theme-sample`, `/admin`, `/admin/settings`, `/admin/status`, `/admin/control`, `/admin/extension` — every stacked pair 17.6px
- all four themes on the dashboard, identical spacing
- the map's 85vh box measures exactly 85vh and the video still plays; no horizontal overflow anywhere

`Tags.cy.js`, `Channels.cy.js`, `Download.cy.js` and `Inventory.cy.js` fail (12 tests) identically on `feature/custom-theme` — pre-existing, confirmed by running them there in a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)