### PR TITLE
build: put the @babel pins back, and make them fail loudly if dropped again

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21793,7 +21793,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       }
@@ -21805,15 +21805,15 @@
       "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helpers": "^7.20.7",
-        "@babel/parser": "^7.20.7",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.12",
-        "@babel/types": "^7.20.7",
+        "@babel/code-frame": "7.29.0",
+        "@babel/generator": "7.29.1",
+        "@babel/helper-compilation-targets": "7.20.7",
+        "@babel/helper-module-transforms": "7.28.6",
+        "@babel/helpers": "7.27.0",
+        "@babel/parser": "7.29.3",
+        "@babel/template": "7.28.6",
+        "@babel/traverse": "7.29.0",
+        "@babel/types": "7.29.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -21831,8 +21831,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -21843,8 +21843,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -21860,8 +21860,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/helper-module-transforms": {
@@ -21869,9 +21869,9 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
           "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.28.6",
-            "@babel/helper-validator-identifier": "^7.28.5",
-            "@babel/traverse": "^7.28.6"
+            "@babel/helper-module-imports": "7.28.6",
+            "@babel/helper-validator-identifier": "7.28.5",
+            "@babel/traverse": "7.29.0"
           }
         },
         "@babel/helper-validator-option": {
@@ -21884,8 +21884,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
           "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
           "requires": {
-            "@babel/template": "^7.27.0",
-            "@babel/types": "^7.27.0"
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -21893,7 +21893,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -21901,9 +21901,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -21911,12 +21911,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -21925,8 +21925,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         },
         "semver": {
@@ -21963,7 +21963,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
       "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -21971,8 +21971,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -21983,7 +21983,7 @@
       "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -21991,8 +21991,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22026,7 +22026,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
       "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "requires": {
-        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-compilation-targets": "7.20.7",
         "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
@@ -22044,8 +22044,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -22073,7 +22073,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
       "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22081,8 +22081,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22092,8 +22092,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "7.28.6",
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/parser": {
@@ -22101,7 +22101,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -22109,9 +22109,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -22119,8 +22119,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22130,7 +22130,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
       "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
       "requires": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22138,8 +22138,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22149,7 +22149,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
       "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22157,8 +22157,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22176,7 +22176,7 @@
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-wrap-function": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22184,8 +22184,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22198,9 +22198,9 @@
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-member-expression-to-functions": "^7.20.7",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/template": "7.28.6",
+        "@babel/traverse": "7.29.0",
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -22208,8 +22208,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -22225,7 +22225,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -22233,9 +22233,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -22243,12 +22243,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -22257,8 +22257,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22268,7 +22268,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
       "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "requires": {
-        "@babel/types": "^7.20.2"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22276,8 +22276,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22287,7 +22287,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
       "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "requires": {
-        "@babel/types": "^7.20.0"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22295,8 +22295,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22306,7 +22306,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -22314,8 +22314,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22336,9 +22336,9 @@
       "integrity": "sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==",
       "requires": {
         "@babel/helper-function-name": "^7.19.0",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5"
+        "@babel/template": "7.28.6",
+        "@babel/traverse": "7.29.0",
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -22346,8 +22346,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -22363,7 +22363,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -22371,9 +22371,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -22381,12 +22381,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -22395,8 +22395,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22520,8 +22520,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
       "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
       "requires": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/compat-data": "7.20.14",
+        "@babel/helper-compilation-targets": "7.20.7",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.20.7"
@@ -22537,8 +22537,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -22786,7 +22786,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz",
       "integrity": "sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==",
       "requires": {
-        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-module-imports": "7.28.6",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-remap-async-to-generator": "^7.18.9"
       },
@@ -22796,8 +22796,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -22813,8 +22813,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -22822,7 +22822,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -22830,9 +22830,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -22840,12 +22840,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -22854,8 +22854,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -22882,7 +22882,7 @@
       "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-compilation-targets": "7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
@@ -22902,8 +22902,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -22927,7 +22927,7 @@
       "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/template": "^7.20.7"
+        "@babel/template": "7.28.6"
       },
       "dependencies": {
         "@babel/parser": {
@@ -22935,7 +22935,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -22943,9 +22943,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -22953,8 +22953,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23015,7 +23015,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
       "integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
       "requires": {
-        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-compilation-targets": "7.20.7",
         "@babel/helper-function-name": "^7.18.9",
         "@babel/helper-plugin-utils": "^7.18.9"
       },
@@ -23030,8 +23030,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -23070,7 +23070,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz",
       "integrity": "sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-module-transforms": "7.28.6",
         "@babel/helper-plugin-utils": "^7.20.2"
       },
       "dependencies": {
@@ -23079,8 +23079,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23096,8 +23096,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/helper-module-transforms": {
@@ -23105,9 +23105,9 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
           "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.28.6",
-            "@babel/helper-validator-identifier": "^7.28.5",
-            "@babel/traverse": "^7.28.6"
+            "@babel/helper-module-imports": "7.28.6",
+            "@babel/helper-validator-identifier": "7.28.5",
+            "@babel/traverse": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23115,7 +23115,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23123,9 +23123,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23133,12 +23133,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23147,8 +23147,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23158,7 +23158,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
       "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-module-transforms": "7.28.6",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-simple-access": "^7.20.2"
       },
@@ -23168,8 +23168,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23185,8 +23185,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/helper-module-transforms": {
@@ -23194,9 +23194,9 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
           "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.28.6",
-            "@babel/helper-validator-identifier": "^7.28.5",
-            "@babel/traverse": "^7.28.6"
+            "@babel/helper-module-imports": "7.28.6",
+            "@babel/helper-validator-identifier": "7.28.5",
+            "@babel/traverse": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23204,7 +23204,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23212,9 +23212,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23222,12 +23222,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23236,8 +23236,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23247,10 +23247,10 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
       "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-module-transforms": "7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-validator-identifier": "7.28.5",
+        "@babel/traverse": "7.29.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -23258,8 +23258,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23275,8 +23275,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/helper-module-transforms": {
@@ -23284,9 +23284,9 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
           "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.28.6",
-            "@babel/helper-validator-identifier": "^7.28.5",
-            "@babel/traverse": "^7.28.6"
+            "@babel/helper-module-imports": "7.28.6",
+            "@babel/helper-validator-identifier": "7.28.5",
+            "@babel/traverse": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23294,7 +23294,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23302,9 +23302,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23312,12 +23312,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23326,8 +23326,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23337,7 +23337,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.6.tgz",
       "integrity": "sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.18.6",
+        "@babel/helper-module-transforms": "7.28.6",
         "@babel/helper-plugin-utils": "^7.18.6"
       },
       "dependencies": {
@@ -23346,8 +23346,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23363,8 +23363,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/helper-module-transforms": {
@@ -23372,9 +23372,9 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
           "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.28.6",
-            "@babel/helper-validator-identifier": "^7.28.5",
-            "@babel/traverse": "^7.28.6"
+            "@babel/helper-module-imports": "7.28.6",
+            "@babel/helper-validator-identifier": "7.28.5",
+            "@babel/traverse": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23382,7 +23382,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23390,9 +23390,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23400,12 +23400,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23414,8 +23414,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23484,10 +23484,10 @@
       "integrity": "sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-module-imports": "7.28.6",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-jsx": "^7.18.6",
-        "@babel/types": "^7.20.7"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -23495,8 +23495,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23512,8 +23512,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23521,7 +23521,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23529,9 +23529,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23539,12 +23539,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23553,8 +23553,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23598,7 +23598,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
       "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "requires": {
-        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-module-imports": "7.28.6",
         "@babel/helper-plugin-utils": "^7.19.0",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
@@ -23611,8 +23611,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -23628,8 +23628,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -23637,7 +23637,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -23645,9 +23645,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -23655,12 +23655,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -23669,8 +23669,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         },
         "semver": {
@@ -23753,10 +23753,10 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
       "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "requires": {
-        "@babel/compat-data": "^7.20.1",
-        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/compat-data": "7.20.14",
+        "@babel/helper-compilation-targets": "7.20.7",
         "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/helper-validator-option": "7.18.6",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
         "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
@@ -23822,7 +23822,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.18.10",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.20.2",
+        "@babel/types": "7.29.0",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -23840,8 +23840,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
           "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
           "requires": {
-            "@babel/compat-data": "^7.20.5",
-            "@babel/helper-validator-option": "^7.18.6",
+            "@babel/compat-data": "7.20.14",
+            "@babel/helper-validator-option": "7.18.6",
             "browserslist": "^4.21.3",
             "lru-cache": "^5.1.1",
             "semver": "^6.3.0"
@@ -23857,8 +23857,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         },
         "semver": {
@@ -23876,7 +23876,7 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/types": "^7.4.4",
+        "@babel/types": "7.29.0",
         "esutils": "^2.0.2"
       },
       "dependencies": {
@@ -23885,8 +23885,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -23897,7 +23897,7 @@
       "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/helper-validator-option": "7.18.6",
         "@babel/plugin-transform-react-display-name": "^7.18.6",
         "@babel/plugin-transform-react-jsx": "^7.18.6",
         "@babel/plugin-transform-react-jsx-development": "^7.18.6",
@@ -23917,7 +23917,7 @@
       "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/helper-validator-option": "7.18.6",
         "@babel/plugin-transform-typescript": "^7.18.6"
       },
       "dependencies": {
@@ -24655,7 +24655,7 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.5.1.tgz",
       "integrity": "sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==",
       "requires": {
-        "@babel/core": "^7.1.0",
+        "@babel/core": "7.20.12",
         "@jest/types": "^27.5.1",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
@@ -25085,7 +25085,7 @@
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
       "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-module-imports": "7.28.6",
         "@rollup/pluginutils": "^3.1.0"
       },
       "dependencies": {
@@ -25094,8 +25094,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -25111,8 +25111,8 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
           "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
           "requires": {
-            "@babel/traverse": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/traverse": "7.29.0",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/parser": {
@@ -25120,7 +25120,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -25128,9 +25128,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -25138,12 +25138,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -25152,8 +25152,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -25304,7 +25304,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
       "integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
       "requires": {
-        "@babel/types": "^7.12.6"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -25312,8 +25312,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -25323,7 +25323,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
       "integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
       "requires": {
-        "@babel/core": "^7.12.3",
+        "@babel/core": "7.20.12",
         "@svgr/babel-preset": "^5.5.0",
         "@svgr/hast-util-to-babel-ast": "^5.5.0",
         "svg-parser": "^2.0.2"
@@ -25344,7 +25344,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
       "integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
       "requires": {
-        "@babel/core": "^7.12.3",
+        "@babel/core": "7.20.12",
         "@babel/plugin-transform-react-constant-elements": "^7.12.1",
         "@babel/preset-env": "^7.12.1",
         "@babel/preset-react": "^7.12.5",
@@ -25373,7 +25373,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "peer": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
+        "@babel/code-frame": "7.29.0",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
@@ -25420,7 +25420,7 @@
           "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
           "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
           "requires": {
-            "@babel/code-frame": "^7.10.4",
+            "@babel/code-frame": "7.29.0",
             "@babel/runtime": "^7.12.5",
             "@types/aria-query": "^5.0.1",
             "aria-query": "5.1.3",
@@ -25504,8 +25504,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
       "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
       "requires": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
+        "@babel/parser": "7.29.3",
+        "@babel/types": "7.29.0",
         "@types/babel__generator": "*",
         "@types/babel__template": "*",
         "@types/babel__traverse": "*"
@@ -25516,7 +25516,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -25524,8 +25524,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -25535,7 +25535,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
       "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -25543,8 +25543,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -25554,8 +25554,8 @@
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
       "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/parser": "7.29.3",
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/parser": {
@@ -25563,7 +25563,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -25571,8 +25571,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -25582,7 +25582,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
       "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
       "requires": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "7.29.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -25590,8 +25590,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -26634,8 +26634,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.1.tgz",
       "integrity": "sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==",
       "requires": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
+        "@babel/template": "7.28.6",
+        "@babel/types": "7.29.0",
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
       },
@@ -26645,7 +26645,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -26653,9 +26653,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -26663,8 +26663,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         }
       }
@@ -26690,7 +26690,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
       "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "requires": {
-        "@babel/compat-data": "^7.17.7",
+        "@babel/compat-data": "7.20.14",
         "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
@@ -26762,7 +26762,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-10.0.1.tgz",
       "integrity": "sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==",
       "requires": {
-        "@babel/core": "^7.16.0",
+        "@babel/core": "7.20.12",
         "@babel/plugin-proposal-class-properties": "^7.16.0",
         "@babel/plugin-proposal-decorators": "^7.16.4",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.0",
@@ -28612,7 +28612,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
       "integrity": "sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==",
       "requires": {
-        "@babel/core": "^7.16.0",
+        "@babel/core": "7.20.12",
         "@babel/eslint-parser": "^7.16.3",
         "@rushstack/eslint-patch": "^1.1.0",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
@@ -29330,7 +29330,7 @@
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
       "integrity": "sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
+        "@babel/code-frame": "7.29.0",
         "@types/json-schema": "^7.0.5",
         "chalk": "^4.1.0",
         "chokidar": "^3.4.2",
@@ -30366,8 +30366,8 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "requires": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
+        "@babel/core": "7.20.12",
+        "@babel/parser": "7.29.3",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
@@ -30378,7 +30378,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/types": {
@@ -30386,8 +30386,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         },
         "semver": {
@@ -30642,7 +30642,7 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
       "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
       "requires": {
-        "@babel/core": "^7.8.0",
+        "@babel/core": "7.20.12",
         "@jest/test-sequencer": "^27.5.1",
         "@jest/types": "^27.5.1",
         "babel-jest": "^27.5.1",
@@ -31025,7 +31025,7 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
       "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
       "requires": {
-        "@babel/code-frame": "^7.12.13",
+        "@babel/code-frame": "7.29.0",
         "@jest/types": "^27.5.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
@@ -31334,11 +31334,11 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.5.1.tgz",
       "integrity": "sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==",
       "requires": {
-        "@babel/core": "^7.7.2",
-        "@babel/generator": "^7.7.2",
+        "@babel/core": "7.20.12",
+        "@babel/generator": "7.29.1",
         "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
-        "@babel/types": "^7.0.0",
+        "@babel/traverse": "7.29.0",
+        "@babel/types": "7.29.0",
         "@jest/transform": "^27.5.1",
         "@jest/types": "^27.5.1",
         "@types/babel__traverse": "^7.0.4",
@@ -31363,8 +31363,8 @@
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
           "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
           "requires": {
-            "@babel/parser": "^7.29.0",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0",
             "@jridgewell/gen-mapping": "^0.3.12",
             "@jridgewell/trace-mapping": "^0.3.28",
             "jsesc": "^3.0.2"
@@ -31380,7 +31380,7 @@
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
           "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
           "requires": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/template": {
@@ -31388,9 +31388,9 @@
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
           "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
           "requires": {
-            "@babel/code-frame": "^7.28.6",
-            "@babel/parser": "^7.28.6",
-            "@babel/types": "^7.28.6"
+            "@babel/code-frame": "7.29.0",
+            "@babel/parser": "7.29.3",
+            "@babel/types": "7.29.0"
           }
         },
         "@babel/traverse": {
@@ -31398,12 +31398,12 @@
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
           "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
           "requires": {
-            "@babel/code-frame": "^7.29.0",
-            "@babel/generator": "^7.29.0",
-            "@babel/helper-globals": "^7.28.0",
-            "@babel/parser": "^7.29.0",
-            "@babel/template": "^7.28.6",
-            "@babel/types": "^7.29.0",
+            "@babel/code-frame": "7.29.0",
+            "@babel/generator": "7.29.1",
+            "@babel/helper-globals": "7.28.0",
+            "@babel/parser": "7.29.3",
+            "@babel/template": "7.28.6",
+            "@babel/types": "7.29.0",
             "debug": "^4.3.1"
           }
         },
@@ -31412,8 +31412,8 @@
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
           "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
           "requires": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "7.27.1",
+            "@babel/helper-validator-identifier": "7.28.5"
           }
         },
         "ansi-styles": {
@@ -31688,7 +31688,7 @@
           "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
           "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
           "requires": {
-            "@babel/code-frame": "^7.12.13",
+            "@babel/code-frame": "7.29.0",
             "@jest/types": "^28.1.3",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
@@ -32972,7 +32972,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.29.0",
         "error-ex": "^1.3.1",
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
@@ -34108,7 +34108,7 @@
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
       "integrity": "sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==",
       "requires": {
-        "@babel/code-frame": "^7.16.0",
+        "@babel/code-frame": "7.29.0",
         "address": "^1.1.2",
         "browserslist": "^4.18.1",
         "chalk": "^4.1.2",
@@ -34307,7 +34307,7 @@
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
       "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
       "requires": {
-        "@babel/core": "^7.16.0",
+        "@babel/core": "7.20.12",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.4.2",
@@ -34702,7 +34702,7 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
       "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
       "requires": {
-        "@babel/code-frame": "^7.10.4",
+        "@babel/code-frame": "7.29.0",
         "jest-worker": "^26.2.1",
         "serialize-javascript": "^4.0.0",
         "terser": "^5.0.0"
@@ -36553,7 +36553,7 @@
       "integrity": "sha512-Tjf+gBwOTuGyZwMz2Nk/B13Fuyeo0Q84W++bebbVsfr9iLkDSo6j6PST8tET9HYA58mlRXwlMGpyWO8ETJiXdQ==",
       "requires": {
         "@apideck/better-ajv-errors": "^0.3.1",
-        "@babel/core": "^7.11.1",
+        "@babel/core": "7.20.12",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
         "@rollup/plugin-babel": "^5.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -72,6 +72,22 @@
     ]
   },
   "overrides": {
+    "@babel/code-frame": "7.29.0",
+    "@babel/compat-data": "7.20.14",
+    "@babel/core": "7.20.12",
+    "@babel/generator": "7.29.1",
+    "@babel/helper-compilation-targets": "7.20.7",
+    "@babel/helper-globals": "7.28.0",
+    "@babel/helper-module-imports": "7.28.6",
+    "@babel/helper-module-transforms": "7.28.6",
+    "@babel/helper-string-parser": "7.27.1",
+    "@babel/helper-validator-identifier": "7.28.5",
+    "@babel/helper-validator-option": "7.18.6",
+    "@babel/helpers": "7.27.0",
+    "@babel/parser": "7.29.3",
+    "@babel/template": "7.28.6",
+    "@babel/traverse": "7.29.0",
+    "@babel/types": "7.29.0",
     "react-scripts": {
       "typescript": "$typescript"
     },

--- a/app/src/babel-pins.test.js
+++ b/app/src/babel-pins.test.js
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+
+/*
+ * The @babel core pipeline is pinned, and has to stay pinned.
+ *
+ * Floating it broke the React /map page: maplibre-gl's Web Worker is inlined into the
+ * production bundle, Babel 7.29 transpiles it differently, and CRA's Terser mangle pass then
+ * turns it into `ReferenceError: a is not defined`.  The worker's style-layer index never
+ * builds, every vector source fails to parse, and the map renders blank with only the pins.
+ *
+ * Two properties make this worth a test rather than a comment:
+ *
+ *   - It is invisible to everything else we run.  The dev server is fine, the jest suite is
+ *     fine, `npm run build` succeeds -- only the MINIFIED bundle is broken, and only on a page
+ *     whose failure looks like missing map data rather than a JS error.
+ *   - It has already regressed once by accident.  The pins were added deliberately, then
+ *     removed as collateral when the Mantine commit rewrote `overrides` for TypeScript 5.
+ *     Nothing failed, so nothing objected; the map survived on lockfile inertia alone until
+ *     someone re-resolved it.
+ *
+ * Verified rather than assumed, on this tree: raising @babel/core to 7.29.7 and reinstalling
+ * fails `npm run build` outright ("'opera_mobile' is not a valid target", from a
+ * helper-compilation-targets that floated away from the browserslist data it was pinned
+ * against).  Restoring these pins builds, and /map renders from the built bundle.
+ */
+
+const APP = path.join(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(APP, 'package.json'), 'utf8'));
+const lock = JSON.parse(fs.readFileSync(path.join(APP, 'package-lock.json'), 'utf8'));
+
+/** The 16 packages that differ between the last-good tree and the one that broke the map. */
+const PINNED = [
+    '@babel/code-frame', '@babel/compat-data', '@babel/core', '@babel/generator',
+    '@babel/helper-compilation-targets', '@babel/helper-globals', '@babel/helper-module-imports',
+    '@babel/helper-module-transforms', '@babel/helper-string-parser',
+    '@babel/helper-validator-identifier', '@babel/helper-validator-option', '@babel/helpers',
+    '@babel/parser', '@babel/template', '@babel/traverse', '@babel/types',
+];
+
+describe('@babel pins', () => {
+    it('names every package in the core pipeline', () => {
+        /*
+         * The whole pipeline, not just @babel/core.  Pinning core alone was tried when this was
+         * first diagnosed and is not enough: the transform plugins resolve their own copies of
+         * traverse/generator/types, so the new AST pipeline comes back in underneath a pinned
+         * core.
+         */
+        const overrides = pkg.overrides || {};
+        const missing = PINNED.filter(name => !overrides[name]);
+
+        expect(missing).toEqual([]);
+    });
+
+    it('pins them to an exact version, not a range', () => {
+        // `^7.20.12` is not a pin -- it resolves to 7.29 the moment anything re-resolves, which
+        // is exactly the event this guards against.
+        const loose = PINNED
+            .map(name => [name, (pkg.overrides || {})[name]])
+            .filter(([, spec]) => typeof spec !== 'string' || !/^\d+\.\d+\.\d+$/.test(spec));
+
+        expect(loose).toEqual([]);
+    });
+
+    it('resolves every installed copy to the pinned version', () => {
+        /*
+         * The manifest is the intent; the lockfile is what actually gets installed.  npm nests
+         * a second copy of a dependency whenever versions conflict, and a nested copy that
+         * escaped the override would put the new pipeline back into the build while the
+         * top-level entry still read correctly.
+         *
+         * So this walks EVERY path in the lockfile, not just `node_modules/<name>`.
+         */
+        const wanted = Object.fromEntries(PINNED.map(name => [name, pkg.overrides[name]]));
+        const mismatched = [];
+        let copies = 0;
+
+        for (const [location, info] of Object.entries(lock.packages || {})) {
+            for (const [name, version] of Object.entries(wanted)) {
+                if (location === `node_modules/${name}` || location.endsWith(`/node_modules/${name}`)) {
+                    copies += 1;
+                    if (info.version !== version) {
+                        mismatched.push(`${location}: ${info.version} (pinned ${version})`);
+                    }
+                }
+            }
+        }
+
+        // The premise: a lockfile these names never matched would report nothing mismatched.
+        expect(copies).toBeGreaterThan(100);
+        expect(mismatched).toEqual([]);
+    });
+});


### PR DESCRIPTION
The `@babel/*` overrides that fixed the blank React `/map` were removed as collateral when the
Mantine commit rewrote `overrides` for TypeScript 5. Nothing failed, so nothing objected — the
map kept working only because `package-lock.json` still happened to resolve `@babel/core` to
7.20.12, and devices run `npm install`, not `npm ci`.

## Verified, not assumed

Raising `@babel/core` to 7.29.7 and reinstalling floats the whole pipeline
(traverse/generator/types to 7.29.8). `npm run build` then fails outright:

```
Error: [BABEL] @babel/helper-compilation-targets: 'opera_mobile' is not a valid target
```

— from a `helper-compilation-targets` that floated away from the browserslist data it was
pinned against. With the pins restored: build compiles, all **141** resolved copies match the
pins, and `/map` renders from the built bundle (maplibre canvas present, no `ReferenceError`).

## The guard

Three checks, each verified to fail when violated:

- every package in the pipeline is named — pinning `@babel/core` alone was tried when this was
  first diagnosed and is not enough, since transform plugins resolve their own copies
- pinned exactly, not by range — `^7.20.12` resolves to 7.29 the moment anything re-resolves
- **every installed copy** in the lockfile matches, not just `node_modules/<name>` — npm nests
  a second copy on conflict, and a nested copy that escaped the override would put the new
  pipeline back into the build while the top-level entry still read correctly

## Checks

- 67 suites / 1186 tests pass
- `npm run build` compiles
- `/map` verified rendering from the built bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)