### PR TITLE
ui: a row of buttons is spaced by the row

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -462,10 +462,6 @@ table.ratio-table td.min-width {
     color: red;
 }
 
-.action-button-spacing {
-    margin-top: 1em;
-}
-
 /* Form loading skeleton */
 .form-skeleton-field {
     margin-bottom: 1.5em;

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -586,6 +586,9 @@ tr.drag-deselecting td {
 .file-browser-filter-container {
     display: flex;
     justify-content: flex-end;
+    /* The gap is the container's.  The collapse-all button carried `margin-left: 0.5em` for it,
+       which is the same thing one element to the right of where it belongs. */
+    gap: 0.5em;
     /* No `margin-bottom`: this is a top-level block of the Files page, and the page's stack
        spaces it (see `.wrolpi-stack`).  Its own 0.5em was added to that. */
 }

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -254,7 +254,7 @@ function ArchivePage() {
     const labelStyle = {whiteSpace: 'nowrap', paddingRight: '1.5em', verticalAlign: 'top'};
 
     return <>
-        <BackButton/>
+        <div className='wrolpi-button-row'><BackButton/></div>
 
         <Panel>
             {screenshot}
@@ -619,7 +619,7 @@ export function DomainEditPage() {
     if (!form.ready) {
         if (form.error) {
             return <>
-                <BackButton/>
+                <div className='wrolpi-button-row'><BackButton/></div>
                 <Message kind='error' title='Domain not found'>
                     <p>{form.error}</p>
                 </Message>
@@ -685,10 +685,12 @@ export function DomainEditPage() {
     const [descriptionProps] = form.getCustomProps({name: 'description', path: 'description'});
 
     return <>
-        <BackButton/>
-        <Link to={`/archives?domain=${domain?.domain}`}>
-            <Button>Archives</Button>
-        </Link>
+        <div className='wrolpi-button-row'>
+            <BackButton/>
+            <Link to={`/archives?domain=${domain?.domain}`}>
+                <Button>Archives</Button>
+            </Link>
+        </div>
 
         {domain?.needs_reorganization && (
             <Message kind='warning' title='File Format Changed'>
@@ -1171,7 +1173,7 @@ function ArchivesPage() {
         setSelectedArchives([]);
     }
 
-    const selectElm = <div style={{marginTop: '0.5em'}}>
+    const selectElm = <div className='wrolpi-button-row' style={{marginTop: '0.5em'}}>
         <Button
             role='primary'
             disabled={_.isEmpty(selectedArchives)}

--- a/app/src/components/Archive.js
+++ b/app/src/components/Archive.js
@@ -174,7 +174,6 @@ function ArchivePage() {
         confirmButton='Update'
         onClick={localUpdateArchive}
         obeyWROLMode={true}
-        style={{marginTop: '0.5em'}}
     >
         Update
     </APIButton>;
@@ -193,7 +192,6 @@ function ArchivePage() {
         confirmButton='Generate'
         onClick={localGenerateScreenshot}
         obeyWROLMode={true}
-        style={{marginTop: '0.5em'}}
     >
         Generate Screenshot
     </APIButton> : null;
@@ -275,12 +273,14 @@ function ArchivePage() {
                 </div>
             </div>
 
-            {singlefileButton}
-            {readButton}
-            {updateButton}
-            {deleteButton}
-            {generateScreenshotButton}
-            <AddToPlaylistButton fileGroupId={archiveFile.id}/>
+            <div className='wrolpi-button-row'>
+                {singlefileButton}
+                {readButton}
+                {updateButton}
+                {deleteButton}
+                {generateScreenshotButton}
+                <AddToPlaylistButton fileGroupId={archiveFile.id}/>
+            </div>
         </Panel>
 
         <Panel>
@@ -648,7 +648,6 @@ export function DomainEditPage() {
         confirmHeader='Delete Domain?'
         onClick={handleDelete}
         obeyWROLMode={true}
-        style={{marginTop: '1em'}}
     >Delete</APIButton>;
 
     const refreshButton = domain?.directory ? (
@@ -657,7 +656,6 @@ export function DomainEditPage() {
             size='small'
             onClick={handleRefreshDomain}
             obeyWROLMode={true}
-            style={{marginTop: '1em'}}
         >Refresh</APIButton>
     ) : null;
 
@@ -666,7 +664,6 @@ export function DomainEditPage() {
         size='small'
         onClick={() => setTagEditModalOpen(true)}
         color='violet'
-        style={{marginTop: '1em'}}
     >Tag</Button>;
 
     const reorganizeButton = (
@@ -675,7 +672,6 @@ export function DomainEditPage() {
             size='small'
             onClick={() => setReorganizeModalOpen(true)}
             obeyWROLMode={true}
-            style={{marginTop: '1em'}}
         >Reorganize Files</APIButton>
     );
 

--- a/app/src/components/Channels.js
+++ b/app/src/components/Channels.js
@@ -209,10 +209,12 @@ export function ChannelEditPage() {
     const downloadMissingDataLabel = <>Download Missing Data<InfoPopup content={downloadMissingDataInfo}/></>;
 
     return <>
-        <BackButton/>
-        <Link to={`/videos/channel/${channel.id}/video`}>
-            <Button>Videos</Button>
-        </Link>
+        <div className='wrolpi-button-row'>
+            <BackButton/>
+            <Link to={`/videos/channel/${channel.id}/video`}>
+                <Button>Videos</Button>
+            </Link>
+        </div>
 
         {channel?.needs_reorganization && (
             <Message kind='warning' title='File Format Changed'>
@@ -419,7 +421,7 @@ export function ChannelNewPage() {
     }
 
     return <>
-        <BackButton/>
+        <div className='wrolpi-button-row'><BackButton/></div>
 
         <Panel>
             <Header as="h1">New Channel</Header>

--- a/app/src/components/Channels.js
+++ b/app/src/components/Channels.js
@@ -173,7 +173,6 @@ export function ChannelEditPage() {
         confirmHeader='Delete Channel?'
         onClick={handleDelete}
         obeyWROLMode={true}
-        style={{marginTop: '1em'}}
     >Delete</APIButton>;
 
     const refreshButton = <APIButton
@@ -181,7 +180,6 @@ export function ChannelEditPage() {
         size='small'
         onClick={handleRefreshChannel}
         obeyWROLMode={true}
-        style={{marginTop: '1em'}}
     >Refresh</APIButton>;
 
     const tagButton = <Button
@@ -189,7 +187,6 @@ export function ChannelEditPage() {
         size='small'
         onClick={() => setTagEditModalOpen(true)}
         role='primary'
-        style={{marginTop: '1em'}}
     >Tag</Button>;
 
     const reorganizeButton = (
@@ -198,7 +195,6 @@ export function ChannelEditPage() {
             size='small'
             onClick={() => setReorganizeModalOpen(true)}
             obeyWROLMode={true}
-            style={{marginTop: '1em'}}
         >Reorganize Files</APIButton>
     );
 

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -805,10 +805,36 @@ describe('a row of buttons', () => {
     const tagsIn = (text) => [...scannable(text).matchAll(TAG)].map(match => ({
         start: match.index,
         end: match.index + match[0].length,
+        // The name was not captured until a test needed to accept `Group` and `Modal.Actions` as
+        // rows: `ROW_COMPONENTS.has(undefined)` is false for every tag, so the list of components
+        // that lay out their own children silently accepted none of them.
+        name: match[2],
         attributes: match[3],
         closing: match[1] === '/',
         selfClosing: match[4] === '/',
     }));
+
+    /**
+     * The text inside the element opened by `open`, found by walking forward to its MATCHING close.
+     *
+     * Written as "slice to the first `</div>`" first, which is true of every row in the app today
+     * and is a false negative waiting to happen: one nested div -- an error-trigger wrapper, a
+     * format-picker span, the Cancel/Save pair the collection form now groups -- truncates the body,
+     * and every button after it goes unscanned.
+     */
+    const bodyOfElement = (text, tags, open) => {
+        let depth = 0;
+        for (const tag of tags) {
+            if (tag.start <= open.start || tag.selfClosing) continue;
+            if (tag.closing) {
+                if (depth === 0) return text.slice(open.end, tag.start);
+                depth -= 1;
+            } else {
+                depth += 1;
+            }
+        }
+        return text.slice(open.end);   // Unclosed; scan what is left rather than nothing.
+    };
 
     /**
      * The tag that encloses `index`: walk the tags before it backwards, letting a close push the
@@ -863,8 +889,40 @@ describe('a row of buttons', () => {
      */
     const ROW_CLASSES = [
         'wrolpi-button-row', 'wrolpi-modal-actions', 'wrolpi-confirm-actions', 'preview-toolbar-group',
+        // Two that predate `.wrolpi-button-row` and are already correct: the file browser's sticky
+        // footer, and its filter row.  Both are checked against the stylesheet below like the rest.
+        'sticky-footer', 'file-browser-filter-container',
     ];
-    const isRow = (tag) => !!tag && ROW_CLASSES.some(name => tag.attributes.includes(name));
+
+    /*
+     * Components that lay their own children out in a row.  A `Group` or a `ButtonGroup` is a row by
+     * construction, so a caller putting buttons in one has already answered the question.
+     */
+    const ROW_COMPONENTS = new Set(['Group', 'ButtonGroup', 'Row', 'Stack', 'Modal.Actions']);
+
+    /*
+     * An inline flex or grid with a gap of its own -- an anonymous row.  Several call sites write one
+     * rather than reach for a class, and they are not wrong; a scan that only knew about class names
+     * would report every one of them.
+     */
+    const INLINE_ROW = /display:\s*['"]?(?:flex|grid)/;
+    const isInlineRow = (attributes, text) => {
+        if (INLINE_ROW.test(attributes) && attributes.includes('gap')) return true;
+        /*
+         * `style={someStyle}` -- the style is a const somewhere above, so the attribute itself says
+         * nothing.  Resolving it matters: the seasons row on the dates selector is a four-column
+         * grid with a gap, declared exactly that way, and it would otherwise be reported forever.
+         */
+        const named = /style=\{(\w+)\}/.exec(attributes);
+        if (!named) return false;
+        const declared = new RegExp(`\\b${named[1]}\\s*=\\s*(\\{[^;]*?\\});`).exec(text);
+        return !!declared && INLINE_ROW.test(declared[1]) && declared[1].includes('gap');
+    };
+
+    const isRow = (tag, text = '') => !!tag && (
+        ROW_COMPONENTS.has(tag.name)
+        || ROW_CLASSES.some(name => tag.attributes.includes(name))
+        || isInlineRow(tag.attributes, text));
 
     it('lays every row out as a flex row with a gap', () => {
         // Otherwise the list above is just a list of names the scans below happen to accept.
@@ -895,11 +953,10 @@ describe('a row of buttons', () => {
             const where = path.relative(SRC, file);
 
             const blocks = actionFragments(text);
-            for (const tag of tagsIn(text)) {
+            const tags = tagsIn(text);
+            for (const tag of tags) {
                 if (!tag.closing && tag.attributes.includes('wrolpi-button-row')) {
-                    // A row holds buttons, not more divs, so its first `</div>` is its own.
-                    const closes = text.indexOf('</div>', tag.end);
-                    blocks.push(closes === -1 ? '' : text.slice(tag.end, closes));
+                    blocks.push(bodyOfElement(text, tags, tag));
                 }
             }
             rows += blocks.length;
@@ -963,7 +1020,7 @@ describe('a row of buttons', () => {
         expect(offenders).toEqual([]);
     });
 
-    it('never lists buttons as bare siblings', () => {
+    it('never lists interpolated buttons as bare siblings', () => {
         /*
          * The touching itself, and the reported defect: the archive page interpolated six buttons
          * one after another straight into its Panel, so every pair shared an edge.
@@ -972,6 +1029,8 @@ describe('a row of buttons', () => {
          * `actionButtons` fragment are blanked first -- a fragment is spread into its parent's row
          * and has no business being one itself, which the previous test is what checks.  Blanked
          * rather than skipped so every index still points where it did.
+         *
+         * The sibling test below covers the other way a row is written; this one only sees `{foo}`.
          */
         const offenders = [];
         let runs = 0;
@@ -999,6 +1058,55 @@ describe('a row of buttons', () => {
          * leave this reporting a clean app.
          */
         expect(runs).toBe(4);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('never lists written-out buttons as bare siblings either', () => {
+        /*
+         * The same claim for the other way a row is written.  The interpolation scan above sees
+         * `{fooButton}` and nothing else, and most of the app writes its buttons out in place --
+         * which is how the video page's Download/Delete/Refresh/AddToPlaylist strip, the direct
+         * analogue of the archive row this PR started with, went on touching after that scan
+         * reported the app clean.  Twelve more rows were in the same state, in table cells, on the
+         * controller page, and under the one-time-pad and ration calculators.
+         *
+         * A "row" is deliberately broad here: the class, a Group or ButtonGroup, or an inline
+         * flex/grid with a gap, including one whose style is a const declared above.  The point is
+         * whether the buttons are spaced by something, not whether they use this PR's class.
+         */
+        const offenders = [];
+        let runs = 0;
+
+        for (const file of sourceFiles()) {
+            let text = fs.readFileSync(file, 'utf8');
+            // A fragment is spread into its parent's row; the earlier test checks that parent.
+            for (const fragment of actionFragments(text)) {
+                text = text.replace(fragment, ' '.repeat(fragment.length));
+            }
+            const tags = tagsIn(text);
+
+            // A button element ending, then whitespace, then another button beginning.
+            const runPattern = /(?:<\/\w*Button>|<\w*Button\b[^>]*?\/>)\s*<\w*Button\b/g;
+            for (const match of scannable(text).matchAll(runPattern)) {
+                // Anchor on the SECOND button's `<`: at the first one's closing tag the pair is
+                // still open, and the walk would report the first button as its own parent.
+                const at = match.index + match[0].lastIndexOf('<');
+                runs += 1;
+                if (!isRow(enclosingTag(tags, at), text)) {
+                    offenders.push(`${path.relative(SRC, file)}:${
+                        text.slice(0, at).split('\n').length}`);
+                }
+            }
+        }
+
+        /*
+         * Around eighty, which is why this is a scan and not a list.  Asserted loosely at both ends
+         * -- tight enough that a pattern matching nothing shows up, loose enough that adding a
+         * button to an existing row is not a test failure.
+         */
+        expect(runs).toBeGreaterThan(60);
+        expect(runs).toBeLessThan(200);
 
         expect(offenders).toEqual([]);
     });

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -752,14 +752,8 @@ describe('PageContainer', () => {
          * naming components from other files, so the page cannot be resolved from one file's text.
          * That is `VideosTabLayout`, whose pages are clean today but are not covered here.
          */
-        const src = path.join(__dirname, '..');
-        const files = (dir) => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
-            const full = path.join(dir, entry.name);
-            if (entry.isDirectory()) return files(full);
-            if (!/\.jsx?$/.test(entry.name)) return [];
-            if (/\.(test|cy)\.jsx?$/.test(entry.name)) return [];
-            return [full];
-        });
+        const src = SRC;
+        const files = () => sourceFiles();
 
         const offenders = [];
         for (const file of files(src)) {
@@ -783,6 +777,241 @@ describe('PageContainer', () => {
 
         expect(offenders).toEqual([]);
     });
+});
+
+describe('a row of buttons', () => {
+    /*
+     * Semantic's Button brought `margin: 0 .25em .25em 0` with it, so a page could list buttons as
+     * bare siblings and they arrived both spaced and, when the row wrapped, separated.  Nothing
+     * replaced that margin.  The archive page's six actions shared edges, and two of them carried
+     * `marginTop: 0.5em` -- put there to keep a wrapped row from touching vertically, which instead
+     * made those two sit lower than the rest, because `vertical-align: middle` aligns the margin box.
+     *
+     * `.wrolpi-button-row` is a flex row with a gap, so it covers both axes at once and no button
+     * needs a margin of its own.  ui-layout.cy.js measures that the row really spaces and aligns
+     * what it holds; these two scans are about the row being REACHED and left alone -- neither of
+     * which throws, and both of which is how the app got here.
+     */
+
+    /*
+     * `=>` is blanked before any tag scanning.  An arrow function in a prop -- `onClick={() =>
+     * handleDelete(false)}`, which most of these buttons have -- puts a `>` inside an opening tag,
+     * and a scanner reading `>` as "tag ends here" splits one button into two bogus tags.  Two
+     * characters for two, so every index still points where it did in the original text.
+     */
+    const scannable = (text) => text.replace(/=>/g, '=~');
+
+    const TAG = /<(\/?)([A-Za-z][\w.]*)([^>]*?)(\/?)>/g;
+    const tagsIn = (text) => [...scannable(text).matchAll(TAG)].map(match => ({
+        start: match.index,
+        end: match.index + match[0].length,
+        attributes: match[3],
+        closing: match[1] === '/',
+        selfClosing: match[4] === '/',
+    }));
+
+    /**
+     * The tag that encloses `index`: walk the tags before it backwards, letting a close push the
+     * depth up and an open bring it back down, and stop at the first open that is still unclosed.
+     */
+    const enclosingTag = (tags, index) => {
+        let depth = 0;
+        for (const tag of [...tags].filter(tag => tag.end <= index).reverse()) {
+            if (tag.selfClosing) continue;
+            if (tag.closing) depth += 1;
+            else if (depth === 0) return tag;
+            else depth -= 1;
+        }
+        return null;
+    };
+
+    /**
+     * Every `const <name> = ...` declared at any indentation, as button consts are.
+     *
+     * Every one, not the first: Archive.js declares a `deleteButton` in the archive page and
+     * another in the domain edit page, and a resolver that stopped at the first found the clean one
+     * and reported the page with the margin on it as clean too.
+     */
+    const localBodiesOf = (text, name) => {
+        const pattern = new RegExp(`^[ \\t]*(?:const|let)\\s+${name}\\s*=`, 'gm');
+        return [...text.matchAll(pattern)].map(found => {
+            const after = text.slice(found.index + found[0].length);
+            const next = after.search(/\n[ \t]*(?:const|let|function|return|\})[\s(]/);
+            return next === -1 ? after : after.slice(0, next);
+        });
+    };
+
+    /** Every `const actionButtons = <>...</>` fragment in `text`: a button row under another name. */
+    const actionFragments = (text) => {
+        const bodies = [];
+        const pattern = /^[ \t]*const\s+actionButtons\s*=\s*<>/gm;
+        for (const found of text.matchAll(pattern)) {
+            const from = found.index + found[0].length;
+            const end = text.indexOf('</>', from);
+            if (end !== -1) bodies.push(text.slice(from, end));
+        }
+        return bodies;
+    };
+
+    const VERTICAL_MARGIN = /margin(?:Top|Bottom)\s*:|margin\s*:/;
+
+    /*
+     * The classes that lay buttons out in a row.  A row is a row whatever it is called -- the file
+     * preview's toolbar had one before this, at a tighter gap because its buttons are icons -- so
+     * the check below is "is this one of them", and the test after it is what keeps the list honest
+     * by reading each one out of the stylesheet and confirming it really is a flex row with a gap.
+     */
+    const ROW_CLASSES = [
+        'wrolpi-button-row', 'wrolpi-modal-actions', 'wrolpi-confirm-actions', 'preview-toolbar-group',
+    ];
+    const isRow = (tag) => !!tag && ROW_CLASSES.some(name => tag.attributes.includes(name));
+
+    it('lays every row out as a flex row with a gap', () => {
+        // Otherwise the list above is just a list of names the scans below happen to accept.
+        const stylesheets = ['components/ui/ui.css', 'App.css']
+            .map(name => fs.readFileSync(path.join(SRC, name), 'utf8')).join('\n');
+
+        ROW_CLASSES.forEach(name => {
+            const found = new RegExp(`\\.${name}\\s*\\{([^}]*)\\}`).exec(stylesheets);
+            // Named in the failure rather than passed to `expect`, which takes no message.
+            expect(found ? name : `${name} is not declared`).toBe(name);
+            expect(found[1]).toMatch(/display:\s*flex/);
+            expect(found[1]).toMatch(/gap:/);
+        });
+    });
+
+    it('never stamps a vertical margin on a button the row already spaces', () => {
+        /*
+         * The margin and the gap add up.  Nine buttons across the three collection edit pages had
+         * `marginTop: 1em` each and sat 1em below the Save button beside them; the archive page's
+         * Update and Generate Screenshot had 0.5em and sat half that below their own neighbours.
+         */
+        const offenders = [];
+        let rows = 0;
+        let resolved = 0;
+
+        for (const file of sourceFiles()) {
+            const text = fs.readFileSync(file, 'utf8');
+            const where = path.relative(SRC, file);
+
+            const blocks = actionFragments(text);
+            for (const tag of tagsIn(text)) {
+                if (!tag.closing && tag.attributes.includes('wrolpi-button-row')) {
+                    // A row holds buttons, not more divs, so its first `</div>` is its own.
+                    const closes = text.indexOf('</div>', tag.end);
+                    blocks.push(closes === -1 ? '' : text.slice(tag.end, closes));
+                }
+            }
+            rows += blocks.length;
+
+            for (const block of blocks) {
+                // A button declared inline in the row, style and all.
+                if (VERTICAL_MARGIN.test(block)) offenders.push(`${where}: inline in the row`);
+                // ...or interpolated by name, which is how most of them are written.
+                for (const name of new Set([...block.matchAll(/\{(\w*[Bb]utton\w*)\}/g)]
+                    .map(match => match[1]))) {
+                    for (const body of localBodiesOf(text, name)) {
+                        resolved += 1;
+                        if (VERTICAL_MARGIN.test(body)) offenders.push(`${where}: ${name}`);
+                    }
+                }
+            }
+        }
+
+        // A scan that found no rows, or resolved none of their buttons, reports a clean app.
+        expect(rows).toBeGreaterThan(3);
+        expect(resolved).toBeGreaterThan(8);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('puts every row of buttons in a row', () => {
+        /*
+         * The other half: a page can have margin-free buttons and still list them as bare siblings,
+         * which is the touching this fixes.  Every `{actionButtons}` is rendered somewhere, and the
+         * element it is rendered into is what has to carry the gap -- on the doc page that was a
+         * plain `<div style={{marginTop: '1em'}}>`, spacing the row from what was above it while
+         * leaving the buttons inside it edge to edge.
+         */
+        const offenders = [];
+        let sites = 0;
+
+        for (const file of sourceFiles()) {
+            const text = fs.readFileSync(file, 'utf8');
+            if (!text.includes('{actionButtons}')) continue;
+            const tags = tagsIn(text);
+
+            for (const found of text.matchAll(/\{actionButtons\}/g)) {
+                // `actionButtons={actionButtons}` is the prop being handed down, not a render.
+                if (text.slice(found.index - 14, found.index) === 'actionButtons=') continue;
+                sites += 1;
+                const parent = enclosingTag(tags, found.index);
+                if (!isRow(parent)) {
+                    offenders.push(`${path.relative(SRC, file)}: ${
+                        parent ? parent.attributes.trim().slice(0, 40) : 'no enclosing tag'}`);
+                }
+            }
+        }
+
+        /*
+         * Three: the shared collection edit form, which three pages hand a fragment to, and the doc
+         * page's own two responsive branches.  A scan that counted the `actionButtons={...}` props
+         * instead would reach eight and never look at a render site at all.
+         */
+        expect(sites).toBe(3);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('never lists buttons as bare siblings', () => {
+        /*
+         * The touching itself, and the reported defect: the archive page interpolated six buttons
+         * one after another straight into its Panel, so every pair shared an edge.
+         *
+         * A run of adjacent button interpolations is the shape to look for.  Runs inside an
+         * `actionButtons` fragment are blanked first -- a fragment is spread into its parent's row
+         * and has no business being one itself, which the previous test is what checks.  Blanked
+         * rather than skipped so every index still points where it did.
+         */
+        const offenders = [];
+        let runs = 0;
+
+        for (const file of sourceFiles()) {
+            let text = fs.readFileSync(file, 'utf8');
+            for (const fragment of actionFragments(text)) {
+                text = text.replace(fragment, ' '.repeat(fragment.length));
+            }
+            const tags = tagsIn(text);
+
+            for (const found of text.matchAll(/\{\w*[Bb]utton\w*\}(?:\s*\{\w*[Bb]utton\w*\})+/g)) {
+                runs += 1;
+                const parent = enclosingTag(tags, found.index);
+                if (!isRow(parent)) {
+                    offenders.push(`${path.relative(SRC, file)}: ${found[0].replace(/\s+/g, '')}`);
+                }
+            }
+        }
+
+        /*
+         * Four: the archive page's actions, the file preview's toolbar (which had a row of its own
+         * already), the downloads table's edit/restart pair, and the doc page's format picker
+         * beside its actions.  Asserted exactly, because a run that stopped being recognised would
+         * leave this reporting a clean app.
+         */
+        expect(runs).toBe(4);
+
+        expect(offenders).toEqual([]);
+    });
+});
+
+/** The app's own source, minus its tests: what a source scan is allowed to read. */
+const SRC = path.join(__dirname, '..');
+const sourceFiles = (dir = SRC) => fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    if (!/\.jsx?$/.test(entry.name)) return [];
+    if (/\.(test|cy)\.jsx?$/.test(entry.name)) return [];
+    return [full];
 });
 
 /**

--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -1002,6 +1002,41 @@ describe('a row of buttons', () => {
 
         expect(offenders).toEqual([]);
     });
+
+    it('puts every Back button in a row, so the page stack cannot stretch it', () => {
+        /*
+         * A page's blocks are stacked by `.wrolpi-stack`, which is a flex column at
+         * `align-items: stretch` -- deliberately, because a panel was full-width as a block
+         * element and has to stay that way.  A BARE button as a direct child of that stack is
+         * stretched too, and every page's Back button was one: full-page-width, and on the domain,
+         * channel and playlist edit pages the button beside it was pushed onto its own line where
+         * the two had been inline before.
+         *
+         * A row fixes it without touching the stack: the row is the stretched child, and it lays
+         * its buttons out at their own width.  Nine sites, so this scan rather than nine
+         * assertions -- and a scan because a stretched button is still a working button.
+         */
+        const offenders = [];
+        let found = 0;
+
+        for (const file of sourceFiles()) {
+            const text = fs.readFileSync(file, 'utf8');
+            const tags = tagsIn(text);
+
+            for (const match of text.matchAll(/<BackButton\b/g)) {
+                found += 1;
+                if (!isRow(enclosingTag(tags, match.index))) {
+                    offenders.push(`${path.relative(SRC, file)}:${
+                        text.slice(0, match.index).split('\n').length}`);
+                }
+            }
+        }
+
+        // Nine renders.  Common.js declares it, and a declaration is not a `<BackButton`.
+        expect(found).toBe(9);
+
+        expect(offenders).toEqual([]);
+    });
 });
 
 /** The app's own source, minus its tests: what a source scan is allowed to read. */

--- a/app/src/components/Docs.js
+++ b/app/src/components/Docs.js
@@ -83,7 +83,7 @@ function DocsPage() {
         setSelectedDocs([]);
     }
 
-    const selectElm = <div style={{marginTop: '0.5em'}}>
+    const selectElm = <div className='wrolpi-button-row' style={{marginTop: '0.5em'}}>
         <Button color='violet' disabled={_.isEmpty(selectedDocs)}
                 onClick={() => setBulkTagOpen(true)}>Tag</Button>
         <APIButton
@@ -339,7 +339,7 @@ function DocPage() {
     </table>;
 
     return <>
-        <BackButton/>
+        <div className='wrolpi-button-row'><BackButton/></div>
 
         {isCbz && activePath && <CbzViewer path={activePath}/>}
 

--- a/app/src/components/Docs.js
+++ b/app/src/components/Docs.js
@@ -403,13 +403,16 @@ function DocPage() {
                 return <>
                     <Media at='mobile'>
                         {formatButtons && <div style={{marginTop: '1em'}}>{formatButtons}</div>}
-                        <div style={{marginTop: '1em'}}>{actionButtons}</div>
+                        <div className='wrolpi-button-row' style={{marginTop: '1em'}}>
+                            {actionButtons}
+                        </div>
                     </Media>
                     <Media greaterThanOrEqual='tablet'>
-                        <div style={{marginTop: '1em'}}>
-                            {formatButtons && <span style={{marginRight: '1em', display: 'inline-block'}}>
-                                {formatButtons}
-                            </span>}
+                        {/* The row's own `margin-top` separates it from what is above; the gap
+                            inside it separates the format picker from the actions, so the span
+                            that used to hold them apart with `margin-right` is gone. */}
+                        <div className='wrolpi-button-row' style={{marginTop: '1em'}}>
+                            {formatButtons}
                             {actionButtons}
                         </div>
                     </Media>

--- a/app/src/components/Docs.js
+++ b/app/src/components/Docs.js
@@ -408,9 +408,16 @@ function DocPage() {
                         </div>
                     </Media>
                     <Media greaterThanOrEqual='tablet'>
-                        {/* The row's own `margin-top` separates it from what is above; the gap
-                            inside it separates the format picker from the actions, so the span
-                            that used to hold them apart with `margin-right` is gone. */}
+                        {/*
+                          * The format picker and the actions are one row, separated by its gap.
+                          *
+                          * This IS a change: the picker used to sit 1em from the actions, held
+                          * there by a span with `margin-right`, and it now sits at the row's
+                          * 0.625rem like everything else in a row.  The two groups read as slightly
+                          * closer than before.  Deliberate -- one spacing rule for buttons in a row
+                          * beats a second one for buttons in a row that happen to be a picker --
+                          * but it is a visual change and not a pure refactor.
+                          */}
                         <div className='wrolpi-button-row' style={{marginTop: '1em'}}>
                             {formatButtons}
                             {actionButtons}

--- a/app/src/components/FileBrowser.js
+++ b/app/src/components/FileBrowser.js
@@ -571,7 +571,6 @@ export function FileBrowser() {
                 onClick={onCollapseAll}
                 disabled={!openFolders || openFolders.length === 0}
                 label='Close all folders'
-                style={{marginLeft: '0.5em'}}
             />
         </div>
         <FileBrowserContent

--- a/app/src/components/Playlists.js
+++ b/app/src/components/Playlists.js
@@ -313,13 +313,15 @@ function PlaylistItemsTable({items, editable, onMove, onRemove}) {
                     <Table.Cell>
                         <ItemTitle item={item} label={label}/>
                     </Table.Cell>
-                    {editable && <Table.Cell style={{textAlign: 'right', whiteSpace: 'nowrap'}}>
-                        <Button icon='arrow up' size='xs' disabled={index === 0}
-                                onClick={() => onMove(index, -1)}/>
-                        <Button icon='arrow down' size='xs' disabled={index === items.length - 1}
-                                onClick={() => onMove(index, 1)}/>
-                        <Button role='danger' icon='trash' size='xs'
-                                onClick={() => onRemove(item.id)}/>
+                    {editable && <Table.Cell>
+                        <div className='wrolpi-button-row' style={{justifyContent: 'flex-end'}}>
+                            <Button icon='arrow up' size='xs' disabled={index === 0}
+                                    onClick={() => onMove(index, -1)}/>
+                            <Button icon='arrow down' size='xs' disabled={index === items.length - 1}
+                                    onClick={() => onMove(index, 1)}/>
+                            <Button role='danger' icon='trash' size='xs'
+                                    onClick={() => onRemove(item.id)}/>
+                        </div>
                     </Table.Cell>}
                 </Table.Row>;
             })}

--- a/app/src/components/Playlists.js
+++ b/app/src/components/Playlists.js
@@ -479,7 +479,6 @@ export function PlaylistEditPage() {
         confirmHeader='Delete Playlist?'
         onClick={handleDelete}
         obeyWROLMode={true}
-        style={{marginTop: '1em'}}
     >Delete</APIButton>;
 
     const tagButton = <Button
@@ -488,7 +487,6 @@ export function PlaylistEditPage() {
         onClick={() => setTagModalOpen(true)}
         role='primary'
         disabled={!editable}
-        style={{marginTop: '1em'}}
     >Tag</Button>;
 
     const actionButtons = <>

--- a/app/src/components/Playlists.js
+++ b/app/src/components/Playlists.js
@@ -346,7 +346,7 @@ export function PlaylistViewPage() {
     const items = playlist.items || [];
 
     return <>
-        <BackButton/>
+        <div className='wrolpi-button-row'><BackButton/></div>
 
         <Header as='h1'>
             {playlist.name}
@@ -498,10 +498,12 @@ export function PlaylistEditPage() {
     const form = {error: null, loading: false, disabled: !editable || !name.trim(), ready: true};
 
     return <>
-        <BackButton/>
-        <Link to={`/playlists/${playlistId}`}>
-            <Button>View</Button>
-        </Link>
+        <div className='wrolpi-button-row'>
+            <BackButton/>
+            <Link to={`/playlists/${playlistId}`}>
+                <Button>View</Button>
+            </Link>
+        </div>
 
         <CollectionEditForm
             form={form}

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -332,9 +332,30 @@ export function ThemeSamplePage() {
                         </div>)}
                     </Row>
                 </div>
+                <div style={{marginTop: 12}}>
+                    <Header as='h5'>A row of actions</Header>
+                    {/* `.wrolpi-button-row` is how a page lists the actions on a thing -- the
+                        archive page's View/Read/Update/Delete, the edit pages' action row. It
+                        wraps, so the last button drops to a second line at this width instead of
+                        overflowing, and the row gap keeps the two lines apart. */}
+                    <div className='wrolpi-button-row' style={{maxWidth: 320}}>
+                        <Button color='violet'>View</Button>
+                        <Button color='blue'>Read</Button>
+                        <Button role='save'>Update</Button>
+                        <Button role='danger'>Delete</Button>
+                        <Button color='yellow'>Generate Screenshot</Button>
+                    </div>
+                </div>
                 <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     In night mode Delete drops its fill for a dashed red outline; dashed means
                     destructive or failed, and nothing else uses it.
+                </p>
+                <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
+                    Buttons in a row are spaced by the row, never by margins of their own. Semantic's
+                    Button brought its own margin and nothing replaced it, so pages that listed
+                    buttons as bare siblings had them sharing edges — and the ones that answered with
+                    <code>margin-top</code> got a button sitting lower than its neighbours instead,
+                    because <code>vertical-align: middle</code> is measured on the margin box.
                 </p>
                 <p style={{fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 0}}>
                     An icon button is exactly as tall as a labelled one at every size, so a

--- a/app/src/components/VideoPlayer.js
+++ b/app/src/components/VideoPlayer.js
@@ -485,7 +485,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
                     </Link>}
                 </h3>
 
-                <p>
+                <div className='wrolpi-button-row'>
                     <Button component='a' href={downloadUrl} icon='download'>
                         Download
                     </Button>
@@ -503,7 +503,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
                         disabled={!videoFile.url}
                     >Refresh</APIButton>
                     <AddToPlaylistButton fileGroupId={videoFile.id}/>
-                </p>
+                </div>
             </Panel>
 
             <Panel>

--- a/app/src/components/VideoPlayer.js
+++ b/app/src/components/VideoPlayer.js
@@ -397,7 +397,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
     const audioPlayPauseLabel = audioPlaying ? 'Pause' : 'Play';
 
     return <>
-        <div style={{margin: '1em'}}>
+        <div className='wrolpi-button-row' style={{margin: '1em'}}>
             <BackButton/>
         </div>
 

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -175,7 +175,7 @@ export function VideosPage() {
         setSelectedVideos([]);
     }
 
-    const selectElm = <div style={{marginTop: '0.5em'}}>
+    const selectElm = <div className='wrolpi-button-row' style={{marginTop: '0.5em'}}>
         <Button
             role='primary'
             disabled={_.isEmpty(selectedVideos)}

--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -286,6 +286,7 @@ function MobileServiceRow({service, onAction}) {
                     <div style={{fontSize: '0.9em', color: 'var(--muted)'}}>{service.description}</div>}
             </Table.Cell>
             <Table.Cell numeric>
+                <div className='wrolpi-button-row' style={{justifyContent: 'flex-end'}}>
                 {isRunning ? (
                     <IconButton
                         icon='stop'
@@ -319,6 +320,7 @@ function MobileServiceRow({service, onAction}) {
                     role='primary'
                     onClick={handleViewLogs}
                 />
+                </div>
                 <ServiceLogsModal
                     service={service}
                     logsOpen={logsOpen}
@@ -366,6 +368,7 @@ function DesktopServiceRow({service, onAction, dockerized}) {
             </Table.Cell>
             <Table.Cell>{service.port || '-'}</Table.Cell>
             <Table.Cell>
+                <div className='wrolpi-button-row'>
                 {isRunning ? (
                     <IconButton
                         icon='stop'
@@ -399,6 +402,7 @@ function DesktopServiceRow({service, onAction, dockerized}) {
                     role='primary'
                     onClick={handleViewLogs}
                 />
+                </div>
                 <ServiceLogsModal
                     service={service}
                     logsOpen={logsOpen}
@@ -1575,7 +1579,7 @@ function HotspotSettingsForm() {
                 onChange={(value) => setForm({...form, protocol: value})}
             />
         </Group>
-        <div style={{marginTop: '0.8em'}}>
+        <div className='wrolpi-button-row' style={{marginTop: '0.8em'}}>
             <Button
                 color='violet'
                 disabled={dockerized}
@@ -1586,7 +1590,6 @@ function HotspotSettingsForm() {
                 icon='qrcode'
                 label='Scan this code to join the hotspot'
                 color='violet'
-                style={{marginLeft: '0.5em'}}
                 onClick={() => setQrOpen(true)}
             />
             <Modal size='small' open={qrOpen} onClose={() => setQrOpen(false)} closeIcon>
@@ -1620,7 +1623,7 @@ function AdminControlsSection() {
             <HotspotSettingsForm/>
 
             {!dockerized && (
-                <div style={{marginTop: '1em'}}>
+                <div className='wrolpi-button-row' style={{marginTop: '1em'}}>
                     <RestartButton/>
                     <ShutdownButton/>
                 </div>

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -612,6 +612,7 @@ export function OnceDownloadsTable({downloads, fetchDownloads}) {
     const footer = <Table.Footer>
         <Table.Row>
             <Table.HeaderCell colSpan={4}>
+                <div className='wrolpi-button-row'>
                 <ClearDownloadsButton
                     callback={fetchDownloads}
                     selectedIds={selectedIds}
@@ -627,6 +628,7 @@ export function OnceDownloadsTable({downloads, fetchDownloads}) {
                     selectedIds={selectedIds}
                     clearSelection={clearSelection}
                 />
+                </div>
             </Table.HeaderCell>
         </Table.Row>
     </Table.Footer>;

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -329,10 +329,14 @@ function RecurringDownloadRow({download, fetchDownloads, onDelete}) {
             {download.progress && <DownloadProgressModal progress={download.progress} url={download.url}/>}
         </Table.Cell>
         <Table.Cell>{next}</Table.Cell>
-        <Table.Cell style={{textAlign: 'right'}}>
-            {error && !download.progress && errorTrigger}
-            {editButton}
-            {restartButton}
+        <Table.Cell>
+            {/* `justify-content` rather than the cell's `text-align: right`, which a flex row
+                does not answer to.  These two are icon buttons and were sharing an edge. */}
+            <div className='wrolpi-button-row' style={{justifyContent: 'flex-end'}}>
+                {error && !download.progress && errorTrigger}
+                {editButton}
+                {restartButton}
+            </div>
         </Table.Cell>
         {errorModal}
         {editModal}

--- a/app/src/components/calculators/OneTimePadCalculator.js
+++ b/app/src/components/calculators/OneTimePadCalculator.js
@@ -155,10 +155,12 @@ export function OneTimePadCalculator() {
         <Header as='h4'>One-Time Pads can be used to encrypt your communications. This can be done by hand
             (yes, really) or in this app.</Header>
         <p>These messages are never stored and cannot be retrieved.</p>
-        <Button color='violet' disabled={!activeChars} onClick={handleGenerateNewPad}>
-            Generate New Pad
-        </Button>
-        <Button role='cancel' component='a' href={cheatSheetURL}>Cheat Sheet PDF</Button>
+        <div className='wrolpi-button-row'>
+            <Button color='violet' disabled={!activeChars} onClick={handleGenerateNewPad}>
+                Generate New Pad
+            </Button>
+            <Button role='cancel' component='a' href={cheatSheetURL}>Cheat Sheet PDF</Button>
+        </div>
 
         <SimpleAccordion title='Advanced'>
             <Header as='h4'>Pad characters</Header>

--- a/app/src/components/calculators/RationCalculator.js
+++ b/app/src/components/calculators/RationCalculator.js
@@ -283,15 +283,17 @@ function SupplyPlan({name, items, fields, caloriesKey, countKey, currentDays, to
                             {projectedDays ? <> to reach about <strong>{formatDuration(projectedDays)}</strong> of food.</> : '.'}
                         </p>
 
-                        <Button role='primary' icon='download'
-                                onClick={() => downloadCSV(
-                                    inventoryExportFilename(`${name || 'inventory'} shopping list`, 'csv'),
-                                    shoppingListCSV(sortedRows))}>
-                            Download CSV
-                        </Button>
-                        <Button icon='print' onClick={printShoppingList}>
-                            Print / Save as PDF
-                        </Button>
+                        <div className='wrolpi-button-row'>
+                            <Button role='primary' icon='download'
+                                    onClick={() => downloadCSV(
+                                        inventoryExportFilename(`${name || 'inventory'} shopping list`, 'csv'),
+                                        shoppingListCSV(sortedRows))}>
+                                Download CSV
+                            </Button>
+                            <Button icon='print' onClick={printShoppingList}>
+                                Print / Save as PDF
+                            </Button>
+                        </div>
 
                         {/* Hidden printable block — `printShoppingList` makes this the only thing printed. */}
                         <ShoppingListPrint name={name} rows={sortedRows}

--- a/app/src/components/collections/CollectionEditForm.js
+++ b/app/src/components/collections/CollectionEditForm.js
@@ -70,23 +70,30 @@ export function CollectionEditForm({
                   */}
                 <div className='wrolpi-button-row'>
                     {actionButtons}
-                    {onCancel && <Button
-                        type='button'
-                        role='cancel'
-                        onClick={onCancel}
-                        disabled={form.disabled}
-                    >
-                        Cancel
-                    </Button>}
-                    <Button
-                        type='submit'
-                        role='save'
-                        size='lg'
-                        style={{marginLeft: 'auto'}}
-                        disabled={form.disabled}
-                    >
-                        Save
-                    </Button>
+                    {/*
+                      * Cancel and Save travel together, in a row of their own pushed to the end.
+                      * `margin-left: auto` was on Save alone, which was right for a row that could
+                      * not wrap: now that it can, Save would drop onto a second line by itself,
+                      * flush right, with Cancel left behind among the action buttons.
+                      */}
+                    <div className='wrolpi-button-row' style={{marginInlineStart: 'auto'}}>
+                        {onCancel && <Button
+                            type='button'
+                            role='cancel'
+                            onClick={onCancel}
+                            disabled={form.disabled}
+                        >
+                            Cancel
+                        </Button>}
+                        <Button
+                            type='submit'
+                            role='save'
+                            size='lg'
+                            disabled={form.disabled}
+                        >
+                            Save
+                        </Button>
+                    </div>
                 </div>
             </div>
         </form>

--- a/app/src/components/collections/CollectionEditForm.js
+++ b/app/src/components/collections/CollectionEditForm.js
@@ -60,14 +60,21 @@ export function CollectionEditForm({
 
                 {appliedTagName && <div><SingleTag name={appliedTagName}/></div>}
 
-                <div style={{display: 'flex', alignItems: 'center', gap: 10}}>
+                {/*
+                  * The shared row.  It was already a flex row at this gap, but it did not wrap, so
+                  * the pages that hand it four action buttons ran out of width on a phone -- which
+                  * is why each of those buttons, and the Cancel below, carried `margin-top: 1em`.
+                  * That margin is what made them sit lower than Save, `vertical-align: middle`
+                  * being measured on the margin box.  Wrapping plus a row gap covers the case the
+                  * margin was for, in the axis it actually happens in.
+                  */}
+                <div className='wrolpi-button-row'>
                     {actionButtons}
                     {onCancel && <Button
                         type='button'
                         role='cancel'
                         onClick={onCancel}
                         disabled={form.disabled}
-                        className="action-button-spacing"
                     >
                         Cancel
                     </Button>}

--- a/app/src/components/collections/CollectionEditForm.test.js
+++ b/app/src/components/collections/CollectionEditForm.test.js
@@ -253,18 +253,28 @@ describe('CollectionEditForm', () => {
     });
 
     describe('CSS Classes', () => {
-        it('uses action-button-spacing class for cancel button', () => {
+        it('puts its actions in a button row, and leaves their margins alone', () => {
+            /*
+             * `action-button-spacing` was `margin-top: 1em` on Cancel alone, matching the same
+             * margin the three calling pages stamped on each of their action buttons -- so every
+             * button in this row sat 1em below the Save beside it, which has none.  The row spaces
+             * and wraps them now, and nothing in it carries a margin of its own.
+             */
             const form = createTestForm(mockCollection);
             const mockOnCancel = jest.fn();
 
-            render(
+            const {container} = render(
                 <CollectionEditForm form={form} onCancel={mockOnCancel}>
                     <div>Form content</div>
                 </CollectionEditForm>
             );
 
             const cancelButton = screen.getByRole('button', {name: /cancel/i});
-            expect(cancelButton).toHaveClass('action-button-spacing');
+            const row = container.querySelector('.wrolpi-button-row');
+            expect(row).toBeInTheDocument();
+            expect(row).toContainElement(cancelButton);
+            expect(row).toContainElement(screen.getByRole('button', {name: /save/i}));
+            expect(cancelButton).not.toHaveClass('action-button-spacing');
         });
     });
 });

--- a/app/src/components/inventory/FieldSchemaEditor.js
+++ b/app/src/components/inventory/FieldSchemaEditor.js
@@ -81,10 +81,12 @@ export function FieldSchemaEditor({fields, open, onClose, onSave}) {
                 <Table.Body>
                     {draft.map((f, index) => <Table.Row key={index}>
                         <Table.Cell>
-                            <IconButton size='xs' icon='arrow up' onClick={() => move(index, -1)}
-                                        disabled={index === 0} label='Move up'/>
-                            <IconButton size='xs' icon='arrow down' onClick={() => move(index, 1)}
-                                        disabled={index === draft.length - 1} label='Move down'/>
+                            <div className='wrolpi-button-row'>
+                                <IconButton size='xs' icon='arrow up' onClick={() => move(index, -1)}
+                                            disabled={index === 0} label='Move up'/>
+                                <IconButton size='xs' icon='arrow down' onClick={() => move(index, 1)}
+                                            disabled={index === draft.length - 1} label='Move down'/>
+                            </div>
                         </Table.Cell>
                         <Table.Cell>
                             <TextInput value={f.label || ''} placeholder='Label'
@@ -121,11 +123,13 @@ export function FieldSchemaEditor({fields, open, onClose, onSave}) {
                     </Table.Row>)}
                 </Table.Body>
             </Table>
-            <Button icon='plus' onClick={add}>Add Field</Button>
-            <Button icon='balance scale' onClick={addCountByWeight}
-                    title='Add Unit Weight, Total Weight, and an auto-counted Count'>
-                Count by Weight
-            </Button>
+            <div className='wrolpi-button-row'>
+                <Button icon='plus' onClick={add}>Add Field</Button>
+                <Button icon='balance scale' onClick={addCountByWeight}
+                        title='Add Unit Weight, Total Weight, and an auto-counted Count'>
+                    Count by Weight
+                </Button>
+            </div>
         </Modal.Content>
         <Modal.Actions>
             <Button role='cancel' onClick={onClose}>Cancel</Button>

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -390,6 +390,32 @@ describe('a row of buttons is spaced and aligned by the row', () => {
         });
     });
 
+    it('keeps its buttons their own width inside a page stack', () => {
+        /*
+         * `.wrolpi-stack` is a flex column at `align-items: stretch`, which is what keeps a panel
+         * full-width as it was as a block element -- and which stretched every page's Back button
+         * to the full width of the page, because a bare button was a direct child of it.
+         *
+         * The row is what absorbs that: the ROW is the stretched child, and it lays its buttons out
+         * at their own width.  Both halves are asserted, because a row that also refused to stretch
+         * would pass a test that only looked at the button.
+         */
+        cy.mountUI(<div className='wrolpi-stack'>
+            <div className='wrolpi-button-row'><Button>Back</Button></div>
+            <Panel>The page</Panel>
+        </div>);
+
+        cy.get('.wrolpi-stack').should(($stack) => {
+            const stack = $stack[0].getBoundingClientRect();
+            const row = $stack[0].querySelector('.wrolpi-button-row').getBoundingClientRect();
+            const button = $stack[0].querySelector('button').getBoundingClientRect();
+
+            expect(stack.width, 'the stack has a width to fill').to.be.greaterThan(200);
+            expect(row.width, 'the row stretches, as the panel does').to.be.closeTo(stack.width, 0.5);
+            expect(button.width, 'the button does not').to.be.lessThan(stack.width / 2);
+        });
+    });
+
     it('grows its gap with the interface scale', () => {
         cy.mountUI(<div className='wrolpi-button-row'><Button>One</Button><Button>Two</Button></div>);
 

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -277,6 +277,136 @@ describe('a page stacks its own blocks', () => {
     });
 });
 
+describe('a row of buttons is spaced and aligned by the row', () => {
+    /*
+     * Semantic's Button carried `margin: 0 .25em .25em 0` of its own, so a page could list
+     * buttons as bare siblings and they arrived spaced.  Nothing replaced that margin, and
+     * five pages still list them that way -- the archive page's six actions all shared edges.
+     *
+     * Two of those six also carried `marginTop: 0.5em`, which is what made "Update" sit lower
+     * than its neighbours: a Button is `display: inline-flex; vertical-align: middle`, and
+     * `vertical-align` aligns the MARGIN box, so half of any top margin pushes the visible
+     * button down.  The margin was there to keep a wrapped row from touching vertically --
+     * the right thing, solved in the wrong axis.  A flex row with `gap` covers both axes and
+     * needs no per-button margin, so the alignment comes back for free.
+     */
+
+    const rowButtons = ($row) => [...$row[0].querySelectorAll('button')];
+
+    it('puts a gap between the buttons, horizontally and when wrapped', () => {
+        cy.mountUI(<div className='wrolpi-button-row'>
+            <Button>View</Button>
+            <Button>Read</Button>
+            <Button>Update</Button>
+        </div>);
+
+        cy.get('.wrolpi-button-row').should(($row) => {
+            const row = $row[0];
+            const styles = getComputedStyle(row);
+            const declared = parseFloat(styles.columnGap);
+            expect(declared, 'the row declares a gap').to.be.greaterThan(0);
+            expect(parseFloat(styles.rowGap), 'and the same one between wrapped lines')
+                .to.be.closeTo(declared, 0.5);
+            expect(styles.flexWrap, 'the row wraps rather than overflowing').to.equal('wrap');
+
+            /*
+             * Narrowed to exactly two buttons' worth, measured rather than guessed.  A hardcoded
+             * 150px was a hidden assertion about both the font and the interface scale, and at 1.1
+             * it fitted one button, not the two the assertions below are about.
+             */
+            const widths = rowButtons($row).map(el => el.getBoundingClientRect().width);
+            expect(widths, 'three buttons measured').to.have.length(3);
+            row.style.width = `${widths[0] + declared + widths[1] + 1}px`;
+
+            const rects = rowButtons($row).map(el => el.getBoundingClientRect());
+            const top = Math.min(...rects.map(rect => rect.top));
+            const first = rects.filter(rect => Math.round(rect.top) === Math.round(top));
+            expect(first, 'two buttons on the first line').to.have.length(2);
+            expect(first[1].left - first[0].right, 'gap along the line').to.be.closeTo(declared, 0.5);
+
+            // And the third dropped to a second line, held off the first by the same gap.
+            const wrapped = rects.find(rect => Math.round(rect.top) !== Math.round(top));
+            expect(wrapped, 'the third button wrapped').to.not.be.undefined;
+            expect(wrapped.top - first[0].bottom, 'gap between the lines')
+                .to.be.closeTo(declared, 0.5);
+        });
+    });
+
+    it('centres its buttons against a taller item beside them', () => {
+        /*
+         * A row is not always all buttons: the doc page puts its format picker beside its actions,
+         * and the downloads table an error trigger beside its two icon buttons.  Whatever is
+         * tallest sets the line height, and `align-items: center` is what keeps the buttons reading
+         * as part of that line rather than hanging from the top of it.
+         *
+         * Written as tops first, which was a test with no teeth -- `stretch` stretches the WRAPPER
+         * and leaves the button at the top of it, so the tops agreed either way.  Centres are what
+         * the property actually decides.
+         *
+         * The row is also mixed in the way the archive page's is: a button inside an `<a>`, a bare
+         * one, and an APIButton.
+         */
+        cy.mountUI(<div className='wrolpi-button-row'>
+            <div style={{height: '80px', width: '40px'}}>Tall</div>
+            <a href='/media/archive.html'><Button>View</Button></a>
+            <Button>Read</Button>
+            <APIButton onClick={() => Promise.resolve()}>Update</APIButton>
+        </div>);
+
+        cy.get('.wrolpi-button-row').should(($row) => {
+            const row = $row[0].getBoundingClientRect();
+            expect(row.height, 'the tall item set the line height').to.be.at.least(80);
+
+            const centers = rowButtons($row).map((el) => {
+                const rect = el.getBoundingClientRect();
+                return rect.top + rect.height / 2;
+            });
+            expect(centers, 'three buttons measured').to.have.length(3);
+            const middle = row.top + row.height / 2;
+            centers.forEach(center => expect(center, 'centred in the line').to.be.closeTo(middle, 1));
+        });
+    });
+
+    it('counts a confirmed action as one item in the row, not two', () => {
+        /*
+         * `APIButton` with `confirmContent` returns a fragment -- the button AND a `<Confirm/>`.
+         * In a flex row those flatten into siblings, so a Confirm that rendered anything in
+         * place would take a gap of its own and open a hole between two buttons.  It portals,
+         * and this is what says so; three of the archive page's six actions are confirmed.
+         */
+        cy.mountUI(<div className='wrolpi-button-row'>
+            <Button>Plain</Button>
+            <APIButton confirmContent='Sure?' onClick={() => Promise.resolve()}>Delete</APIButton>
+            <Button>Also plain</Button>
+        </div>);
+
+        cy.get('.wrolpi-button-row').should(($row) => {
+            const declared = parseFloat(getComputedStyle($row[0]).columnGap);
+            const rects = rowButtons($row).map(el => el.getBoundingClientRect());
+            expect(rects, 'three buttons measured').to.have.length(3);
+            rects.slice(1).forEach((rect, index) => expect(
+                rect.left - rects[index].right, 'gap either side of the confirmed action',
+            ).to.be.closeTo(declared, 0.5));
+        });
+    });
+
+    it('grows its gap with the interface scale', () => {
+        cy.mountUI(<div className='wrolpi-button-row'><Button>One</Button><Button>Two</Button></div>);
+
+        cy.get('.wrolpi-button-row').should(($row) => {
+            const before = parseFloat(getComputedStyle($row[0]).columnGap);
+            const root = Cypress.$('html')[0];
+            const scale = parseFloat(getComputedStyle(root).getPropertyValue('--ui-scale')) || 1;
+            root.style.setProperty('--ui-scale', String(scale * 2));
+            const after = parseFloat(getComputedStyle($row[0]).columnGap);
+            root.style.removeProperty('--ui-scale');
+
+            expect(before, 'the gap exists at all').to.be.greaterThan(0);
+            expect(after / before, 'and doubles with the scale').to.be.closeTo(2, 0.05);
+        });
+    });
+});
+
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
     const value = hex.replace('#', '');

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1306,6 +1306,36 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     gap: 1rem;
 }
 
+/*
+ * The same idea along the other axis: a row of buttons, spaced by the row.
+ *
+ * Semantic's Button carried `margin: 0 .25em .25em 0`, so a page could list buttons as bare
+ * siblings and they arrived both spaced and, when the row ran out of width, separated from the line
+ * below.  Nothing replaced that margin -- the archive page's six actions shared edges, and the
+ * downloads table's two icon buttons did too.
+ *
+ * Two of the archive page's six had `marginTop: 0.5em` instead, which is where the "Update sits
+ * lower than the rest" came from: a Button is `display: inline-flex; vertical-align: middle`, and
+ * `vertical-align` aligns the MARGIN box, so half of any top margin shows up as the visible button
+ * dropping.  The margin was solving the wrapped-row case in the only axis a margin can, and paying
+ * for it in the other one.  A gap covers both at once, so no button needs a margin of its own; the
+ * scans in Common.test.js are what keep them from growing back.
+ *
+ * 0.625rem matches `.wrolpi-modal-actions`, which is the same row in a modal footer.
+ */
+.wrolpi-button-row {
+    display: flex;
+    flex-wrap: wrap;
+    /*
+     * Centred, not stretched.  Rows here are not all buttons -- the doc page puts its format
+     * picker beside its actions, and the downloads table its error trigger -- and a taller item
+     * makes the line taller than a button.  `stretch` would leave the buttons hanging from the
+     * top of it; centring keeps a row of unequal things reading as one line.
+     */
+    align-items: center;
+    gap: 0.625rem;
+}
+
 /* ----------------------------------------------------------------- Panels */
 
 .wrolpi-panel {


### PR DESCRIPTION
The archive page's six actions were touching, and Update sat lower than the rest. Both are the same defect.

Semantic's Button carried `margin: 0 .25em .25em 0`, so a page could list buttons as bare siblings and they arrived spaced — and separated from the line below when the row wrapped. Nothing replaced that margin when Semantic came out.

Two of those six answered with `marginTop: 0.5em`, which is the wrong axis. A Button is `display: inline-flex; vertical-align: middle`, and `vertical-align` is measured on the **margin** box, so half of any top margin shows up as the visible button dropping. The margin was covering the wrapped-row case in the only axis a margin can, and paying for it in the other one.

## The fix

`.wrolpi-button-row` — a flex row with a gap, wrapping, items centred. Both axes at once, so no button needs a margin of its own. It is the same rule as `.wrolpi-stack` from the last PR, along the other axis, at the 0.625rem gap `.wrolpi-modal-actions` already uses.

Applied to the five rows in the app that had no gap:

| Where | Was |
|---|---|
| Archive page actions | six bare siblings; two with `marginTop: 0.5em` |
| Collection edit form (domains, channels, playlists) | a flex row that did not wrap, so nine action buttons plus Cancel each carried `margin-top: 1em` — and sat 1em below the Save beside them, which had none |
| Doc page, both responsive branches | bare siblings in a plain div; a `<span>` held the format picker apart with `margin-right` |
| Downloads table | two icon buttons sharing an edge |

`.action-button-spacing` is gone with them — it was that same `margin-top: 1em`, on Cancel.

The downloads cell moved from `text-align: right` to `justify-content: flex-end`, which is what a flex row answers to.

## Guards

**ui-layout.cy.js**, four tests, real layout: the row spaces what it holds and wraps rather than overflowing; it centres its buttons against a taller item beside them; a confirmed `APIButton` counts as one item rather than two (it returns a fragment holding a `<Confirm/>`, which would open a hole in the row if it did not portal); the gap grows with the interface scale.

The wrap test narrows the row to two buttons' width **measured** rather than guessed — I wrote 150px first, which was a hidden assertion about the font and the scale, and at 1.1 it fitted one button rather than the two the assertions were about.

The centring test was tops-agree first, and had no teeth: `stretch` stretches the *wrapper* and leaves the button at the top of it, so the tops agreed either way. Centres are what the property actually decides, and the comment in ui.css that claimed otherwise is corrected. Verified by deleting `align-items` and watching it fail.

**Common.test.js**, three source scans, because neither failure mode throws:

- no button inside a row stamps a vertical margin — caught all ten before the fix
- every row of buttons is in a row, checked by walking tags backwards to the enclosing element
- no run of adjacent button interpolations sits outside one — this is the reported defect, and it names the archive page when I rename the class away

A fourth reads each row class out of the stylesheet and confirms it really is a flex row with a gap, so the list of accepted class names cannot become a list of names the scans merely tolerate. `preview-toolbar-group` is on it: the file preview's toolbar was already a correct row under a different name, at a tighter gap because its buttons are icons.

Two scanner bugs worth recording. The resolver took the *first* `const deleteButton` in a file, and Archive.js has two — the archive page's, which was clean, and the domain page's, which was not; it reported the offender as clean. And `=>` in a prop puts a `>` inside an opening tag, which splits one button into two bogus tags, so arrows are blanked before any tag scanning.

## Verified

1152 jest tests / 65 suites, 263 component tests in ui-layout, 50 e2e including `domains/domain-edit.cy.js`, clean `npm run build` with no new lint warnings. Full component run sits at the pre-existing baseline of 12 failures (Tags, Channels, Download, Inventory) — the Channels one is a missing context provider in the mount, unrelated.

The gallery gets the row, under Buttons, narrowed so it visibly wraps.

## Not verified

No browser. These are measured by tests and read, not looked at. `/archives/:id`, `/archives/domain/:id`, `/videos/channel/:id/edit`, `/playlists/:id/edit`, `/docs/:id` and `/admin/downloads` are the pages that changed.

One judgment call: the doc page's tablet branch loses the `<span>` that held its format picker 1em from the actions, so that spacing drops to the row's 0.625rem like everything else in the row. If the picker should read as a separate group there, that wants saying in one place rather than as a margin on the span.