### PR TITLE
ui: an icon button that was given a color, and never used it

### DIFF
--- a/app/src/components/ThemeSamplePage.js
+++ b/app/src/components/ThemeSamplePage.js
@@ -357,6 +357,21 @@ export function ThemeSamplePage() {
                     </Row>
                 </div>
                 <div style={{marginTop: 12}}>
+                    {/* An icon button takes a color the same way a labelled one does. It did
+                        not used to: with no role it fell back to Mantine's `default` variant,
+                        which reads only the default tokens, so a named color rendered exactly
+                        like no color at all. The pair below is what says it still works --
+                        each row should read as one color, in every theme. */}
+                    <Row>
+                        {['violet', 'blue', 'yellow'].map(color => <div key={color}
+                            style={{display: 'flex', gap: '0.4em', alignItems: 'center'}}>
+                            <Button color={color}>{color}</Button>
+                            <IconButton color={color} icon='external' label={`Open (${color})`}/>
+                        </div>)}
+                        <IconButton icon='external' label='Open (no color)'/>
+                    </Row>
+                </div>
+                <div style={{marginTop: 12}}>
                     <Row>
                         {['xs', 'sm', 'md', 'lg', 'xl'].map(size => <div key={size}
                             style={{display: 'flex', gap: '0.4em', alignItems: 'flex-start'}}>

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -162,7 +162,18 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((
         aria-label={label}
         title={label}
         color={props.color ?? fromRole?.color}
-        variant={props.variant ?? fromRole?.variant ?? 'default'}
+        /*
+         * `default` only when nothing was asked for.
+         *
+         * Mantine's `default` variant draws itself entirely from `--mantine-color-default*`
+         * and never reads `color`, so `<IconButton color='violet'/>` rendered byte-identical
+         * to one with no props at all -- eleven call sites were passing a color that could
+         * not reach a pixel, two of them the color a user had picked.  `Button` has no such
+         * fallback, which is why the same `color='violet'` works there: Mantine fills in
+         * `filled` on its own.  Match it, and keep the neutral default for the icon buttons
+         * that name no color, which is most of them.
+         */
+        variant={props.variant ?? fromRole?.variant ?? (props.color ? 'filled' : 'default')}
         className={[fromRole?.className, className].filter(Boolean).join(' ') || undefined}
         {...props}
         size={resolveSize(size)}

--- a/app/src/components/ui/ui.test.js
+++ b/app/src/components/ui/ui.test.js
@@ -309,6 +309,48 @@ describe('Button', () => {
 
         expect(screen.getByRole('button', {name: 'Delete channel'})).toBeInTheDocument();
     });
+
+    it('paints an icon button the color it was given', () => {
+        /*
+         * `IconButton` fell back to Mantine's `default` variant whenever no role was set, and
+         * that variant draws from `--mantine-color-default*` alone -- it never reads `color`.
+         * So a named color rendered byte-identical to no color at all, silently, at eleven
+         * call sites.  `Button` was never affected: it leaves `variant` undefined and Mantine
+         * fills in `filled`, which is why the same `color='violet'` worked there.
+         */
+        renderUI(<>
+            <IconButton icon='external' label='Open it' color='violet'/>
+            <IconButton icon='external' label='Plain'/>
+            <Button color='violet'>Labelled</Button>
+        </>);
+
+        const bg = (name, role = 'button') =>
+            screen.getByRole(role, {name}).getAttribute('style') || '';
+
+        // The color reaches the background, and matches what the labelled Button already did.
+        expect(bg('Open it')).toContain('var(--mantine-color-violet-filled)');
+        expect(bg('Labelled')).toContain('var(--mantine-color-violet-filled)');
+        // An icon button that names no color keeps the neutral default -- most of them.
+        expect(bg('Plain')).toContain('var(--mantine-color-default)');
+        expect(bg('Plain')).not.toContain('violet');
+    });
+
+    it('lets a role and an explicit variant still win over a color', () => {
+        // The color fallback is the LAST resort: it must not outrank either of the two ways a
+        // call site already had to state a variant, or `role='danger'` would lose its dashed
+        // night outline the moment someone also named a color.
+        renderUI(<>
+            <IconButton icon='trash' label='Roled' role='danger'/>
+            <IconButton icon='trash' label='Varianted' color='violet' variant='outline'/>
+        </>);
+
+        expect(screen.getByRole('button', {name: 'Roled'}))
+            .toHaveAttribute('data-variant', 'filled');
+        expect(screen.getByRole('button', {name: 'Roled'}))
+            .toHaveClass('wrolpi-button-danger');
+        expect(screen.getByRole('button', {name: 'Varianted'}))
+            .toHaveAttribute('data-variant', 'outline');
+    });
 });
 
 describe('Message', () => {


### PR DESCRIPTION
`IconButton` resolved its variant as:

```ts
variant={props.variant ?? fromRole?.variant ?? 'default'}
```

Any call site naming a **color** but no role and no variant therefore landed on Mantine's `default` variant — which draws its background, hover, text and border from `--mantine-color-default*` alone and **never reads `color`**. The button rendered byte-identical to one with no props at all:

```
<IconButton color='violet'/>   variant=default   --ai-bg: var(--mantine-color-default)
<IconButton/>                  variant=default   --ai-bg: var(--mantine-color-default)
<IconButton color='violet' variant='filled'/>    --ai-bg: var(--mantine-color-violet-filled)
```

`Button` was never affected — it leaves `variant` undefined and Mantine fills in `filled`, which is why the same `color='violet'` has always worked there. This makes `IconButton` match: `filled` when a color is named, `default` when one is not (most of them).

### The eleven call sites

Each was passing a color that could not reach a pixel:

| | |
|---|---|
| `DonatePage:19`, `Files:421` | the color **the user picked**, discarded |
| `Downloads:241,404,427,460` | `danger` and `blue` on the download controls |
| `ControllerPage:326,408,1591` | the service **Open** buttons |
| `FilePreview:71,541` | |

Both `violet` and `danger` are valid keys in our palette (`mantine.ts:28,39`) — the names were fine, the variant discarded them.

### Precedence

The color fallback is **last**, behind both `variant` and `role`, so `role='danger'` keeps its dashed night outline even when a color is also named. Tested.

### Verification

Checked in the browser across all four themes. Each icon button now matches the labelled button of the same color exactly; an icon button with no color keeps the neutral default:

```
light   violet  rgb(92,79,168)    both     no-color  rgb(255,255,255) + border
dark    violet  rgb(154,143,224)  both     no-color  rgb(38,41,43)    + border
night   violet  rgb(122,41,41)    both     no-color  rgb(22,4,4)      + border
amber   violet  rgb(122,76,20)    both     no-color  rgb(26,15,0)     + border
```

In night and amber the hues collapse to brightnesses, which is what those themes intend — the same thing already happens to labelled buttons.

The gallery grows one labelled/icon pair per hue, so a regression here is visible rather than silent.

- 68 suites / 1204 tests pass; the new test fails on the old fallback
- `npm run build` is clean
