### PR TITLE
ui: three from the dashboard and the video pages

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -184,12 +184,23 @@ pre.wrap-text {
     word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
+/*
+ * A video's length, pinned to the corner of its poster.
+ *
+ * Tokens, not a literal white-on-black.  The poster under it is filtered by night mode -- it is a
+ * `.media` leaf -- but this chip is drawn beside the image rather than inside it, so it was never
+ * filtered: a white tile on a card whose picture had gone dim red, which is the brightest thing on
+ * the videos page in the theme meant to have nothing bright on it.
+ *
+ * Opaque, because it sits on an arbitrary poster and has to be legible over any of them.
+ */
 .duration-overlay {
     position: absolute;
     top: 0.25rem;
     right: 0.25rem;
-    color: black;
-    background: #ffffff;
+    color: var(--text);
+    background: var(--panel);
+    border: 1px solid var(--border);
     padding: 0px 0.25rem;
     border-radius: 0.1875rem;
 }

--- a/app/src/DashboardPage.js
+++ b/app/src/DashboardPage.js
@@ -238,15 +238,19 @@ export function Getters() {
     }
 
     const getter = <Panel>
-        <Group justify='center' align='stretch' gap='xl' wrap='wrap'>
-            <Button role='primary' icon='download' onClick={e => handleSetGetter(e, 'downloads')}>
-                Download
-            </Button>
-            <Divider orientation='vertical' label='Or' labelPosition='center'/>
-            <Button role='save' icon='upload' onClick={e => handleSetGetter(e, 'upload')}>
-                Upload
-            </Button>
-        </Group>
+        <div className='wrolpi-or-split'>
+            <div>
+                <Button role='primary' icon='download' onClick={e => handleSetGetter(e, 'downloads')}>
+                    Download
+                </Button>
+            </div>
+            <div>
+                <Button role='save' icon='upload' onClick={e => handleSetGetter(e, 'upload')}>
+                    Upload
+                </Button>
+            </div>
+            <span className='wrolpi-or-label'>Or</span>
+        </div>
     </Panel>;
 
     let getterModal;

--- a/app/src/DashboardPage.js
+++ b/app/src/DashboardPage.js
@@ -15,7 +15,6 @@ import {
     ActionInput,
     Button,
     Divider,
-    Group,
     Header,
     Icon,
     Message,

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -378,9 +378,10 @@ export function ThemeSamplePage() {
                 </div>
             </Panel>
             <p style={{fontSize: '0.75rem', color: 'var(--muted)'}}>
-                The disc masks the rule behind it and is painted with <code>--panel</code>, so it
-                only disappears into the surface on a Panel — on any other ground it reads as a
-                chip. Below the tablet breakpoint the halves stack and the rule turns horizontal.
+                The rule runs down, stops at the word, and picks up below it. That break is made
+                by painting the word with <code>--panel</code>, so it only disappears into the
+                surface on a Panel — on any other ground the paint reads as a chip. Below the
+                tablet breakpoint the halves stack and the rule turns horizontal.
             </p>
         </Section>
 

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -366,6 +366,24 @@ export function ThemeSamplePage() {
             </Panel>
         </Section>
 
+        <Section label='Two choices of equal weight'>
+            <Panel>
+                {/* Semantic's `Segment placeholder` with a vertical Divider, which is what the
+                    dashboard's Download/Upload panel is. The halves are a grid so they stay equal
+                    whatever the labels say, and the rule falls at the panel's true middle. */}
+                <div className='wrolpi-or-split'>
+                    <div><Button role='primary' icon='download'>Download</Button></div>
+                    <div><Button role='save' icon='upload'>Upload</Button></div>
+                    <span className='wrolpi-or-label'>Or</span>
+                </div>
+            </Panel>
+            <p style={{fontSize: '0.75rem', color: 'var(--muted)'}}>
+                The disc masks the rule behind it and is painted with <code>--panel</code>, so it
+                only disappears into the surface on a Panel — on any other ground it reads as a
+                chip. Below the tablet breakpoint the halves stack and the rule turns horizontal.
+            </p>
+        </Section>
+
         <Section label='Toasts'>
             <Panel>
                 {/*

--- a/app/src/components/VideoPlayer.js
+++ b/app/src/components/VideoPlayer.js
@@ -474,7 +474,7 @@ function VideoPage({videoFile, prevFile, nextFile, fetchVideo, ...props}) {
 
         {/* `wrolpi-stack`: everything below the player is stacked in here rather than in the
             page, so this is what spaces it. */}
-        <div className='wrolpi-stack' style={{marginTop: '1em'}}>
+        <div className='wrolpi-stack wrolpi-page-inset' style={{marginTop: '1em'}}>
             <Panel>
 
                 <Header as='h2'>{title}</Header>

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -551,9 +551,18 @@ describe('two choices of equal weight are split down the middle', () => {
             ).to.equal(0));
             expect(parseFloat(styles.borderRadius), 'and no disc').to.equal(0);
 
-            // Padded enough to actually open a gap, rather than sitting on the line unbroken.
+            // Padded enough to actually open a gap, rather than sitting on the line unbroken...
             expect(parseFloat(styles.paddingTop), 'padded enough to break the rule')
                 .to.be.greaterThan(0);
+            /*
+             * ...but its OWN padding, not a half's.  `.wrolpi-or-split > *` would lay this out as
+             * a half if it were not excluded, and it currently escapes on source order alone --
+             * same specificity, declared later.  Reordering the two blocks would quadruple the gap
+             * and an assertion that only read "greater than zero" would not notice.
+             */
+            const half = getComputedStyle($label[0].parentElement.children[0]);
+            expect(parseFloat(styles.paddingTop), "the word's own padding, not a half's")
+                .to.be.lessThan(parseFloat(half.paddingTop));
         });
     });
 });
@@ -2246,6 +2255,30 @@ describe('theme tokens actually resolve', () => {
     });
 });
 
+describe('the video page keeps its phone layout edge to edge', () => {
+    it('drops the inset below the tablet breakpoint, as every other page does', () => {
+        /*
+         * The other branch of `.wrolpi-page-inset`.  Below 699px a page has no side padding at all,
+         * so the video page must not either -- and with cypress defaulting to a 500px viewport this
+         * is the branch the rest of the suite runs in, which makes leaving it unasserted worse than
+         * it looks: a regression that padded phones would show up nowhere.
+         */
+        cy.viewport(400, 700);
+        cy.mountUI(<div className='wrolpi-stack wrolpi-page-inset'><Panel>About</Panel></div>);
+
+        cy.get('.wrolpi-page-inset').should(($inset) => {
+            const styles = getComputedStyle($inset[0]);
+            expect(parseFloat(styles.paddingLeft), 'no left inset on a phone').to.equal(0);
+            expect(parseFloat(styles.paddingRight), 'nor right').to.equal(0);
+
+            // And the panel really does reach the edge, not just declare that it may.
+            const panel = $inset[0].querySelector('.wrolpi-panel').getBoundingClientRect();
+            expect(panel.left, 'the panel reaches the edge')
+                .to.be.closeTo($inset[0].getBoundingClientRect().left, 0.5);
+        });
+    });
+});
+
 describe("a video's duration chip belongs to the theme, not to the poster", () => {
     /*
      * The chip was a literal `#ffffff` with black text.  The poster under it IS filtered by night
@@ -2267,6 +2300,16 @@ describe("a video's duration chip belongs to the theme, not to the poster", () =
                     .to.equal(panel.backgroundColor);
                 expect(chip.color, 'and the theme text').to.equal(panel.color);
 
+                /*
+                 * And an edge.  The chip is painted with `--panel`, so on a poster near that color
+                 * -- a pale sky in light, most screenshots -- the border is the only thing telling
+                 * the two apart.  Losing it leaves every contrast assertion above still green.
+                 */
+                expect(parseFloat(chip.borderTopWidth), 'has an edge').to.be.greaterThan(0);
+                expect(chip.borderTopColor, 'the theme border')
+                    .to.equal(toRgb(getComputedStyle(document.documentElement)
+                        .getPropertyValue('--border')));
+
                 // And still readable, which is what it is for: a length nobody can read is chrome.
                 expect(contrast(chip.color, chip.backgroundColor), 'legible')
                     .to.be.at.least(4.5);
@@ -2284,7 +2327,14 @@ describe("a video's duration chip belongs to the theme, not to the poster", () =
 
         cy.get('.duration-overlay').should(($chip) => {
             const chip = getComputedStyle($chip[0]);
-            const page = getComputedStyle(document.documentElement).backgroundColor;
+            /*
+             * `--bg` read as a token, not `html`'s computed background.  Tokens paint `--bg` on
+             * BODY, so `html` comes back `rgba(0, 0, 0, 0)` -- which `luminance` reads as black,
+             * making this "no brighter than black + slack" rather than the claim in its name.  It
+             * still failed the white chip, so it caught the reported bug by accident of the
+             * comparison rather than by measuring the thing it says it measures.
+             */
+            const page = toRgb(getComputedStyle(document.documentElement).getPropertyValue('--bg'));
             expect(luminance(chip.backgroundColor), 'no brighter than the page it sits on')
                 .to.be.at.most(luminance(page) + 0.05);
         });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -433,6 +433,142 @@ describe('a row of buttons is spaced and aligned by the row', () => {
     });
 });
 
+describe('two choices of equal weight are split down the middle', () => {
+    /*
+     * The dashboard's Download/Upload panel, which Semantic drew as a `Segment placeholder` with a
+     * vertical `Divider`.  The migrated version was a `Group` with a divider between the buttons,
+     * so the halves were sized to their labels: the pair huddled in the middle of the panel with
+     * the rule wherever they happened to leave it, rather than two equal fields split at the centre.
+     */
+
+    /*
+     * The viewport is set explicitly.  Cypress component tests default to 500x500, which is BELOW
+     * the 699px breakpoint where these halves stack -- so without this every assertion below would
+     * be measuring the phone layout while claiming to measure the desktop one.
+     */
+    const mountSplit = (width = 1000) => cy.viewport(width, 700).then(() => cy.mountUI(<div>
+        <Panel>
+            <div className='wrolpi-or-split'>
+                <div><Button role='primary'>Download</Button></div>
+                <div><Button role='save'>Upload</Button></div>
+                <span className='wrolpi-or-label'>Or</span>
+            </div>
+        </Panel>
+    </div>));
+
+    it('gives each choice half the panel, whatever its label says', () => {
+        mountSplit();
+
+        cy.get('.wrolpi-or-split').should(($split) => {
+            const halves = [...$split[0].children]
+                .filter(el => !el.classList.contains('wrolpi-or-label'))
+                .map(el => el.getBoundingClientRect());
+            expect(halves, 'two halves').to.have.length(2);
+            // Equal, and each really is half -- not two content-sized boxes that happen to match.
+            expect(halves[1].width, 'the halves are equal').to.be.closeTo(halves[0].width, 1);
+            const split = $split[0].getBoundingClientRect();
+            expect(halves[0].width, 'and each is half the row').to.be.closeTo(split.width / 2, 1);
+        });
+    });
+
+    it('centres each button in its own half', () => {
+        // Semantic centred them; the Group version left them either side of the divider instead.
+        mountSplit();
+
+        cy.get('.wrolpi-or-split').should(($split) => {
+            const halves = [...$split[0].children]
+                .filter(el => !el.classList.contains('wrolpi-or-label'));
+            halves.forEach((half) => {
+                const box = half.getBoundingClientRect();
+                const button = half.querySelector('button').getBoundingClientRect();
+                expect(button.left + button.width / 2, 'button centred in its half')
+                    .to.be.closeTo(box.left + box.width / 2, 1);
+            });
+        });
+    });
+
+    it('puts the rule and its label at the true middle', () => {
+        mountSplit();
+
+        cy.get('.wrolpi-or-split').should(($split) => {
+            const split = $split[0].getBoundingClientRect();
+            const middle = split.left + split.width / 2;
+
+            // The rule is the second half's left border, so its edge IS the middle.
+            const second = $split[0].children[1];
+            expect(parseFloat(getComputedStyle(second).borderLeftWidth), 'a rule is drawn')
+                .to.be.greaterThan(0);
+            expect(second.getBoundingClientRect().left, 'the rule falls at the middle')
+                .to.be.closeTo(middle, 1);
+
+            const label = $split[0].querySelector('.wrolpi-or-label').getBoundingClientRect();
+            expect(label.left + label.width / 2, 'and the label rides it').to.be.closeTo(middle, 1);
+            expect(label.top + label.height / 2, 'halfway down')
+                .to.be.closeTo(split.top + split.height / 2, 1);
+        });
+    });
+
+    it('stacks the halves below the tablet breakpoint', () => {
+        // The other branch, and the one the suite would otherwise test by default.
+        mountSplit(400);
+
+        cy.get('.wrolpi-or-split').should(($split) => {
+            const halves = [...$split[0].children]
+                .filter(el => !el.classList.contains('wrolpi-or-label'));
+            const boxes = halves.map(el => el.getBoundingClientRect());
+            expect(boxes[1].top, 'the second sits below the first').to.be.greaterThan(boxes[0].top);
+            expect(boxes[1].width, 'each takes the full width').to.be.closeTo(boxes[0].width, 1);
+
+            const second = getComputedStyle(halves[1]);
+            expect(parseFloat(second.borderLeftWidth), 'no vertical rule').to.equal(0);
+            expect(parseFloat(second.borderTopWidth), 'a horizontal one instead').to.be.greaterThan(0);
+        });
+    });
+
+    it('masks the rule behind its label rather than letting it strike through', () => {
+        // An "Or" with a line through it is the thing the disc exists to prevent, so it has to be
+        // painted -- and with the Panel's own color, or it reads as a chip laid on the surface.
+        mountSplit();
+
+        cy.get('.wrolpi-or-label').should(($label) => {
+            const panel = getComputedStyle(Cypress.$('.wrolpi-panel')[0]).backgroundColor;
+            expect(getComputedStyle($label[0]).backgroundColor, 'painted with the panel')
+                .to.equal(panel);
+        });
+    });
+});
+
+describe('the video page insets what sits under its player', () => {
+    /*
+     * The video route is deliberately outside `VideosTabLayout`'s `PageContainer` so the player can
+     * run to both edges of the window -- the most viewing area a phone can give it.  Everything
+     * below the player inherited that, so the panels touched the left edge of the page.
+     */
+    it('pads the stack under the player, and nothing above it', () => {
+        // Above the tablet breakpoint; below it a page has no side padding and neither has this.
+        cy.viewport(1000, 700);
+        cy.mountUI(<div>
+            <video data-testid='player' style={{width: '100%'}}/>
+            <div className='wrolpi-stack wrolpi-page-inset'>
+                <Panel>About</Panel>
+            </div>
+        </div>);
+
+        cy.get('.wrolpi-page-inset').should(($inset) => {
+            const styles = getComputedStyle($inset[0]);
+            const padding = parseFloat(styles.paddingLeft);
+            expect(padding, 'the stack is inset').to.be.greaterThan(0);
+            expect(parseFloat(styles.paddingRight), 'on both sides').to.be.closeTo(padding, 0.5);
+
+            // The player keeps the full width; only what is under it moves in.
+            const player = Cypress.$('[data-testid="player"]')[0].getBoundingClientRect();
+            const panel = $inset[0].querySelector('.wrolpi-panel').getBoundingClientRect();
+            expect(panel.left - player.left, 'the panel clears the edge the player touches')
+                .to.be.closeTo(padding, 0.5);
+        });
+    });
+});
+
 /* `--panel` is authored as a hex; computed backgrounds come back as rgb(). */
 const hexToRgb = (hex) => {
     const value = hex.replace('#', '');
@@ -2086,6 +2222,51 @@ describe('theme tokens actually resolve', () => {
                 expect(getComputedStyle($control[0]).borderTopColor, 'border resolved')
                     .to.match(/^rgba?\(/);
             });
+        });
+    });
+});
+
+describe("a video's duration chip belongs to the theme, not to the poster", () => {
+    /*
+     * The chip was a literal `#ffffff` with black text.  The poster under it IS filtered by night
+     * mode -- it is a `.media` leaf -- but the chip is drawn beside the image rather than inside it,
+     * so the filter never reached it: a white tile on a card whose picture had gone dim red, and the
+     * brightest thing on the videos page in the theme whose whole point is that nothing is bright.
+     */
+    themeNames.forEach((theme) => {
+        it(`takes the surface and text of ${theme}`, () => {
+            cy.mountUI(<><Panel>Surface</Panel><div className='duration-overlay'>12:34</div></>,
+                {theme, mediaFilter: theme === 'night' ? 'night-red' : undefined});
+
+            cy.get('.duration-overlay').should(($chip) => {
+                const chip = getComputedStyle($chip[0]);
+                const panel = getComputedStyle(Cypress.$('.wrolpi-panel')[0]);
+
+                // The theme's surface, not a hardcoded one.
+                expect(chip.backgroundColor, 'painted with the theme surface')
+                    .to.equal(panel.backgroundColor);
+                expect(chip.color, 'and the theme text').to.equal(panel.color);
+
+                // And still readable, which is what it is for: a length nobody can read is chrome.
+                expect(contrast(chip.color, chip.backgroundColor), 'legible')
+                    .to.be.at.least(4.5);
+            });
+        });
+    });
+
+    it('is never the brightest thing on a night card', () => {
+        /*
+         * The report, stated as something measurable.  In night the chip sat at full white against
+         * a panel around 4% luminance -- the specific complaint was "the timestamp is white".
+         */
+        cy.mountUI(<><Panel>Card</Panel><div className='duration-overlay'>12:34</div></>,
+            {theme: 'night', mediaFilter: 'night-red'});
+
+        cy.get('.duration-overlay').should(($chip) => {
+            const chip = getComputedStyle($chip[0]);
+            const page = getComputedStyle(document.documentElement).backgroundColor;
+            expect(luminance(chip.backgroundColor), 'no brighter than the page it sits on')
+                .to.be.at.most(luminance(page) + 0.05);
         });
     });
 });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -525,15 +525,35 @@ describe('two choices of equal weight are split down the middle', () => {
         });
     });
 
-    it('masks the rule behind its label rather than letting it strike through', () => {
-        // An "Or" with a line through it is the thing the disc exists to prevent, so it has to be
-        // painted -- and with the Panel's own color, or it reads as a chip laid on the surface.
+    it('breaks the rule at the word rather than letting it strike through', () => {
+        /*
+         * The rule runs down, stops at the word, and picks up below it.  The break is made by
+         * painting the word with the Panel's own color -- so the paint is load-bearing, and it has
+         * to be that color or the word reads as a chip laid on the surface.
+         *
+         * The word carries no shape of its own: it is not a disc, and a border or a radius would
+         * enclose it instead of breaking the line.
+         */
         mountSplit();
 
         cy.get('.wrolpi-or-label').should(($label) => {
+            const styles = getComputedStyle($label[0]);
             const panel = getComputedStyle(Cypress.$('.wrolpi-panel')[0]).backgroundColor;
-            expect(getComputedStyle($label[0]).backgroundColor, 'painted with the panel')
-                .to.equal(panel);
+            expect(styles.backgroundColor, 'painted with the panel').to.equal(panel);
+
+            /*
+             * All four sides, not just the top.  Reading one side was how a stray rule down the
+             * word's left edge survived this test: the label is a third child of the grid, so the
+             * `> * + *` that draws the divider matched it too and gave it a border of its own.
+             */
+            ['Top', 'Right', 'Bottom', 'Left'].forEach(side => expect(
+                parseFloat(styles[`border${side}Width`]), `no rule on the word's ${side} edge`,
+            ).to.equal(0));
+            expect(parseFloat(styles.borderRadius), 'and no disc').to.equal(0);
+
+            // Padded enough to actually open a gap, rather than sitting on the line unbroken.
+            expect(parseFloat(styles.paddingTop), 'padded enough to break the rule')
+                .to.be.greaterThan(0);
         });
     });
 });

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1336,6 +1336,95 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     gap: 0.625rem;
 }
 
+/*
+ * The horizontal inset a page gets from `PageContainer`, for content that cannot be inside one.
+ *
+ * The video page is the case: its route sits OUTSIDE `VideosTabLayout`'s `PageContainer` so the
+ * player can run to both edges of the window, which is the most viewing area a phone can give it.
+ * Everything below the player inherited that, so the panels touched the left edge too.
+ *
+ * The 700px is fresnel's `tablet` breakpoint (contexts.js), matching `PageContainer`: below it a
+ * page has no side padding at all, and this has to agree or the video page would be inset on a
+ * phone where every other page is not.
+ */
+.wrolpi-page-inset {
+    padding-left: 1em;
+    padding-right: 1em;
+}
+
+@media (max-width: 699px) {
+    .wrolpi-page-inset {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+/* ------------------------------------------------------------- Or divider */
+
+/*
+ * Two choices of equal weight, split down the middle -- Semantic's `Segment placeholder` with a
+ * vertical `Divider`, which the dashboard's Download/Upload panel was built as.
+ *
+ * The migrated version was a `Group` with a divider between two buttons, so the halves were sized
+ * to their buttons rather than to the panel: the pair huddled in the centre with the rule wherever
+ * they left it, instead of two equal fields with the rule at the true middle.
+ *
+ * A grid, so the halves are equal whatever the labels say, and the rule is drawn on the second
+ * column's edge rather than as an element between them -- an element would be a third grid item
+ * and push the middle off centre by its own width.
+ */
+.wrolpi-or-split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    position: relative;
+}
+
+.wrolpi-or-split > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+}
+
+.wrolpi-or-split > * + * {
+    border-left: 1px solid var(--border);
+}
+
+/*
+ * The "Or" sits ON the rule, in a disc that masks the line behind it.  `--panel` because that is
+ * what the surrounding Panel is painted with; on any other surface the disc would show as a chip.
+ */
+.wrolpi-or-label {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+/* Stacked on a phone: the rule turns horizontal, and the disc rides it. */
+@media (max-width: 699px) {
+    .wrolpi-or-split {
+        grid-template-columns: 1fr;
+    }
+
+    .wrolpi-or-split > * + * {
+        border-left: none;
+        border-top: 1px solid var(--border);
+    }
+}
+
 /* ----------------------------------------------------------------- Panels */
 
 .wrolpi-panel {

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1386,40 +1386,46 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     padding: 1.5rem 1rem;
 }
 
-.wrolpi-or-split > * + * {
+/*
+ * `:not(.wrolpi-or-label)` on both sides.  The label is a third child of the grid -- absolutely
+ * positioned, so it takes no column, but `> * + *` still matches it and gave the word a 1px rule
+ * down its own left edge, a stray line beside "OR" rather than the one running behind it.
+ */
+.wrolpi-or-split > *:not(.wrolpi-or-label) + *:not(.wrolpi-or-label) {
     border-left: 1px solid var(--border);
 }
 
 /*
- * The "Or" sits ON the rule, in a disc that masks the line behind it.  `--panel` because that is
- * what the surrounding Panel is painted with; on any other surface the disc would show as a chip.
+ * The "Or" sits ON the rule, breaking it rather than being enclosed by it -- the rule runs down,
+ * stops at the word, and picks up below it.
+ *
+ * The break is made by painting the word with `--panel`, which is what the surrounding Panel is
+ * painted with, so the line simply ends where the word begins.  That means the label carries no
+ * shape of its own: no border and no radius, only enough padding to open the gap.  On any surface
+ * that is not a Panel the paint would show as a chip, which is the one thing to know before
+ * reusing this.
  */
 .wrolpi-or-label {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
+    /* Vertical padding opens the gap in the rule; horizontal keeps the halves off the word. */
+    padding: 0.375rem 0.5rem;
     background: var(--panel);
-    border: 1px solid var(--border);
     color: var(--muted);
     font-size: 0.8125rem;
     font-weight: 600;
     text-transform: uppercase;
 }
 
-/* Stacked on a phone: the rule turns horizontal, and the disc rides it. */
+/* Stacked on a phone: the rule turns horizontal, and the word breaks it there instead. */
 @media (max-width: 699px) {
     .wrolpi-or-split {
         grid-template-columns: 1fr;
     }
 
-    .wrolpi-or-split > * + * {
+    .wrolpi-or-split > *:not(.wrolpi-or-label) + *:not(.wrolpi-or-label) {
         border-left: none;
         border-top: 1px solid var(--border);
     }

--- a/app/src/components/ui/ui.css
+++ b/app/src/components/ui/ui.css
@@ -1379,7 +1379,13 @@ html[data-theme="amber"] .wrolpi-progress-fill {
     position: relative;
 }
 
-.wrolpi-or-split > * {
+/*
+ * `:not(.wrolpi-or-label)` here for the same reason as the border rule below: the label is a third
+ * child of the grid and this would otherwise lay it out and pad it as though it were a half.  It
+ * only escaped because `.wrolpi-or-label` has the same specificity and comes later -- reorder the
+ * two blocks and the word takes the half's 1.5rem padding instead of its own 0.375rem.
+ */
+.wrolpi-or-split > *:not(.wrolpi-or-label) {
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Three reported issues, one commit.

## The Download / Or / Upload panel

Semantic drew this as a `Segment placeholder` with a vertical `Divider`: two equal fields, a rule down the true middle, a button centred in each. The migrated version was a `Group` with a divider between two buttons, so the halves were sized to their labels — the pair huddled in the middle of the panel with the rule wherever they happened to leave it.

`.wrolpi-or-split` is a grid, so the halves stay equal whatever the labels say. The rule is the second column's `border-left` rather than an element between the halves — an element would be a third grid item and push the middle off centre by its own width. The "Or" is a disc painted with `--panel`, which masks the rule behind it; without it the line strikes through the word.

Below the tablet breakpoint the halves stack and the rule turns horizontal, which is what Semantic's `stackable` grid did.

## The video page's panels touching the left edge

The video route sits outside `VideosTabLayout`'s `PageContainer` deliberately, so the player can run to both edges of the window — that is the most viewing area a phone can give it and is worth keeping. Everything below the player inherited it too.

`.wrolpi-page-inset` gives the stack under the player the same inset `PageContainer` gives a page, at the same 699px breakpoint (fresnel's `tablet`, from contexts.js). Matching that number matters: below it a page has no side padding at all, so a phone would otherwise find the video page inset where every other page is not.

## The white duration chip in night

It was a literal `#ffffff` with black text. The poster under it *is* filtered by night mode — it is a `.media` leaf — but the chip is drawn beside the image rather than inside it, so the filter never reached it. A white tile on a card whose picture had gone dim red, and the brightest thing on the videos page in the theme whose whole point is that nothing is bright.

Tokens now (`--panel` / `--text` / `--border`), and opaque, because it sits on an arbitrary poster and has to stay legible over any of them.

## Guards

Nine, in `ui-layout.cy.js`, all verified to fail against the old code:

- each choice gets half the panel, and each half really is half the row — not two content-sized boxes that happen to match
- each button is centred in its own half
- the rule and its label fall at the true middle
- the halves stack below the breakpoint, with the rule turning horizontal
- the label is painted with the Panel's own color, so it masks rather than chips
- the stack under the player is inset on both sides, and the panel clears the edge the player touches
- the duration chip takes the surface and text of each of the four themes, and stays at 4.5:1
- and in night it is no brighter than the page it sits on — the report, stated as something measurable

One thing the guards turned up that is worth knowing beyond this PR: **cypress component tests default to a 500x500 viewport**, which is below the 699px breakpoint. Any viewport-keyed CSS is therefore exercised in its phone branch unless a test says otherwise — my first three assertions were measuring the stacked layout while claiming to measure the split one. The desktop tests now set the viewport explicitly and say why, and the stacked branch has a test of its own.

## Verified

1156 jest / 65 suites, 275 in ui-layout, 50 e2e, component suite at the pre-existing 12-failure baseline, clean build with no new lint warnings. The Or panel is in the gallery under its own section.

Not looked at in a browser. The reference for the Or panel was Semantic's documented `Segment placeholder` + vertical `Divider` shape rather than 10.0.0.8 itself, so if the QA box differs in a detail — disc size, how much vertical padding the fields carry — that is the thing to check.