### PR TITLE
ui: an input goes under its label, not beside it

### DIFF
--- a/app/src/hooks/useForm.js
+++ b/app/src/hooks/useForm.js
@@ -356,8 +356,15 @@ export function InputForm({
         </Message>;
     }
 
-    return <>
-        <label htmlFor={`${name}_input`}>
+    /*
+     * One element, not a fragment: every caller that puts an InputForm in a grid or flex
+     * container was getting the label and the input laid out as two separate items -- the
+     * input beside its own label rather than under it.  The label is block with the same
+     * 4px gap the migrated fields (Download.js FieldLabel) use, so an InputForm and a
+     * DestinationForm side by side line their inputs up at the same height.
+     */
+    return <div>
+        <label htmlFor={`${name}_input`} style={{display: 'block', marginBottom: 4}}>
             <b>{label} {required && <RequiredAsterisk/>}</b>
             {helpContent &&
                 <InfoPopup
@@ -375,7 +382,7 @@ export function InputForm({
             />
         </div>
         {messageElm}
-    </>
+    </div>
 }
 
 export function NumberInputForm({

--- a/app/src/hooks/useForm.test.js
+++ b/app/src/hooks/useForm.test.js
@@ -944,6 +944,44 @@ describe('Form Components', () => {
             const input = screen.getByRole('textbox');
             expect(input).toBeDisabled();
         });
+
+        it('puts the label and the input inside a single element', () => {
+            // A fragment made them two children of whatever contained them, so a grid or flex
+            // parent laid the input out beside its label instead of under it.
+            const form = createMockForm({file_name_format: ''});
+
+            renderWithProviders(
+                <div data-testid="grid">
+                    <InputForm
+                        form={form}
+                        name="file_name_format"
+                        label="Video File Format"
+                    />
+                </div>
+            );
+
+            const grid = screen.getByTestId('grid');
+            expect(grid.children).toHaveLength(1);
+            expect(grid.firstElementChild).toContainElement(screen.getByRole('textbox'));
+            expect(grid.firstElementChild).toContainElement(
+                screen.getByText(/Video File Format/).closest('label')
+            );
+        });
+
+        it('renders the label as a block above the input', () => {
+            const form = createMockForm({name: ''});
+
+            renderWithProviders(
+                <InputForm
+                    form={form}
+                    name="name"
+                    label="Channel Name"
+                />
+            );
+
+            const label = screen.getByText(/Channel Name/).closest('label');
+            expect(label).toHaveStyle({display: 'block'});
+        });
     });
 
     describe('NumberInputForm', () => {

--- a/app/src/hooks/useForm.test.js
+++ b/app/src/hooks/useForm.test.js
@@ -968,7 +968,7 @@ describe('Form Components', () => {
             );
         });
 
-        it('renders the label as a block above the input', () => {
+        it('renders the label as a block above the input, with the gap FieldLabel uses', () => {
             const form = createMockForm({name: ''});
 
             renderWithProviders(
@@ -980,7 +980,9 @@ describe('Form Components', () => {
             );
 
             const label = screen.getByText(/Channel Name/).closest('label');
-            expect(label).toHaveStyle({display: 'block'});
+            // Both halves of the alignment: without the margin, an InputForm beside a
+            // DestinationForm starts its input 4px higher.
+            expect(label).toHaveStyle({display: 'block', marginBottom: '4px'});
         });
     });
 


### PR DESCRIPTION
## Problem

`InputForm` returned a fragment. Its `<label>` and its field `<div>` therefore arrived as two separate children of whatever contained them:

- **`/videos/settings`** — the settings grid (`repeat(auto-fit, minmax(240px, 1fr))`) put each of them in its own cell, so the **Video File Format** and **Extra yt-dlp Arguments** inputs rendered in the column *to the right* of their own labels.
- **Channel edit page** — `InputForm`'s label was inline with no bottom gap, while the neighbouring `DestinationForm` uses `FieldLabel` (block, 4px). **Channel Name** and **Directory** started at different heights.

## Fix

`InputForm` returns one `<div>`, and its label is block with the same 4px gap `FieldLabel` uses. Two changes, one component, no call sites touched.

## Tests

Two guards in `useForm.test.js`, both verified to fail against the old component and pass against the new one:

- the label and the input are the single child of a containing element
- the label computes to `display: block`

Full frontend suite: 65 suites / 1155 tests passing. `npm run build` clean.

Not visually confirmed in a browser — the change was made in a worktree and the dev server mounts the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)