### PR TITLE
ui: sample data names Blender and WROLPi, not real channels

### DIFF
--- a/app/src/components/Common.test.js
+++ b/app/src/components/Common.test.js
@@ -455,7 +455,7 @@ describe('SearchResultsInput', () => {
     const results = {
         tags: {name: 'Tags', results: [{type: 'tag', title: 'Cooking'}]},
         videos: {name: 'Videos', results: [
-            {title: 'How To Sharpen An Axe', description: 'Wranglerstar', location: '/videos/1'},
+            {title: 'Big Buck Bunny', description: 'Blender', location: '/videos/1'},
         ]},
     };
 
@@ -470,7 +470,7 @@ describe('SearchResultsInput', () => {
                                    handleResultSelect={handleResultSelect}/>);
 
         await userEvent.click(screen.getByRole('combobox'));
-        await userEvent.click(screen.getByText('How To Sharpen An Axe'));
+        await userEvent.click(screen.getByText('Big Buck Bunny'));
 
         expect(handleResultSelect).toHaveBeenCalledWith(
             {result: expect.objectContaining({location: '/videos/1'})});

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -760,7 +760,7 @@ export function ThemeSamplePage() {
                         channels: {
                             name: 'Channels',
                             results: [
-                                {title: 'videos/Wranglerstar', description: 'Wranglerstar'},
+                                {title: 'videos/Blender', description: 'Blender'},
                                 {title: 'videos/RoseRed Homestead', description: 'RoseRed Homestead'},
                             ],
                         },
@@ -885,7 +885,7 @@ export function ThemeSamplePage() {
         <Section label='Cards'>
             <CardGroup>
                 {[
-                    ['How To Sharpen An Axe The Right Way', 'Wranglerstar · 2024-11-03', 'blue', 'film'],
+                    ['Big Buck Bunny', 'Blender · 2024-11-03', 'blue', 'film'],
                     ['Pressure Canning Basics', 'RoseRed Homestead · 2025-02-17', 'blue', 'film'],
                     ['Water Storage Guide.pdf', 'docs/ · 2025-08-21', 'red', 'file pdf'],
                     ['Ham Radio General License.epub', 'ebooks/ · 2024-05-09', 'yellow', 'book'],
@@ -1023,10 +1023,10 @@ export function ThemeSamplePage() {
             onCancel={() => setConfirmOpen(false)}
         >
             <p style={{marginTop: 0}}>
-                The channel <strong>Wranglerstar</strong> and its download rules will be removed.
+                The channel <strong>Blender</strong> and its download rules will be removed.
             </p>
             <p style={{color: 'var(--muted)', marginBottom: 0}}>
-                videos/Wranglerstar/ (312 files) will not be deleted.
+                videos/Blender/ (312 files) will not be deleted.
             </p>
         </Confirm>
 

--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -761,7 +761,7 @@ export function ThemeSamplePage() {
                             name: 'Channels',
                             results: [
                                 {title: 'videos/Blender', description: 'Blender'},
-                                {title: 'videos/RoseRed Homestead', description: 'RoseRed Homestead'},
+                                {title: 'videos/WROLPi', description: 'WROLPi'},
                             ],
                         },
                     }}
@@ -886,7 +886,7 @@ export function ThemeSamplePage() {
             <CardGroup>
                 {[
                     ['Big Buck Bunny', 'Blender · 2024-11-03', 'blue', 'film'],
-                    ['Pressure Canning Basics', 'RoseRed Homestead · 2025-02-17', 'blue', 'film'],
+                    ['Getting Started With WROLPi', 'WROLPi · 2025-02-17', 'blue', 'film'],
                     ['Water Storage Guide.pdf', 'docs/ · 2025-08-21', 'red', 'file pdf'],
                     ['Ham Radio General License.epub', 'ebooks/ · 2024-05-09', 'yellow', 'book'],
                 ].map(([title, meta, color, icon]) => <Card

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -2652,8 +2652,8 @@ describe('a card reads as titles, not as a wall of links', () => {
         it(`keeps a card title legible in ${theme}`, () => {
             cy.mountUI(<MemoryRouter>
                 <Card title={<a href='/videos/1' className='no-link-underscore card-link'>
-                    How To Sharpen An Axe
-                </a>} meta='Wranglerstar'/>
+                    Big Buck Bunny
+                </a>} meta='Blender'/>
             </MemoryRouter>, {theme});
 
             cy.get('.card-link').should(($link) => {

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -1366,7 +1366,7 @@ describe('SearchBox', () => {
         directories: {name: 'Directories', results: [{title: 'videos/'}]},
         channels: {name: 'Channels', results: [
             {title: 'videos/Blender', description: 'Blender'},
-            {title: 'videos/RoseRed', description: 'RoseRed Homestead'},
+            {title: 'videos/WROLPi', description: 'WROLPi'},
         ]},
     };
 
@@ -1426,7 +1426,7 @@ describe('SearchBox', () => {
         await userEvent.keyboard('{ArrowUp}{Enter}');
 
         expect(onResultSelect).toHaveBeenCalledWith(
-            expect.objectContaining({title: 'videos/RoseRed'}));
+            expect.objectContaining({title: 'videos/WROLPi'}));
     });
 
     it('lets a caller render a suggestion its own way', async () => {

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -1365,7 +1365,7 @@ describe('SearchBox', () => {
     const results = {
         directories: {name: 'Directories', results: [{title: 'videos/'}]},
         channels: {name: 'Channels', results: [
-            {title: 'videos/Wranglerstar', description: 'Wranglerstar'},
+            {title: 'videos/Blender', description: 'Blender'},
             {title: 'videos/RoseRed', description: 'RoseRed Homestead'},
         ]},
     };
@@ -1395,10 +1395,10 @@ describe('SearchBox', () => {
                             onResultSelect={onResultSelect}/>);
         await userEvent.click(screen.getByRole('combobox'));
 
-        await userEvent.click(screen.getByText('videos/Wranglerstar'));
+        await userEvent.click(screen.getByText('videos/Blender'));
 
         expect(onResultSelect).toHaveBeenCalledWith(
-            expect.objectContaining({title: 'videos/Wranglerstar'}));
+            expect.objectContaining({title: 'videos/Blender'}));
     });
 
     it('moves through suggestions with the arrow keys and takes one with Enter', async () => {
@@ -1412,7 +1412,7 @@ describe('SearchBox', () => {
         await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
 
         expect(onResultSelect).toHaveBeenCalledWith(
-            expect.objectContaining({title: 'videos/Wranglerstar'}));
+            expect.objectContaining({title: 'videos/Blender'}));
         // Enter took the highlighted suggestion instead of submitting the raw text.
         expect(onSubmit).not.toHaveBeenCalled();
     });
@@ -1438,7 +1438,7 @@ describe('SearchBox', () => {
 
         await userEvent.click(screen.getByRole('combobox'));
 
-        expect(screen.getByText('custom: videos/Wranglerstar').tagName).toBe('EM');
+        expect(screen.getByText('custom: videos/Blender').tagName).toBe('EM');
         // The default title/description markup is replaced, not wrapped.
         expect(document.querySelector('.wrolpi-searchbox-result-title')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
The gallery's sample data, the card samples, and the search fixtures used two real YouTube channels and their video titles as demo content.

That matters more than it looks: this is sample data that ships to users, on a page linked from Settings. The delete-confirmation sample read

> The channel **Wranglerstar** and its download rules will be removed.

which puts words in a real person's mouth in the shipped interface.

## What changed

| Before | After |
|---|---|
| `Wranglerstar` / `videos/Wranglerstar` | `Blender` / `videos/Blender` |
| `How To Sharpen An Axe The Right Way` | `Big Buck Bunny` |
| `RoseRed Homestead` / `videos/RoseRed` | `WROLPi` / `videos/WROLPi` |
| `Pressure Canning Basics` | `Getting Started With WROLPi` |

Titles moved with their bylines. Leaving "Pressure Canning Basics" under a WROLPi byline would only have relocated the borrowing — the titles are the channels' work too.

**Blender** rather than an invented name because the repo's own test media is Big Buck Bunny: the sample library now refers to something it actually contains, from a project that publishes its films for exactly this use.

Files: `ThemeSamplePage.js`, `ui.test.js`, `Common.test.js`, `ui-layout.cy.js`.

## Verification

1157 jest tests across 65 suites pass; `npm run build` clean. No real third-party channel name remains anywhere in the repo.