### PR TITLE
ui: the Open button rejoins the service's other actions

### DIFF
--- a/app/src/components/admin/ControllerPage.js
+++ b/app/src/components/admin/ControllerPage.js
@@ -270,7 +270,9 @@ function ServiceLogsModal({
 }
 
 // Mobile service row - simplified layout
-function MobileServiceRow({service, onAction}) {
+// Exported so tests can mount a row directly: `Media` renders neither branch in jsdom,
+// where no media query matches, so `ServicesSection` produces no rows at all there.
+export function MobileServiceRow({service, onAction}) {
     const {
         loading, logsOpen, setLogsOpen, logs, logsLoading, linesCount, countdown, logsRef,
         handleAction, fetchLogs, handleViewLogs, handleLinesChange, handleDownloadLogs,
@@ -320,6 +322,17 @@ function MobileServiceRow({service, onAction}) {
                     role='primary'
                     onClick={handleViewLogs}
                 />
+                {viewUrl && (
+                    <IconButton
+                        icon='external'
+                        label={`Open ${service.name}`}
+                        color='violet'
+                        component='a'
+                        href={viewUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    />
+                )}
                 </div>
                 <ServiceLogsModal
                     service={service}
@@ -334,24 +347,13 @@ function MobileServiceRow({service, onAction}) {
                     handleDownloadLogs={handleDownloadLogs}
                     fetchLogs={fetchLogs}
                 />
-                {viewUrl && (
-                    <IconButton
-                        icon='external'
-                        label={`Open ${service.name}`}
-                        color='violet'
-                        component='a'
-                        href={viewUrl}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                    />
-                )}
             </Table.Cell>
         </Table.Row>
     );
 }
 
 // Desktop service row - full layout with all columns
-function DesktopServiceRow({service, onAction, dockerized}) {
+export function DesktopServiceRow({service, onAction, dockerized}) {
     const {
         loading, logsOpen, setLogsOpen, logs, logsLoading, linesCount, countdown, logsRef,
         handleAction, fetchLogs, handleViewLogs, handleLinesChange, handleDownloadLogs,
@@ -402,6 +404,17 @@ function DesktopServiceRow({service, onAction, dockerized}) {
                     role='primary'
                     onClick={handleViewLogs}
                 />
+                {viewUrl && (
+                    <IconButton
+                        icon='external'
+                        label={`Open ${service.name}`}
+                        color='violet'
+                        component='a'
+                        href={viewUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    />
+                )}
                 </div>
                 <ServiceLogsModal
                     service={service}
@@ -416,17 +429,6 @@ function DesktopServiceRow({service, onAction, dockerized}) {
                     handleDownloadLogs={handleDownloadLogs}
                     fetchLogs={fetchLogs}
                 />
-                {viewUrl && (
-                    <IconButton
-                        icon='external'
-                        label={`Open ${service.name}`}
-                        color='violet'
-                        component='a'
-                        href={viewUrl}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                    />
-                )}
             </Table.Cell>
             {!dockerized && (
                 <Table.Cell>

--- a/app/src/components/admin/ControllerPage.test.js
+++ b/app/src/components/admin/ControllerPage.test.js
@@ -4,7 +4,8 @@ import {BrowserRouter} from 'react-router';
 import {MantineProvider} from '@mantine/core';
 import {ThemeContext, SettingsContext} from '../../contexts/contexts';
 import {cssVariablesResolver, mantineTheme} from '../../themes/mantine';
-import {ControllerPage} from './ControllerPage';
+import {ControllerPage, DesktopServiceRow, MobileServiceRow} from './ControllerPage';
+import {Table} from '../ui';
 
 // Mock the controller API
 jest.mock('../../api/controller', () => ({
@@ -350,5 +351,46 @@ describe('ControllerPage in Docker mode', () => {
         await waitFor(() => {
             expect(screen.getByText('Disk management is not available in Docker environments.')).toBeInTheDocument();
         });
+    });
+});
+
+describe('service action buttons', () => {
+    // `Media` renders neither branch in jsdom -- no media query matches -- so `ServicesSection`
+    // produces no rows there.  Mount the rows themselves instead.
+    const renderRow = (RowComponent, extraProps = {}) => render(
+        <BrowserRouter>
+            <MantineProvider theme={mantineTheme} cssVariablesResolver={cssVariablesResolver}>
+                <Table>
+                    <Table.Body>
+                        <RowComponent
+                            service={{
+                                name: 'wrolpi-api',
+                                port: 8081,
+                                status: 'running',
+                                viewable: true,
+                                view_path: '/docs',
+                                enabled: true,
+                            }}
+                            onAction={jest.fn()}
+                            {...extraProps}
+                        />
+                    </Table.Body>
+                </Table>
+            </MantineProvider>
+        </BrowserRouter>
+    );
+
+    test.each([
+        ['mobile', MobileServiceRow, {}],
+        ['desktop', DesktopServiceRow, {dockerized: false}],
+    ])('the %s row keeps Open on the same line as the other actions', (_name, RowComponent, extraProps) => {
+        renderRow(RowComponent, extraProps);
+        // Open used to sit outside `.wrolpi-button-row`, after the logs modal, which put it on a
+        // line of its own below the rest.  It belongs in the flex row with them.
+        const row = screen.getByLabelText('Open wrolpi-api').closest('.wrolpi-button-row');
+        expect(row).not.toBeNull();
+        expect(within(row).getByLabelText('Stop wrolpi-api')).toBeInTheDocument();
+        expect(within(row).getByLabelText('Restart wrolpi-api')).toBeInTheDocument();
+        expect(within(row).getByLabelText('View logs for wrolpi-api')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
On the Control tab, each service's action buttons — start/stop, restart, logs — live in a `.wrolpi-button-row`, a wrapping flex row. **Open** sat outside that row, after the logs modal, so it was a block-level sibling of the row rather than a member of it, and it rendered on a line of its own beneath the others. Both the mobile and the desktop row had it.

This moves it inside the row, after logs. Nothing else changes: same icon, same link, same left-to-right order. The row already wraps, so a narrow Actions column breaks it where it needs to, rather than a break being hard-coded at Open.

### Testing

The two row components are now exported. That was needed to test them at all: `Media` (`@artsy/fresnel`) renders neither branch under jsdom, where `matchMedia` matches nothing, so `ServicesSection` produces no service rows there — none of these buttons were reachable through the page.

The new test mounts each row and asserts Open shares a `.wrolpi-button-row` with stop, restart and logs. Checked against the old layout: both cases fail there.

- 68 suites / 1202 tests pass
- `npm run build` is clean
