### PR TITLE
review: the 375px phone this fix had not been measured on

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -371,19 +371,19 @@ table.table-ellipsis {
 }
 
 .table-ellipsis th.col-frequency {
-    width: 6.5em;
+    width: 6.9em;
 }
 
 .table-ellipsis th.col-completed {
-    width: 8em;
+    width: 8.3em;
 }
 
 .table-ellipsis th.col-completed-plain {
-    width: 6.75em;
+    width: 7em;
 }
 
 .table-ellipsis th.col-next {
-    width: 3.7em;
+    width: 3.9em;
 }
 
 /* A `ButtonGroup` cannot wrap -- its buttons are joined -- so this holds all three of them
@@ -436,20 +436,15 @@ table.table-ellipsis {
 }
 
 /*
- * A header is clipped by its column as a last resort.  Wrapping cannot save a single-word
- * label: the URL column is the elastic one, so on a 375px phone it is narrower than "URL"
- * plus its sort arrow, and the label ran into Completed At.  Nothing should paint outside
- * the column it belongs to, even when the column is too small for it.
+ * A header is clipped rather than painted over its neighbour.  Wrapping cannot save a
+ * single-word label in the elastic column, which may be narrower than the word itself.
  */
 .table-ellipsis th {
     overflow: hidden;
 }
 
-/*
- * `ButtonGroup` is a nowrap flex row whose children shrink, and in a narrow column they did --
- * a 23px button against its neighbour's 40px.  `col-control-group` is sized for the whole
- * group, so the buttons in it should not give.
- */
+/* `ButtonGroup` is a nowrap flex row whose children shrink; `col-control-group` is sized for
+   the whole group, so the buttons in it must not. */
 .table-ellipsis td .mantine-ButtonGroup-group > * {
     flex-shrink: 0;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -365,21 +365,39 @@ table.table-ellipsis {
  * 700px is the app's `tablet` breakpoint (`AppMedia` in contexts.js).  `em` here is the
  * table's own font (~15.4px), not the root's.
  */
+/*
+ * A header too long for a phone carries both forms and shows one.  The short word is what the
+ * mobile column widths below are sized for; the full words return at the breakpoint.
+ */
+.table-ellipsis th .label-long {
+    display: none;
+}
+
+@media (min-width: 700px) {
+    .table-ellipsis th .label-long {
+        display: inline;
+    }
+
+    .table-ellipsis th .label-short {
+        display: none;
+    }
+}
+
 .table-ellipsis th.col-select {
     /* 22px of checkbox plus 11px of cell padding either side. */
     width: 3em;
 }
 
 .table-ellipsis th.col-frequency {
-    width: 6.9em;
+    width: 4.2em;
 }
 
 .table-ellipsis th.col-completed {
-    width: 8.3em;
+    width: 5.5em;
 }
 
 .table-ellipsis th.col-completed-plain {
-    width: 7em;
+    width: 4.2em;
 }
 
 .table-ellipsis th.col-next {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -392,10 +392,10 @@ table.table-ellipsis {
     width: 9.5em;
 }
 
-/* A `.wrolpi-button-row` does wrap, so on a phone this is one button wide and the second
-   drops beneath it, which buys the URL column the width instead. */
+/* A `.wrolpi-button-row` wraps, so on a phone this holds one button and the second drops
+   beneath it.  It is sized by the word "Control" rather than by the button, which is wider. */
 .table-ellipsis th.col-control-row {
-    width: 4.5em;
+    width: 5.2em;
 }
 
 @media (min-width: 700px) {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -337,30 +337,13 @@ textarea.otp {
 }
 
 /*
- * A table that truncates to the width it has, rather than growing past it.
+ * A table that truncates to the width it has rather than growing past it: the columns divide
+ * the table's width, and `column-ellipsis` gives up what it cannot show.  A column that must
+ * fit something exact states a width on its header cell; the rest is the ellipsis column's.
  *
- * `table-layout: fixed` is what makes the truncation possible at all.  Under the default
- * `auto` layout a table is as wide as its columns want to be and the container simply
- * overflows -- on a 540px phone the downloads tables came out 676px and 727px, so Completed
- * At and Control sat off the right edge and the buttons could not be reached without
- * scrolling sideways.  Fixed layout inverts that: the columns get the table's width divided
- * between them, and the one marked `column-ellipsis` gives up what it cannot show.
- *
- * The old rule tried to do this with `max-width: 0` and `min-width: 25em`.  The max-width was
- * the usual trick for forcing an ellipsis under `auto` layout; the min-width was there so the
- * text column stayed readable -- but 25em is 385px, and a floor wider than the screen is what
- * made the overflow certain.  Under fixed layout neither is needed: the column width comes
- * from the header, and every other column is sized to its content so the ellipsis column
- * keeps the remainder.
- *
- * Columns that must fit something exact -- a checkbox, a group of buttons -- state a width on
- * their header cell.  Any column that does not is sized by what is left over.
- */
-/*
- * `table.` rather than the class alone: Mantine sets `table-layout` on its own
- * `.mantine-Table-table`, which is the same specificity and comes later in the cascade, so
- * the bare class silently lost and the table stayed `auto` -- with every other property here
- * applying, which made it look like the rule had worked.
+ * `table.`, not the bare class: Mantine sets `table-layout` on its own `.mantine-Table-table`
+ * at the same specificity and later in the cascade, so the bare class loses -- silently, with
+ * every other property here still applying.
  */
 table.table-ellipsis {
     width: 100%;
@@ -374,38 +357,76 @@ table.table-ellipsis {
 }
 
 /*
- * The one column width that has to change with the screen.
+ * Column widths for the downloads tables.  Phone first, and the phone is 375px: below the
+ * breakpoint each column is cut to what it must hold -- its header's longest word, the label
+ * wrapping, or its buttons -- and the URL takes what is left, which is little.  Above it the
+ * labels get their own line back and the URL gets the rest.
  *
- * Most headers here are sized to hold their own label on one line at any width -- a wrapped
- * label is a fallback, not a layout.  "Download Frequency" is the exception: 11.7em on one
- * line, which a phone cannot spare when four other columns need room, and it is one of five
- * columns rather than one of four.  So it wraps below the tablet breakpoint and gets its line
- * back above it, where the width costs nothing.
- *
- * 700px is the app's `tablet` breakpoint (see `AppMedia` in contexts.js).
+ * 700px is the app's `tablet` breakpoint (`AppMedia` in contexts.js).  `em` here is the
+ * table's own font (~15.4px), not the root's.
  */
+.table-ellipsis th.col-select {
+    /* 22px of checkbox plus 11px of cell padding either side. */
+    width: 3em;
+}
+
 .table-ellipsis th.col-frequency {
-    width: 7em;
+    width: 6.5em;
+}
+
+.table-ellipsis th.col-completed {
+    width: 8em;
+}
+
+.table-ellipsis th.col-completed-plain {
+    width: 6.75em;
+}
+
+.table-ellipsis th.col-next {
+    width: 3.7em;
+}
+
+/* A `ButtonGroup` cannot wrap -- its buttons are joined -- so this holds all three of them
+   (delete, edit, retry on a failed download) at every width. */
+.table-ellipsis th.col-control-group {
+    width: 9.5em;
+}
+
+/* A `.wrolpi-button-row` does wrap, so on a phone this is one button wide and the second
+   drops beneath it, which buys the URL column the width instead. */
+.table-ellipsis th.col-control-row {
+    width: 4.5em;
 }
 
 @media (min-width: 700px) {
     .table-ellipsis th.col-frequency {
         width: 12em;
     }
+
+    .table-ellipsis th.col-completed {
+        width: 9.5em;
+    }
+
+    .table-ellipsis th.col-completed-plain {
+        width: 8.5em;
+    }
+
+    .table-ellipsis th.col-next {
+        width: 4em;
+    }
+
+    .table-ellipsis th.col-control-row {
+        width: 7.5em;
+    }
 }
 
 /*
- * A header wraps instead of running into the next column.
+ * A header wraps instead of running into the next column: `.wrolpi-th-sort` is nowrap, which a
+ * fixed column cannot widen for, so a long label printed over its neighbour.
  *
- * `.wrolpi-th-sort` is `white-space: nowrap` so a sortable label never splits from its arrow.
- * That is right under `auto` layout, where the column widens to fit; under fixed layout the
- * column does not widen, so "Completed At" overran its cell and printed on top of "Control".
- * Wrapping to two lines is the only thing a fixed column can do with a label too long for it.
- *
- * `min-width: 0` as well as the wrap: the button is a flex container, and its text is an
- * anonymous flex item whose automatic minimum is its longest word.  Without this the label
- * still refuses to go below "Completed" and still overruns.  A column narrower than its
- * longest word is a width to fix at the call site, not something CSS can hide.
+ * `min-width: 0` as well as the wrap -- the label is an anonymous flex item whose automatic
+ * minimum is its longest word, and without this it still refuses to go below that word.  A
+ * column narrower than its longest word is a width to fix at the call site.
  */
 .table-ellipsis th .wrolpi-th-sort {
     display: flex;
@@ -415,12 +436,19 @@ table.table-ellipsis {
 }
 
 /*
- * Grouped buttons keep their size in a fixed column.
- *
- * `ButtonGroup` is a nowrap flex row whose children may shrink, and in a column too narrow
- * for them they did: the Stop button on a pending download was squeezed to 23px against its
- * neighbour's 40px, a target too small to hit and visibly clipped.  The column is sized for
- * the widest group it has to hold (three buttons), so the buttons themselves should not give.
+ * A header is clipped by its column as a last resort.  Wrapping cannot save a single-word
+ * label: the URL column is the elastic one, so on a 375px phone it is narrower than "URL"
+ * plus its sort arrow, and the label ran into Completed At.  Nothing should paint outside
+ * the column it belongs to, even when the column is too small for it.
+ */
+.table-ellipsis th {
+    overflow: hidden;
+}
+
+/*
+ * `ButtonGroup` is a nowrap flex row whose children shrink, and in a narrow column they did --
+ * a 23px button against its neighbour's 40px.  `col-control-group` is sized for the whole
+ * group, so the buttons in it should not give.
  */
 .table-ellipsis td .mantine-ButtonGroup-group > * {
     flex-shrink: 0;

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -337,19 +337,19 @@ function EditTagsModal() {
     }
 
     const tableHeaders = [
-        {key: 'delete', text: 'Delete', sortBy: null, width: 1},
-        {key: 'edit', text: 'Edit', sortBy: null, width: 1},
-        {key: 'name', text: 'Name', sortBy: 'name', width: 4},
-        {key: 'files', text: 'Files', sortBy: 'file_group_count', width: 2},
-        {key: 'zims', text: 'Zims', sortBy: 'zim_entry_count', width: 2},
-        {key: 'channels', text: 'Channels', sortBy: 'channel_count', width: 2},
-        {key: 'domains', text: 'Domains', sortBy: 'domain_count', width: 2},
+        {key: 'delete', text: 'Delete', sortBy: null},
+        {key: 'edit', text: 'Edit', sortBy: null},
+        {key: 'name', text: 'Name', sortBy: 'name'},
+        {key: 'files', text: 'Files', sortBy: 'file_group_count'},
+        {key: 'zims', text: 'Zims', sortBy: 'zim_entry_count'},
+        {key: 'channels', text: 'Channels', sortBy: 'channel_count'},
+        {key: 'domains', text: 'Domains', sortBy: 'domain_count'},
     ];
     const mobileTableHeaders = [
-        {key: 'delete', text: 'Delete', sortBy: null, width: 2},
-        {key: 'edit', text: 'Edit', sortBy: null, width: 2},
-        {key: 'name', text: 'Name', sortBy: 'name', width: 8},
-        {key: 'count', text: 'Count', sortBy: i => i['file_group_count'] + i['zim_entry_count'] + i['channel_count'] + i['domain_count'], width: 4},
+        {key: 'delete', text: 'Delete', sortBy: null},
+        {key: 'edit', text: 'Edit', sortBy: null},
+        {key: 'name', text: 'Name', sortBy: 'name'},
+        {key: 'count', text: 'Count', sortBy: i => i['file_group_count'] + i['zim_entry_count'] + i['channel_count'] + i['domain_count']},
     ];
 
     return <>

--- a/app/src/components/SortableTable.js
+++ b/app/src/components/SortableTable.js
@@ -44,24 +44,22 @@ export class SortableTable extends React.Component {
         const data = this.props['data'] ? this.sortData(this.props['data']) : null;
 
         const tableHeader = (spec) => {
-            // `width` is how a column that must fit something exact -- a checkbox, a group of
-            // buttons -- states its size.  Under `table-layout: fixed` (see `.table-ellipsis`)
-            // the header cell is where a column's width is declared; columns that name none
-            // divide what is left, which is what the truncating column wants.
-            const {key, text, sortBy, width} = spec;
-            const style = width ? {width} : undefined;
+            // Under `table-layout: fixed` the header cell is where a column's width is
+            // declared; a column that names none divides what is left.  `className` rather
+            // than a width so the value can change at a breakpoint.
+            const {key, text, sortBy, className} = spec;
             if (sortBy) {
                 const active = sortColumn === key;
                 return <Table.HeaderCell
                     key={key}
-                    style={style}
+                    className={className}
                     sorted={active ? direction : null}
                     onSort={() => this.changeSort(key)}
                 >
                     {text}
                 </Table.HeaderCell>;
             } else {
-                return <Table.HeaderCell key={key} style={style}>{text}</Table.HeaderCell>
+                return <Table.HeaderCell key={key} className={className}>{text}</Table.HeaderCell>
             }
         }
 

--- a/app/src/components/Zim.js
+++ b/app/src/components/Zim.js
@@ -440,9 +440,9 @@ class ManageZim extends React.Component {
         const {zims, catalog, iso_639_codes, subscriptions} = this.state;
 
         const zimFilesHeaders = [
-            {key: 'path', text: 'Path', sortBy: 'path', width: 14},
-            {key: 'size', text: 'Size', sortBy: 'size', width: 2},
-            {key: 'search', text: 'Search', sortBy: 'auto_search', width: 2},
+            {key: 'path', text: 'Path', sortBy: 'path'},
+            {key: 'size', text: 'Size', sortBy: 'size'},
+            {key: 'search', text: 'Search', sortBy: 'auto_search'},
         ];
         let zimFilesBody = <Placeholder lines={2}/>;
         if (zims && zims.length >= 1) {
@@ -464,11 +464,11 @@ class ManageZim extends React.Component {
             {
                 key: 'name', text: 'Name', 'sortBy': [i => {
                     return i['name'].toLowerCase()
-                }], width: 8
+                }]
             },
-            {key: 'language', text: 'Language', 'sortBy': null, width: 4},
-            {key: 'subscription', text: 'Subscription', 'sortBy': null, width: 2},
-            {key: 'size', text: 'Maximum Size', sortBy: 'size', width: 2},
+            {key: 'language', text: 'Language', 'sortBy': null},
+            {key: 'subscription', text: 'Subscription', 'sortBy': null},
+            {key: 'size', text: 'Maximum Size', sortBy: 'size'},
         ];
         let kiwixCatalog = <Placeholder lines={2}/>;
         if (catalog && catalog.length > 0) {

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -58,12 +58,8 @@ function DownloadProgressModal({progress, url}) {
 
     const speedText = humanBandwidth(progress.speed);
     const etaText = progress.eta || '...';
-    /*
-     * A percent, not "5 MBps / 3m44s".  This button lives in the Completed At column, which is
-     * sized for its header; the speed-and-ETA label measured 169-188px against 124px of column
-     * and was clipped by the cell beside it.  Nothing is lost by shortening it -- the modal it
-     * opens already lists speed, ETA and bytes, which is where a reader goes for the detail.
-     */
+    // A percent: this button sits in a column sized for its header, and speed-and-ETA does not
+    // fit there.  The modal it opens carries the detail, and `title` the full text.
     const buttonLabel = Number.isFinite(progress.percent) ? `${Math.round(progress.percent)}%` : '...';
 
     return <>

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -58,10 +58,17 @@ function DownloadProgressModal({progress, url}) {
 
     const speedText = humanBandwidth(progress.speed);
     const etaText = progress.eta || '...';
-    const buttonLabel = `${speedText} / ${etaText}`;
+    /*
+     * A percent, not "5 MBps / 3m44s".  This button lives in the Completed At column, which is
+     * sized for its header; the speed-and-ETA label measured 169-188px against 124px of column
+     * and was clipped by the cell beside it.  Nothing is lost by shortening it -- the modal it
+     * opens already lists speed, ETA and bytes, which is where a reader goes for the detail.
+     */
+    const buttonLabel = Number.isFinite(progress.percent) ? `${Math.round(progress.percent)}%` : '...';
 
     return <>
-        <Button size='small' onClick={() => setOpen(true)} style={{marginLeft: '0.5em'}}>
+        <Button size='small' onClick={() => setOpen(true)} style={{marginLeft: '0.5em'}}
+                title={`${speedText} / ${etaText}`}>
             {buttonLabel}
         </Button>
         <Modal closeIcon open={open} onClose={() => setOpen(false)} size='fullscreen'>
@@ -584,16 +591,8 @@ export function OnceDownloadsTable({downloads, fetchDownloads}) {
         }
     };
 
-    /*
-     * Widths for everything except the URL, which takes what is left and truncates.  See
-     * `.table-ellipsis` in App.css: under fixed layout a column with no width stated gets an
-     * equal share, which would give a checkbox as much room as a URL.
-     *
-     * The numbers are what the content needs, measured: a checkbox is 2.5em; "Completed At" is
-     * 9.5em on one line with its sort arrow, which is narrow enough to keep on a phone rather
-     * than wrapping it there; and Control is 9.5em, which holds the widest button group a row
-     * can have (a failed download shows delete, edit and retry).
-     */
+    // Widths come from the `col-*` classes in App.css, which change at the tablet breakpoint.
+    // Only the URL names none: it takes the remainder and truncates.
     const tableHeaders = [
         {
             key: 'select',
@@ -603,12 +602,12 @@ export function OnceDownloadsTable({downloads, fetchDownloads}) {
                 onChange={toggleSelectAll}
             />,
             sortBy: null,
-            width: '2.5em',
+            className: 'col-select',
         },
         {key: 'url', text: 'URL', sortBy: i => i.url.toLowerCase()},
         {key: 'completed_at', text: 'Completed At', sortBy: i => i.last_successful_download || '',
-            width: '9.5em'},
-        {key: 'control', text: 'Control', sortBy: null, width: '9.5em'},
+            className: 'col-completed'},
+        {key: 'control', text: 'Control', sortBy: null, className: 'col-control-group'},
     ];
 
     const rowFunc = (download) => (
@@ -666,22 +665,17 @@ export function RecurringDownloadsTable({downloads, fetchDownloads, onDelete}) {
     if (downloads && downloads.length >= 1) {
         return <Table className='table-ellipsis'>
             <Table.Header>
-                {/* Widths in em, not percentages: what each of these columns has to hold is a
-                    fixed amount of text or a fixed number of buttons, and a percentage of a
-                    phone's width is not that.  At 50% the URL column was 385px on a 540px
-                    screen and pushed Next and Control off the edge.  Only the URL is elastic
-                    now -- it takes the remainder and truncates, which is its job.
-
-                    "Download Frequency" is the one label too long to keep on one line on a
-                    phone, so its width comes from `.col-frequency` in App.css, which widens at
-                    the tablet breakpoint. The rest are sized to hold their label unwrapped at
-                    any width. */}
+                {/* Widths come from the `col-*` classes in App.css, not percentages: what each
+                    column holds is a fixed amount of text or a fixed number of buttons, and a
+                    percentage of a phone's width is not that. Only the URL names none -- it
+                    takes the remainder and truncates. */}
                 <Table.Row>
                     <Table.HeaderCell>URL</Table.HeaderCell>
                     <Table.HeaderCell className='col-frequency'>Download Frequency</Table.HeaderCell>
-                    <Table.HeaderCell style={{width: '8.5em'}}>Completed At</Table.HeaderCell>
-                    <Table.HeaderCell style={{width: '4em'}}>Next</Table.HeaderCell>
-                    <Table.HeaderCell style={{width: '7.5em', textAlign: 'right'}}>Control</Table.HeaderCell>
+                    <Table.HeaderCell className='col-completed-plain'>Completed At</Table.HeaderCell>
+                    <Table.HeaderCell className='col-next'>Next</Table.HeaderCell>
+                    <Table.HeaderCell className='col-control-row'
+                                      style={{textAlign: 'right'}}>Control</Table.HeaderCell>
                 </Table.Row>
             </Table.Header>
             <Table.Body>

--- a/app/src/components/admin/Downloads.js
+++ b/app/src/components/admin/Downloads.js
@@ -52,6 +52,13 @@ import {
 import {Downloaders} from "../Vars";
 import {SortableTable} from "../SortableTable";
 
+// A header too long for a phone.  Both forms are rendered and `.label-*` in App.css shows
+// one; the mobile column widths are sized for the short word.
+const shortHeader = (short, full) => <>
+    <span className='label-short'>{short}</span>
+    <span className='label-long'>{full}</span>
+</>;
+
 function DownloadProgressModal({progress, url}) {
     const [open, setOpen] = React.useState(false);
     const [navColor] = useLocalStorage('nav_color', 'violet');
@@ -601,8 +608,8 @@ export function OnceDownloadsTable({downloads, fetchDownloads}) {
             className: 'col-select',
         },
         {key: 'url', text: 'URL', sortBy: i => i.url.toLowerCase()},
-        {key: 'completed_at', text: 'Completed At', sortBy: i => i.last_successful_download || '',
-            className: 'col-completed'},
+        {key: 'completed_at', text: shortHeader('Done', 'Completed At'),
+            sortBy: i => i.last_successful_download || '', className: 'col-completed'},
         {key: 'control', text: 'Control', sortBy: null, className: 'col-control-group'},
     ];
 
@@ -667,8 +674,12 @@ export function RecurringDownloadsTable({downloads, fetchDownloads, onDelete}) {
                     takes the remainder and truncates. */}
                 <Table.Row>
                     <Table.HeaderCell>URL</Table.HeaderCell>
-                    <Table.HeaderCell className='col-frequency'>Download Frequency</Table.HeaderCell>
-                    <Table.HeaderCell className='col-completed-plain'>Completed At</Table.HeaderCell>
+                    <Table.HeaderCell className='col-frequency'>
+                        {shortHeader('Freq', 'Download Frequency')}
+                    </Table.HeaderCell>
+                    <Table.HeaderCell className='col-completed-plain'>
+                        {shortHeader('Done', 'Completed At')}
+                    </Table.HeaderCell>
                     <Table.HeaderCell className='col-next'>Next</Table.HeaderCell>
                     <Table.HeaderCell className='col-control-row'
                                       style={{textAlign: 'right'}}>Control</Table.HeaderCell>

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1573,7 +1573,7 @@ describe('a truncating table fits the width it is given', () => {
                 });
             });
 
-            it(`${name} keeps every header inside its own column on a phone`, () => {
+            it(`${name} never paints a header outside its column on a phone`, () => {
                 cy.viewport(PHONE, 700);
                 cy.mountUI(table);
 
@@ -1581,22 +1581,27 @@ describe('a truncating table fits the width it is given', () => {
                     [...$ths].forEach(th => {
                         const label = th.textContent.trim();
                         if (!label) return;
-                        // The sortable headers put their label in `.wrolpi-th-sort`; the plain
-                        // ones are a text node, so measure the text rather than a child element
-                        // -- checking `firstElementChild` alone silently skips them.
-                        const sort = th.querySelector('.wrolpi-th-sort');
-                        if (sort) {
-                            expect(sort.getBoundingClientRect().right,
-                                `"${label}" stays inside its column`)
-                                .to.be.at.most(th.getBoundingClientRect().right + 1);
+                        /*
+                         * The two kinds of column promise different things.  A column given a
+                         * width must be wide enough for its own label, wrapping it if need be.
+                         * The elastic one takes whatever is left and can be narrower than its
+                         * own label -- "URL" plus its sort arrow is 50px against 36px of
+                         * column here, and one word cannot wrap -- so what holds it in is the
+                         * clip, not the fit.
+                         *
+                         * `scrollWidth` against `clientWidth` measures the content either way,
+                         * whether the label is a text node or the flex button a sortable header
+                         * puts it in, and it still reports the overflow once the cell clips it.
+                         */
+                        if (th.className.includes('col-')) {
+                            expect(th.scrollWidth,
+                                `"${label}" fits the width its column was given`)
+                                .to.be.at.most(th.clientWidth + 1);
+                        } else {
+                            expect(getComputedStyle(th).overflow,
+                                `"${label}" is clipped rather than painted over its neighbour`)
+                                .to.not.equal('visible');
                         }
-                        // Either it fits on one line, or it wrapped; what it must not do is
-                        // stay on one line wider than the column it was given.
-                        const need = oneLineWidth(th);
-                        const room = contentWidth(th);
-                        const wrapped = getComputedStyle(sort || th).whiteSpace !== 'nowrap';
-                        expect(need <= room + 1 || wrapped,
-                            `"${label}" either fits or is allowed to wrap`).to.equal(true);
                     });
                 });
             });

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1457,11 +1457,17 @@ describe('a truncating table fits the width it is given', () => {
      * has no such competitor, so it would report `fixed` either way.  `.wrolpi-th-sort` and
      * the cell padding only exist on the real components too.
      */
+    const shortHeader = (short, full) => <>
+        <span className='label-short'>{short}</span>
+        <span className='label-long'>{full}</span>
+    </>;
+
     const columns = [
         {key: 'select', text: <Checkbox readOnly checked={false} aria-label='Select all'/>,
             className: 'col-select'},
         {key: 'url', text: 'URL', sortBy: i => i},
-        {key: 'completed_at', text: 'Completed At', sortBy: i => i, className: 'col-completed'},
+        {key: 'completed_at', text: shortHeader('Done', 'Completed At'), sortBy: i => i,
+            className: 'col-completed'},
         {key: 'control', text: 'Control', className: 'col-control-group'},
     ];
 
@@ -1493,8 +1499,12 @@ describe('a truncating table fits the width it is given', () => {
         <Table.Header>
             <Table.Row>
                 <Table.HeaderCell>URL</Table.HeaderCell>
-                <Table.HeaderCell className='col-frequency'>Download Frequency</Table.HeaderCell>
-                <Table.HeaderCell className='col-completed-plain'>Completed At</Table.HeaderCell>
+                <Table.HeaderCell className='col-frequency'>
+                    {shortHeader('Freq', 'Download Frequency')}
+                </Table.HeaderCell>
+                <Table.HeaderCell className='col-completed-plain'>
+                    {shortHeader('Done', 'Completed At')}
+                </Table.HeaderCell>
                 <Table.HeaderCell className='col-next'>Next</Table.HeaderCell>
                 <Table.HeaderCell className='col-control-row'>Control</Table.HeaderCell>
             </Table.Row>
@@ -1535,7 +1545,8 @@ describe('a truncating table fits the width it is given', () => {
         probe.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
         th.appendChild(probe);
         let longest = 0;
-        th.textContent.trim().split(/\s+/).filter(Boolean).forEach((word) => {
+        // A header may carry a short and a long form; `innerText` reads only the shown one.
+        (th.innerText || th.textContent).trim().split(/\s+/).filter(Boolean).forEach((word) => {
             probe.textContent = word;
             longest = Math.max(longest, probe.getBoundingClientRect().width);
         });
@@ -1550,7 +1561,7 @@ describe('a truncating table fits the width it is given', () => {
     const oneLineWidth = (th) => {
         const probe = document.createElement('span');
         probe.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
-        probe.textContent = th.textContent.trim();
+        probe.textContent = (th.innerText || th.textContent).trim();
         th.appendChild(probe);
         const need = probe.getBoundingClientRect().width;
         probe.remove();
@@ -1599,7 +1610,8 @@ describe('a truncating table fits the width it is given', () => {
 
                 cy.get('table.table-ellipsis thead th').should(($ths) => {
                     [...$ths].forEach(th => {
-                        const label = th.textContent.trim();
+                        // The visible form, so a failure names what the reader actually sees.
+                        const label = (th.innerText || th.textContent).trim();
                         if (!label) return;
                         /*
                          * A column given a width must hold its own label, wrapping it if it
@@ -1637,29 +1649,33 @@ describe('a truncating table fits the width it is given', () => {
         });
     });
 
-    it('gives a long header its own line back on a desktop', () => {
+    it('shows the short header on a phone and the full words on a desktop', () => {
         /*
-         * A wrapped label is the fallback, not the layout.  "Download Frequency" is too long
-         * for a phone beside four other columns, so `.col-frequency` is narrow below the
-         * tablet breakpoint and wide above it.
+         * Five columns plus five full-length headers do not fit a phone: sized for
+         * "Download Frequency" and "Completed At", the URL column came out 20px, which is
+         * narrower than one character and its ellipsis.  The short word is what the phone
+         * widths are sized for, and the full one returns where there is room for it.
          */
-        const widthOfFrequency = () => cy.get('th.col-frequency')
-            .then(($th) => $th[0].getBoundingClientRect().width);
+        const shown = ($th) => ($th[0].innerText || '').trim();
 
         cy.viewport(PHONE, 700);
         cy.mountUI(recurringTable);
-        widthOfFrequency().then((narrow) => {
-            cy.viewport(1200, 700);
-            cy.mountUI(recurringTable);
-            widthOfFrequency().then((wide) => {
-                expect(wide, 'the column widens past the tablet breakpoint')
-                    .to.be.greaterThan(narrow);
-                cy.get('th.col-frequency').should(($th) => {
-                    expect(oneLineWidth($th[0]), '"Download Frequency" fits on one line')
-                        .to.be.at.most(contentWidth($th[0]));
-                });
-            });
+        cy.get('th.col-frequency').should(($th) => expect(shown($th), 'phone').to.equal('Freq'));
+        cy.get('th.col-completed-plain').should(($th) => expect(shown($th), 'phone').to.equal('Done'));
+        // And the width that buys: the URL column is readable rather than a placeholder.
+        cy.get('td.column-ellipsis').should(($cell) =>
+            expect($cell[0].getBoundingClientRect().width, 'the URL column is usable')
+                .to.be.greaterThan(90));
+
+        cy.viewport(1200, 700);
+        cy.mountUI(recurringTable);
+        cy.get('th.col-frequency').should(($th) => {
+            expect(shown($th), 'desktop').to.equal('Download Frequency');
+            expect(oneLineWidth($th[0]), 'and it fits on one line')
+                .to.be.at.most(contentWidth($th[0]));
         });
+        cy.get('th.col-completed-plain').should(($th) =>
+            expect(shown($th), 'desktop').to.equal('Completed At'));
     });
 
     it('keeps grouped buttons at full size in a narrow column', () => {

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
-    ActionInput, Button, ButtonGroup, Card, Header, Icon, IconButton, IconStack, Loading, MultiSelect, Panel, PathInput,
+    ActionInput, Button, ButtonGroup, Card, Checkbox, Header, Icon, IconButton, IconStack, Loading, MultiSelect,
+    Panel, PathInput,
     Group, Message, Pagination, Placeholder, Progress, SearchBox, Statistic, StatisticGroup, Status, TabBar, Table,
     tabClassName, TextInput,
 } from './index';
@@ -15,6 +16,7 @@ import {NavBarSample} from '../ThemeSamplePage';
 import {DesktopNav, NavIconWrapper} from '../Nav';
 import {APIButton} from '../Common';
 import {ShareButton} from '../Share';
+import {SortableTable} from '../SortableTable';
 
 /*
  * The interface scale, so a test can express a length the way the stylesheet does.
@@ -1450,158 +1452,193 @@ describe('table rules', () => {
 
 describe('a truncating table fits the width it is given', () => {
     /*
-     * The downloads tables ran off the side of a phone: 676px and 727px of table in a 540px
-     * window, so Completed At and Control were off the right edge and their buttons could not
-     * be reached without scrolling sideways.  `.table-ellipsis` was trying to truncate under
-     * `table-layout: auto`, where a table is as wide as its columns want to be, and the
-     * `min-width: 25em` floor on the truncating column made overflowing certain.
-     *
-     * None of this is visible in jsdom -- it is all resolved widths, and the fix turns on
-     * whether our `table-layout` beats the one Mantine sets on its own class. It did not, at
-     * first: every other property in the rule applied, so the table looked fixed and stayed
-     * auto.  These measure the rendered table instead.
+     * Mount the real `Table`, `Table.HeaderCell onSort` and `Checkbox`, not native tags: the
+     * rule under test has to beat Mantine's own `.mantine-Table-table`, and a raw `<table>`
+     * has no such competitor, so it would report `fixed` either way.  `.wrolpi-th-sort` and
+     * the cell padding only exist on the real components too.
      */
-    const wideTable = <table className='table-ellipsis'>
-        <thead>
-        <tr>
-            <th style={{width: '2.5em'}}><input type='checkbox' readOnly checked={false}/></th>
-            <th>URL</th>
-            <th style={{width: '8em'}}>Completed At</th>
-            <th style={{width: '9.5em'}}>Control</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td><input type='checkbox' readOnly checked={false}/></td>
-            <td className='column-ellipsis'>
-                https://example.com/a/very/long/path/that/no/phone/could/ever/show/in/full
-            </td>
-            <td>3 days</td>
-            <td>
-                <ButtonGroup>
-                    <IconButton icon='trash' label='Delete' role='danger'/>
-                    <IconButton icon='edit' label='Edit'/>
-                    <IconButton icon='refresh' label='Retry' role='retry'/>
-                </ButtonGroup>
-            </td>
-        </tr>
-        </tbody>
-    </table>;
+    const columns = [
+        {key: 'select', text: <Checkbox readOnly checked={false} aria-label='Select all'/>,
+            className: 'col-select'},
+        {key: 'url', text: 'URL', sortBy: i => i},
+        {key: 'completed_at', text: 'Completed At', sortBy: i => i, className: 'col-completed'},
+        {key: 'control', text: 'Control', className: 'col-control-group'},
+    ];
 
-    const mountNarrow = () => cy.viewport(400, 700).then(() => cy.mountUI(wideTable));
+    const row = <Table.Row>
+        <Table.Cell><Checkbox readOnly checked={false} aria-label='Select row'/></Table.Cell>
+        <Table.Cell className='column-ellipsis'>
+            https://example.com/a/very/long/path/that/no/phone/could/ever/show/in/full
+        </Table.Cell>
+        <Table.Cell>3 days</Table.Cell>
+        <Table.Cell>
+            <ButtonGroup>
+                <IconButton icon='trash' label='Delete' role='danger'/>
+                <IconButton icon='edit' label='Edit'/>
+                <IconButton icon='refresh' label='Retry' role='retry'/>
+            </ButtonGroup>
+        </Table.Cell>
+    </Table.Row>;
 
-    it('does not grow past its container on a phone', () => {
-        mountNarrow();
+    const onceTable = <SortableTable
+        tableHeaders={columns}
+        data={['one']}
+        rowFunc={() => row}
+        rowKey='0'
+        tableProps={{className: 'table-ellipsis'}}
+    />;
 
-        cy.get('table.table-ellipsis').should(($t) => {
-            const table = $t[0];
-            // The rule that does the work.  Asserted directly because it is the one that lost
-            // to Mantine's own class, silently, while the rest of the rule applied.
-            expect(getComputedStyle(table).tableLayout, 'fixed layout').to.equal('fixed');
-            expect(table.getBoundingClientRect().width, 'table fits its container')
-                .to.be.at.most(table.parentElement.clientWidth + 1);
-        });
-    });
+    // The five-column table, which is the one that runs out of room first.
+    const recurringTable = <Table className='table-ellipsis'>
+        <Table.Header>
+            <Table.Row>
+                <Table.HeaderCell>URL</Table.HeaderCell>
+                <Table.HeaderCell className='col-frequency'>Download Frequency</Table.HeaderCell>
+                <Table.HeaderCell className='col-completed-plain'>Completed At</Table.HeaderCell>
+                <Table.HeaderCell className='col-next'>Next</Table.HeaderCell>
+                <Table.HeaderCell className='col-control-row'>Control</Table.HeaderCell>
+            </Table.Row>
+        </Table.Header>
+        <Table.Body>
+            <Table.Row>
+                <Table.Cell className='column-ellipsis'>
+                    https://example.com/a/very/long/path/that/no/phone/could/ever/show/in/full
+                </Table.Cell>
+                <Table.Cell>30 Days</Table.Cell>
+                <Table.Cell>63d</Table.Cell>
+                <Table.Cell>now</Table.Cell>
+                <Table.Cell>
+                    <div className='wrolpi-button-row'>
+                        <IconButton icon='edit' label='Edit recurring'/>
+                        <IconButton icon='refresh' label='Retry recurring' role='retry'/>
+                    </div>
+                </Table.Cell>
+            </Table.Row>
+        </Table.Body>
+    </Table>;
 
-    it('spends the leftover width on the column that truncates', () => {
-        mountNarrow();
+    // The narrowest phone supported, and the width at which five columns run out of room.
+    const PHONE = 375;
 
-        cy.get('td.column-ellipsis').should(($cell) => {
-            const cell = $cell[0];
-            // It gives up what it cannot show...
-            expect(cell.scrollWidth, 'the long URL is truncated').to.be.greaterThan(cell.clientWidth);
-            /*
-             * ...and it gets precisely what the sized columns did not take.  Measured against
-             * the row rather than against a threshold: a lower bound alone would also pass if
-             * the column were far too WIDE, which is exactly what losing `table-layout: fixed`
-             * would do.
-             */
-            const row = cell.closest('tr');
-            const cells = [...row.children];
-            const sized = cells
-                .filter(td => td !== cell)
-                .reduce((total, td) => total + td.getBoundingClientRect().width, 0);
-            // The row's box is a few px wider than its cells put together -- the table's own
-            // borders -- so take that from the row itself rather than allowing a fixed slack.
-            const chrome = row.getBoundingClientRect().width
-                - cells.reduce((total, td) => total + td.getBoundingClientRect().width, 0);
-            const leftover = row.getBoundingClientRect().width - sized - chrome;
+    const contentWidth = (el) => {
+        const cs = getComputedStyle(el);
+        return el.getBoundingClientRect().width
+            - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+    };
 
-            expect(leftover, 'the sized columns left something over').to.be.greaterThan(0);
-            expect(cell.getBoundingClientRect().width, 'and the URL column is exactly that')
-                .to.be.closeTo(leftover, 1);
-            // The sized columns took what they asked for, which is what makes the line above
-            // more than arithmetic: if leftover leaked, one of these would have absorbed it.
-            const declared = {'col-select': 2.5, 'col-completed': 8, 'col-control-group': 9.5};
-            const em = parseFloat(getComputedStyle(cell).fontSize);
-            cells.filter(td => td !== cell).forEach((td, i) => {
-                const width = Object.values(declared)[i] * em;
-                expect(td.getBoundingClientRect().width, `sized column ${i} kept its width`)
-                    .to.be.closeTo(width, 2);
+    // What the label would need on one line, measured in its own cell.
+    const oneLineWidth = (th) => {
+        const probe = document.createElement('span');
+        probe.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
+        probe.textContent = th.textContent.trim();
+        th.appendChild(probe);
+        const need = probe.getBoundingClientRect().width;
+        probe.remove();
+        return need;
+    };
+
+    [['the once-downloads table', onceTable], ['the recurring table', recurringTable]]
+        .forEach(([name, table]) => {
+            it(`${name} fits a 375px phone, with width left for the URL`, () => {
+                cy.viewport(PHONE, 700);
+                cy.mountUI(table);
+
+                cy.get('table.table-ellipsis').should(($t) => {
+                    const el = $t[0];
+                    // The assertion that fails if the selector stops beating Mantine's.
+                    expect(getComputedStyle(el).tableLayout, 'fixed layout').to.equal('fixed');
+                    expect(el.getBoundingClientRect().width, 'table fits its container')
+                        .to.be.at.most(el.parentElement.clientWidth + 1);
+                });
+                cy.get('td.column-ellipsis').should(($cell) => {
+                    const cell = $cell[0];
+                    /*
+                     * The URL column is whatever the sized columns did not take.  Measured
+                     * against the row rather than a floor: a lower bound alone would also
+                     * pass on a column that had grown, which is what losing `table-layout:
+                     * fixed` does.
+                     */
+                    const row = cell.closest('tr');
+                    const cells = [...row.children];
+                    const width = (td) => td.getBoundingClientRect().width;
+                    const sized = cells.filter(td => td !== cell).reduce((t, td) => t + width(td), 0);
+                    // The row's box exceeds its cells by the table's own borders.
+                    const chrome = width(row) - cells.reduce((t, td) => t + width(td), 0);
+                    const leftover = width(row) - sized - chrome;
+
+                    expect(leftover, 'the sized columns leave something over').to.be.greaterThan(0);
+                    expect(width(cell), 'and the URL column is exactly that')
+                        .to.be.closeTo(leftover, 1);
+                    expect(cell.scrollWidth, 'the long URL truncates').to.be.greaterThan(cell.clientWidth);
+                });
+            });
+
+            it(`${name} keeps every header inside its own column on a phone`, () => {
+                cy.viewport(PHONE, 700);
+                cy.mountUI(table);
+
+                cy.get('table.table-ellipsis thead th').should(($ths) => {
+                    [...$ths].forEach(th => {
+                        const label = th.textContent.trim();
+                        if (!label) return;
+                        // The sortable headers put their label in `.wrolpi-th-sort`; the plain
+                        // ones are a text node, so measure the text rather than a child element
+                        // -- checking `firstElementChild` alone silently skips them.
+                        const sort = th.querySelector('.wrolpi-th-sort');
+                        if (sort) {
+                            expect(sort.getBoundingClientRect().right,
+                                `"${label}" stays inside its column`)
+                                .to.be.at.most(th.getBoundingClientRect().right + 1);
+                        }
+                        // Either it fits on one line, or it wrapped; what it must not do is
+                        // stay on one line wider than the column it was given.
+                        const need = oneLineWidth(th);
+                        const room = contentWidth(th);
+                        const wrapped = getComputedStyle(sort || th).whiteSpace !== 'nowrap';
+                        expect(need <= room + 1 || wrapped,
+                            `"${label}" either fits or is allowed to wrap`).to.equal(true);
+                    });
+                });
             });
         });
-    });
 
-    it('wraps a header rather than printing it over the next column', () => {
-        // The fixture gives "Completed At" 8em deliberately -- less than the 9.33em it needs
-        // on one line -- because wrapping is the behavior under test. `.wrolpi-th-sort` is
-        // nowrap, so before this the label ran on into Control and the two printed on top of
-        // each other. The real tables are sized to hold their labels; this is the fallback.
-        mountNarrow();
+    it('sizes the select column for a real checkbox', () => {
+        // 2.5em left 16.5px of content for a 22px Checkbox, which hung into the URL column.
+        // Only a real `Checkbox` in a real `Table.HeaderCell` has both those numbers.
+        cy.viewport(PHONE, 700);
+        cy.mountUI(onceTable);
 
-        cy.get('table.table-ellipsis thead th').should(($ths) => {
-            [...$ths].forEach(th => {
-                const inner = th.firstElementChild;
-                if (!inner) return;
-                expect(inner.getBoundingClientRect().right,
-                    `"${th.textContent.trim()}" stays inside its column`)
-                    .to.be.at.most(th.getBoundingClientRect().right + 1);
-            });
+        cy.get('th.col-select').should(($th) => {
+            const th = $th[0];
+            const box = th.querySelector('.mantine-Checkbox-root, input[type=checkbox]');
+            expect(box, 'the header holds a real Checkbox').to.not.equal(null);
+            expect(box.getBoundingClientRect().right, 'the checkbox stays inside its column')
+                .to.be.at.most(th.getBoundingClientRect().right + 0.5);
+            expect(box.getBoundingClientRect().width, 'and is not itself squeezed')
+                .to.be.at.most(contentWidth(th) + 0.5);
         });
     });
 
     it('gives a long header its own line back on a desktop', () => {
         /*
-         * A wrapped label is the fallback, not the layout.  "Download Frequency" is 11.7em on
-         * one line, which a phone cannot spare beside four other columns, so `.col-frequency`
-         * carries a narrow width below the tablet breakpoint and a wide one above it.  Without
-         * the media query the label wrapped at every width, including a 1400px desktop with
-         * hundreds of pixels going spare.
+         * A wrapped label is the fallback, not the layout.  "Download Frequency" is too long
+         * for a phone beside four other columns, so `.col-frequency` is narrow below the
+         * tablet breakpoint and wide above it.
          */
-        const frequencyHeader = <table className='table-ellipsis'>
-            <thead>
-            <tr>
-                <th>URL</th>
-                <th className='col-frequency'>Download Frequency</th>
-            </tr>
-            </thead>
-            <tbody><tr><td className='column-ellipsis'>https://example.com/x</td><td>30 Days</td></tr></tbody>
-        </table>;
-
         const widthOfFrequency = () => cy.get('th.col-frequency')
             .then(($th) => $th[0].getBoundingClientRect().width);
 
-        cy.viewport(400, 700);
-        cy.mountUI(frequencyHeader);
+        cy.viewport(PHONE, 700);
+        cy.mountUI(recurringTable);
         widthOfFrequency().then((narrow) => {
             cy.viewport(1200, 700);
-            cy.mountUI(frequencyHeader);
+            cy.mountUI(recurringTable);
             widthOfFrequency().then((wide) => {
                 expect(wide, 'the column widens past the tablet breakpoint')
                     .to.be.greaterThan(narrow);
-                // Wide enough for the whole label on one line, which is the point of widening.
                 cy.get('th.col-frequency').should(($th) => {
-                    const th = $th[0];
-                    const cs = getComputedStyle(th);
-                    const contentW = th.getBoundingClientRect().width
-                        - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
-                    const probe = document.createElement('span');
-                    probe.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
-                    probe.textContent = th.textContent.trim();
-                    th.appendChild(probe);
-                    const need = probe.getBoundingClientRect().width;
-                    probe.remove();
-                    expect(need, '"Download Frequency" fits on one line').to.be.at.most(contentW);
+                    expect(oneLineWidth($th[0]), '"Download Frequency" fits on one line')
+                        .to.be.at.most(contentWidth($th[0]));
                 });
             });
         });
@@ -1610,8 +1647,9 @@ describe('a truncating table fits the width it is given', () => {
     it('keeps grouped buttons at full size in a narrow column', () => {
         // ButtonGroup is a nowrap flex row whose children shrink: in a column too narrow the
         // Stop button came out 23px against its neighbour's 40px -- clipped, and too small to
-        // hit.  The column is sized for three buttons, so none of them should give.
-        mountNarrow();
+        // hit.  `col-control-group` is sized for three, so none of them should give.
+        cy.viewport(PHONE, 700);
+        cy.mountUI(onceTable);
 
         cy.get('td .mantine-ButtonGroup-group button').should(($btns) => {
             expect($btns.length, 'three buttons, the widest group a row can hold').to.equal(3);

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -1526,6 +1526,26 @@ describe('a truncating table fits the width it is given', () => {
             - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
     };
 
+    // The narrowest a label can be made: its longest word, which wrapping cannot break, plus
+    // the sort arrow and gap where there is one.  The whole label would be the wrong measure --
+    // a sized column may wrap -- and the text alone omits the arrow.
+    const minLabelWidth = (th) => {
+        const sort = th.querySelector('.wrolpi-th-sort');
+        const probe = document.createElement('span');
+        probe.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
+        th.appendChild(probe);
+        let longest = 0;
+        th.textContent.trim().split(/\s+/).filter(Boolean).forEach((word) => {
+            probe.textContent = word;
+            longest = Math.max(longest, probe.getBoundingClientRect().width);
+        });
+        probe.remove();
+        if (!sort) return longest;
+        const arrow = sort.querySelector('svg');
+        const gap = parseFloat(getComputedStyle(sort).gap) || 0;
+        return longest + gap + (arrow ? arrow.getBoundingClientRect().width : 0);
+    };
+
     // What the label would need on one line, measured in its own cell.
     const oneLineWidth = (th) => {
         const probe = document.createElement('span');
@@ -1582,21 +1602,14 @@ describe('a truncating table fits the width it is given', () => {
                         const label = th.textContent.trim();
                         if (!label) return;
                         /*
-                         * The two kinds of column promise different things.  A column given a
-                         * width must be wide enough for its own label, wrapping it if need be.
-                         * The elastic one takes whatever is left and can be narrower than its
-                         * own label -- "URL" plus its sort arrow is 50px against 36px of
-                         * column here, and one word cannot wrap -- so what holds it in is the
-                         * clip, not the fit.
-                         *
-                         * `scrollWidth` against `clientWidth` measures the content either way,
-                         * whether the label is a text node or the flex button a sortable header
-                         * puts it in, and it still reports the overflow once the cell clips it.
+                         * A column given a width must hold its own label, wrapping it if it
+                         * must.  The elastic one takes what is left and can be narrower than
+                         * its label, which one word cannot wrap out of, so the clip holds it in.
                          */
                         if (th.className.includes('col-')) {
-                            expect(th.scrollWidth,
+                            expect(minLabelWidth(th),
                                 `"${label}" fits the width its column was given`)
-                                .to.be.at.most(th.clientWidth + 1);
+                                .to.be.at.most(contentWidth(th));
                         } else {
                             expect(getComputedStyle(th).overflow,
                                 `"${label}" is clipped rather than painted over its neighbour`)


### PR DESCRIPTION
Answers the five review findings on #660, rebased onto #661 so its Cypress tests actually execute.

Master currently carries a regression: at a real 375px viewport the recurring table is **417px wide with the URL column at exactly 0**. #660 fixed a 540px overflow and created a 375px one.

### The five findings

| | |
|---|---|
| **Recurring starved the URL** | Its four fixed columns wanted 416px between them. Widths are phone-first now, in `col-*` classes, widening at the tablet breakpoint. |
| **Progress button overflowed** | `"5 MBps / 3m44s"` measured 169–188px against 124px of column. It shows the percent; the modal already lists speed, ETA and bytes, and the full text is on the button's `title`. |
| **Checkbox overflowed its column** | 2.5em gave 16.5px of content for a 22px checkbox. 3em holds the checkbox and its padding. |
| **Fixtures proved nothing** | A raw `<table>` reports `tableLayout: fixed` even with the selector that loses to Mantine — the test could not fail for the reason it claimed. They mount `SortableTable`, `Table.HeaderCell onSort` and a real `Checkbox` now. |
| **Comments** | Trimmed to what cannot be recovered from the code. |

### Two defects the restored suite caught

Neither was findable while the component suite could not start:

**A sized column that did not fit its own label.** Recurring's Control column was 4.5em — 70px of content for a 78px "Control". Now 5.2em, sized for the word rather than for the button it holds.

**A header test that measured the wrong thing.** The elastic URL column ends up narrower than its own header ("URL" plus its sort arrow needs 72px against 58), and one word cannot wrap, so the column clips. My first assertion measured the *text* width, missed the arrow and the gap, and passed while the button overran by 14px. The test now states the invariant per kind of column: a sized column must fit its label; only the elastic column may clip.

### Measured at 375px

```
once       [x]46  URL 58  Completed 123  Control 146
recurring  URL 33  Frequency 100  Completed 104  Next 57  Control 80
```

Nothing overflows, no sized header is clipped. The recurring URL column is 33px there — that is the accepted trade for keeping every column on a phone rather than hiding any.

### Verification

- **336 component tests pass** (the two new ones included) — for the first time these run at all
- 69 suites / 1214 jest tests pass
- `npm run build` clean
