### PR TITLE
ci: a cached venv outlives the interpreter it was built for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,22 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install -y ffmpeg catdoc
       - restore_cache:
-          key: deps-3.13-{{ checksum "requirements.txt" }}-5
+          key: deps-3.13-{{ checksum "requirements.txt" }}-6
       - run:
           name: Install Requirements
           command: |
+            # A restored venv points at the exact interpreter that built it.  CircleCI's
+            # cimg/python:3.13 gets patch bumps, and this cache key does not name the
+            # patch, so a venv cached before a bump has a dangling bin/python3 -- and
+            # `python3 -m venv` over it fails with `[Errno 2]` instead of repairing it,
+            # which broke every Python job.  Rebuild when it cannot run: that costs a
+            # reinstall only on the first run after a bump.
+            if ! ./venv/bin/python3 --version >/dev/null 2>&1; then rm -rf venv; fi
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
       - save_cache:
-          key: deps-3.13-{{ checksum "requirements.txt" }}-5
+          key: deps-3.13-{{ checksum "requirements.txt" }}-6
           paths:
             - "venv"
       # `-nauto` parallelizes across all available cores via pytest-xdist.
@@ -49,10 +56,17 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-3.13-{{ checksum "requirements.txt" }}-5
+          key: deps-3.13-{{ checksum "requirements.txt" }}-6
       - run:
           name: Install Requirements
           command: |
+            # A restored venv points at the exact interpreter that built it.  CircleCI's
+            # cimg/python:3.13 gets patch bumps, and this cache key does not name the
+            # patch, so a venv cached before a bump has a dangling bin/python3 -- and
+            # `python3 -m venv` over it fails with `[Errno 2]` instead of repairing it,
+            # which broke every Python job.  Rebuild when it cannot run: that costs a
+            # reinstall only on the first run after a bump.
+            if ! ./venv/bin/python3 --version >/dev/null 2>&1; then rm -rf venv; fi
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
@@ -67,10 +81,17 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-3.13-{{ checksum "requirements.txt" }}-5
+          key: deps-3.13-{{ checksum "requirements.txt" }}-6
       - run:
           name: Install Requirements
           command: |
+            # A restored venv points at the exact interpreter that built it.  CircleCI's
+            # cimg/python:3.13 gets patch bumps, and this cache key does not name the
+            # patch, so a venv cached before a bump has a dangling bin/python3 -- and
+            # `python3 -m venv` over it fails with `[Errno 2]` instead of repairing it,
+            # which broke every Python job.  Rebuild when it cannot run: that costs a
+            # reinstall only on the first run after a bump.
+            if ! ./venv/bin/python3 --version >/dev/null 2>&1; then rm -rf venv; fi
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
@@ -89,10 +110,17 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-3.13-{{ checksum "requirements.txt" }}-5
+          key: deps-3.13-{{ checksum "requirements.txt" }}-6
       - run:
           name: Install dependencies
           command: |
+            # A restored venv points at the exact interpreter that built it.  CircleCI's
+            # cimg/python:3.13 gets patch bumps, and this cache key does not name the
+            # patch, so a venv cached before a bump has a dangling bin/python3 -- and
+            # `python3 -m venv` over it fails with `[Errno 2]` instead of repairing it,
+            # which broke every Python job.  Rebuild when it cannot run: that costs a
+            # reinstall only on the first run after a bump.
+            if ! ./venv/bin/python3 --version >/dev/null 2>&1; then rm -rf venv; fi
             python -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt


### PR DESCRIPTION
Every Python job (`api-tests`, `api-contract-tests`, `api-alembic-migrations`, `sanic-api-start`)
fails in **Install Requirements** — before any test runs — with:

```
Error: [Errno 2] No such file or directory: '/home/circleci/project/venv/bin/python3'
```

It is not the code under review. It reproduces on a branch whose only changes are under `app/`,
with `.circleci/config.yml` byte-identical to master, and the same config passed on **Aug 9** and
fails on **Aug 11**.

## Cause

The cache key names the minor version (`deps-3.13-…`) but not the patch, and the cached path is
the whole `venv`. A venv's `bin/python3` points at the exact interpreter that built it, so once
`cimg/python:3.13` takes a patch bump, the restored venv refers to an interpreter the image no
longer has — and creating a venv over that directory fails rather than repairing it.

## Fix — two changes, both load-bearing

- **Rebuild the venv when its interpreter cannot run.** Heals a restored cache whatever left it
  unusable, and costs a reinstall only on the first run after a bump.
- **Move the cache key (`-5` → `-6`).** CircleCI keys are immutable and `save_cache` will not
  overwrite one. Without this the poisoned entry is restored and discarded on *every* run
  forever and never replaced — the guard alone would mask the problem, not end it.

## What I verified, and what I didn't

Verified: the guard removes a venv with a dangling interpreter and keeps a healthy one, so the
cache still pays off; the config parses.

**Not reproduced locally** — macOS Python recreates the symlink and exits 0, so the exact crash
belongs to CI's Linux Python. The guard does not depend on the mechanism: it removes any venv
whose `bin/python3` will not run, which is precisely the state the error names. CI is the real
proof here.

## Separately, still open

`api-tests` fails on master itself, in
`test_format_video_filename_uses_channel_name_over_info_json` — a known flake under `-nauto`
that passes when run alone. Unrelated to this, and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)