### PR TITLE
fix: flush the duplicate's deletion before renaming onto its path

### DIFF
--- a/modules/videos/models.py
+++ b/modules/videos/models.py
@@ -533,6 +533,11 @@ class Video(ModelHelper, Base):
         existing_video = Video.get_by_path(session, video_path)
         if existing_video and largest_video != existing_video:
             delete_video(existing_video)
+            # `FileGroup.delete` unlinks the files immediately, but its DELETE is only queued on the session.  The
+            # rename below claims `video_path` as its `primary_path`, and SQLAlchemy emits UPDATEs before DELETEs in a
+            # flush -- so without this flush the UPDATE hits the not-yet-deleted row and violates the unique index on
+            # `file_group.primary_path`, rolling back the entire download.
+            session.flush()
             for idx, video in enumerate(duplicate_videos):
                 if video == existing_video:
                     duplicate_videos.pop(idx)

--- a/modules/videos/models.py
+++ b/modules/videos/models.py
@@ -533,17 +533,17 @@ class Video(ModelHelper, Base):
         existing_video = Video.get_by_path(session, video_path)
         if existing_video and largest_video != existing_video:
             delete_video(existing_video)
-            # `FileGroup.delete` unlinks the files immediately, but its DELETE is only queued on the session.  The
-            # rename below claims `video_path` as its `primary_path`, and SQLAlchemy emits UPDATEs before DELETEs in a
-            # flush -- so without this flush the UPDATE hits the not-yet-deleted row and violates the unique index on
-            # `file_group.primary_path`, rolling back the entire download.
-            session.flush()
             for idx, video in enumerate(duplicate_videos):
                 if video == existing_video:
                     duplicate_videos.pop(idx)
 
         # Rename the video, add any missing tag names.
         if largest_video.video_path != video_path:
+            # Every deletion above unlinked its files immediately, but only queued its DELETE on the session.  The
+            # rename claims `video_path` as its `primary_path`, and SQLAlchemy emits UPDATEs before DELETEs within a
+            # flush -- so without this flush the UPDATE can hit a not-yet-deleted row and violate the unique index on
+            # `file_group.primary_path`, rolling back the entire download.
+            session.flush()
             largest_video.file_group.move(video_path)
         for tag_name in tag_names:
             if tag_name not in largest_video.file_group.tag_names:

--- a/modules/videos/test/test_video.py
+++ b/modules/videos/test/test_video.py
@@ -238,6 +238,49 @@ async def test_delete_duplicate_video_tagged_duplicate(async_client, test_sessio
 
 
 @pytest.mark.asyncio
+async def test_delete_duplicate_video_smaller_copy_at_destination(async_client, test_session, channel_factory,
+                                                                  video_factory):
+    """The kept Video can be renamed onto the path of the smaller duplicate that was just deleted."""
+    channel = channel_factory(name='Channel Name')
+    video_path = channel.directory / f'{channel.name}_20000101_ABC123456_The video title.mp4'
+
+    channel.info_json = {'entries': [{'id': 'ABC123456', 'title': 'The video title'}]}
+    entry = channel.info_json['entries'][0]
+
+    # The smaller copy already occupies the destination path.
+    small = video_factory(
+        channel_id=channel.id,
+        title=f'{channel.name}_20000101_ABC123456_The video title',
+        upload_date=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        source_id='ABC123456',
+        with_video_file=True,
+    )
+    large = video_factory(
+        channel_id=channel.id,
+        title=f'{channel.name}_20000101_ABC123456_The video title ',  # Trailing space, so a different path.
+        upload_date=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        source_id='ABC123456',
+        with_video_file=True,
+    )
+    small.file_group.url = large.file_group.url = 'https://example.com/video'
+    large.file_group.size = small.file_group.size + 1
+    large_id = large.id
+
+    test_session.commit()
+    assert small.video_path == video_path
+
+    assert await Video.delete_duplicate_videos(test_session, 'https://example.com/video', entry['id'], video_path)
+    # The commit must not raise IntegrityError: the deleted duplicate still held `video_path` when the kept Video's
+    # `primary_path` was updated to it.
+    test_session.commit()
+
+    video = test_session.query(Video).one()
+    assert video.id == large_id, 'The larger Video was not the one kept'
+    assert video.video_path == video_path
+    assert video.video_path.is_file()
+
+
+@pytest.mark.asyncio
 async def test_delete_renamed_video(async_client, test_session, channel_factory, video_factory, tag_factory):
     """If duplicate Video's exist, delete all the videos that do not have the new title."""
     channel = channel_factory(name='Channel Name')

--- a/modules/videos/test/test_video.py
+++ b/modules/videos/test/test_video.py
@@ -265,6 +265,7 @@ async def test_delete_duplicate_video_smaller_copy_at_destination(async_client, 
     small.file_group.url = large.file_group.url = 'https://example.com/video'
     large.file_group.size = small.file_group.size + 1
     large_id = large.id
+    large_old_path = large.video_path
 
     test_session.commit()
     assert small.video_path == video_path
@@ -278,6 +279,8 @@ async def test_delete_duplicate_video_smaller_copy_at_destination(async_client, 
     assert video.id == large_id, 'The larger Video was not the one kept'
     assert video.video_path == video_path
     assert video.video_path.is_file()
+    assert not large_old_path.exists(), 'The kept Video was copied to the destination rather than moved'
+    assert set(channel.directory.iterdir()) == set(video.file_group.my_paths())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A video download on the docker WROLPi died at commit with:

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: file_group.primary_path
[SQL: UPDATE file_group SET files=?, primary_path=?, a_text=? WHERE file_group.id = ?]
```

`VideoDownloader.finalize_download` calls `Video.delete_duplicate_videos`, which:

1. finds the copy occupying the destination path and deletes it — `FileGroup.delete` unlinks the files immediately, but only queues `session.delete` for the row;
2. calls `FileGroup.move()` on the copy it keeps. The `new_primary_path.exists()` guard passes, because the files are already gone from disk.

At flush time SQLAlchemy emits saves before deletes for a mapper, so the rename's `UPDATE ... primary_path` runs while the doomed row still holds that path.

The failure rolls back the entire download transaction: the freshly downloaded video never gets a DB record, and the previous copy's files are already unlinked. It triggers whenever a re-download's destination filename is held by a *smaller* duplicate — the equal-size and largest-at-destination cases take other branches, which is why existing tests didn't catch it. The earlier missing-file deletions in the same function are safe because the `get_by_path` query between them autoflushes.

## Fix

`session.flush()` after deleting the video at the destination, before the rename claims its path.

## Test

`test_delete_duplicate_video_smaller_copy_at_destination` seeds a smaller copy at the destination path and a larger one beside it. Without the flush it fails with the exact production `IntegrityError`; with it, the larger video is kept and renamed onto the path.

`modules/videos` and `wrolpi/files` suites pass (564 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)