### PR TITLE
downloads: a deferred once-download that nothing ever retried

### DIFF
--- a/wrolpi/downloader.py
+++ b/wrolpi/downloader.py
@@ -1254,6 +1254,11 @@ class DownloadManager:
             self.log_error(f'Unable to renew downloads!', exc_info=e)
 
         try:
+            self.renew_deferred_once_downloads()
+        except Exception as e:
+            self.log_error(f'Unable to renew deferred once downloads!', exc_info=e)
+
+        try:
             self.delete_old_once_downloads()
         except Exception as e:
             self.log_error(f'Unable to delete old downloads!', exc_info=e)
@@ -1381,6 +1386,43 @@ class DownloadManager:
 
             if renewed_count:
                 self.log_debug(f'Renewed {renewed_count} recurring downloads')
+
+    def renew_deferred_once_downloads(self):
+        """Mark any deferred once-downloads whose backoff has elapsed as "new" so they are retried.
+
+        Deferring only schedules -- it sets `next_download` and nothing more.  `renew_recurring_downloads`
+        acts on that schedule for downloads with a `frequency`; a once-download has none, so without this
+        a single transient error (a 403, a dropped connection) strands it as "deferred" forever and it is
+        only ever cleared by a manual retry.
+
+        `attempts` is preserved so `calculate_next_download`'s exponential backoff keeps growing -- a URL
+        that never succeeds backs off toward never, rather than retrying at a fixed interval."""
+        now_ = now()
+
+        # Decide what is due in a read session so the usual cycle (nothing due) never takes the write
+        # lock.  See `renew_recurring_downloads` for why the read and write are split.  The status filter
+        # runs in SQL because deferred once-downloads are few; the datetime comparison runs in Python to
+        # match how the rest of this class compares `next_download`.
+        with get_db_session() as session:
+            due_ids = [i.id for i in session.query(Download).filter(
+                Download.frequency == None,  # noqa
+                Download.status == DownloadStatus.deferred,
+            ) if i.next_download and i.next_download < now_]
+
+        if not due_ids:
+            return
+
+        with get_db_session(commit=True) as session:
+            renewed_count = 0
+            for download in session.query(Download).filter(Download.id.in_(due_ids)):
+                # A row's status may have moved on since the read above (the dispatcher claims
+                # downloads constantly), so re-check it here.
+                if download.is_deferred:
+                    download.renew()
+                    renewed_count += 1
+
+            if renewed_count:
+                self.log_debug(f'Renewed {renewed_count} deferred once downloads')
 
     @staticmethod
     def get_downloads(session: Session) -> List[Download]:

--- a/wrolpi/downloader.py
+++ b/wrolpi/downloader.py
@@ -1390,13 +1390,7 @@ class DownloadManager:
     def renew_deferred_once_downloads(self):
         """Mark any deferred once-downloads whose backoff has elapsed as "new" so they are retried.
 
-        Deferring only schedules -- it sets `next_download` and nothing more.  `renew_recurring_downloads`
-        acts on that schedule for downloads with a `frequency`; a once-download has none, so without this
-        a single transient error (a 403, a dropped connection) strands it as "deferred" forever and it is
-        only ever cleared by a manual retry.
-
-        `attempts` is preserved so `calculate_next_download`'s exponential backoff keeps growing -- a URL
-        that never succeeds backs off toward never, rather than retrying at a fixed interval."""
+        `renew()` is called without `reset_attempts` so `calculate_next_download`'s backoff keeps growing."""
         now_ = now()
 
         # Decide what is due in a read session so the usual cycle (nothing due) never takes the write

--- a/wrolpi/test/test_downloader.py
+++ b/wrolpi/test/test_downloader.py
@@ -620,12 +620,7 @@ async def test_recurring_downloads(test_session, test_download_manager, fake_now
 @pytest.mark.asyncio
 async def test_deferred_once_download_is_retried(test_session, test_download_manager, fake_now, test_downloader,
                                                  await_switches):
-    """A once-download that was deferred is retried once its backoff has elapsed.
-
-    A deferred download is only ever scheduled -- `next_download` is set, but nothing marks it "new"
-    again.  Recurring downloads are renewed by `renew_recurring_downloads`; once-downloads must be
-    renewed too, or a single transient error (a YouTube 403, a flaky connection) strands the
-    download as "deferred" forever."""
+    """A once-download that was deferred is retried once its backoff has elapsed."""
     fake_now(datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
     test_downloader.set_test_failure()
 

--- a/wrolpi/test/test_downloader.py
+++ b/wrolpi/test/test_downloader.py
@@ -618,6 +618,92 @@ async def test_recurring_downloads(test_session, test_download_manager, fake_now
 
 
 @pytest.mark.asyncio
+async def test_deferred_once_download_is_retried(test_session, test_download_manager, fake_now, test_downloader,
+                                                 await_switches):
+    """A once-download that was deferred is retried once its backoff has elapsed.
+
+    A deferred download is only ever scheduled -- `next_download` is set, but nothing marks it "new"
+    again.  Recurring downloads are renewed by `renew_recurring_downloads`; once-downloads must be
+    renewed too, or a single transient error (a YouTube 403, a flaky connection) strands the
+    download as "deferred" forever."""
+    fake_now(datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
+    test_downloader.set_test_failure()
+
+    test_download_manager.create_download(test_session, 'https://example.com/once', test_downloader.name)
+    await test_download_manager.wait_for_all_downloads()
+
+    # The download failed, so it is deferred for 3 hours (3^attempts).
+    download = test_session.query(Download).one()
+    assert download.frequency is None, 'This must be a once-download'
+    assert download.is_deferred, download.status_code
+    assert download.attempts == 1
+    assert download.next_download == datetime(2020, 1, 1, 3, 0, 0, tzinfo=pytz.UTC)
+
+    # An hour before it is due, it is left alone.
+    fake_now(datetime(2020, 1, 1, 2, 0, 0, tzinfo=pytz.UTC))
+    test_download_manager.renew_deferred_once_downloads()
+    download = test_session.query(Download).one()
+    assert download.is_deferred, download.status_code
+
+    # Once due, it is renewed and downloaded again.  This time it succeeds.
+    fake_now(datetime(2020, 1, 1, 3, 0, 1, tzinfo=pytz.UTC))
+    test_download_manager.renew_deferred_once_downloads()
+    download = test_session.query(Download).one()
+    assert download.is_new, download.status_code
+    assert download.attempts == 1, 'Attempts are preserved so the backoff keeps growing'
+
+    test_downloader.set_test_success()
+    await test_download_manager.wait_for_all_downloads()
+    download = test_session.query(Download).one()
+    assert download.is_complete, download.status_code
+    assert download.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_deferred_once_download_backoff_grows(test_session, test_download_manager, fake_now, test_downloader,
+                                                    await_switches):
+    """Repeated failures of a once-download back off exponentially rather than retrying in a loop."""
+    fake_now(datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
+    test_downloader.set_test_failure()
+
+    test_download_manager.create_download(test_session, 'https://example.com/once', test_downloader.name)
+    await test_download_manager.wait_for_all_downloads()
+
+    download = test_session.query(Download).one()
+    # First failure: 3^1 hours.
+    assert download.next_download == datetime(2020, 1, 1, 3, 0, 0, tzinfo=pytz.UTC)
+
+    fake_now(datetime(2020, 1, 1, 3, 0, 1, tzinfo=pytz.UTC))
+    test_download_manager.renew_deferred_once_downloads()
+    await test_download_manager.wait_for_all_downloads()
+
+    download = test_session.query(Download).one()
+    assert download.is_deferred, download.status_code
+    assert download.attempts == 2
+    # Second failure: 3^2 hours.
+    assert download.next_download == datetime(2020, 1, 1, 12, 0, 1, tzinfo=pytz.UTC)
+
+
+@pytest.mark.asyncio
+async def test_failed_once_download_is_not_renewed(test_session, test_download_manager, fake_now, test_downloader,
+                                                  await_switches):
+    """A once-download that failed unrecoverably is never renewed, no matter how overdue it is."""
+    fake_now(datetime(2020, 1, 1, 0, 0, 0, tzinfo=pytz.UTC))
+    test_downloader.set_test_unrecoverable_exception()
+
+    test_download_manager.create_download(test_session, 'https://example.com/once', test_downloader.name)
+    await test_download_manager.wait_for_all_downloads()
+
+    download = test_session.query(Download).one()
+    assert download.is_failed, download.status_code
+
+    fake_now(datetime(2020, 2, 1, 0, 0, 0, tzinfo=pytz.UTC))
+    test_download_manager.renew_deferred_once_downloads()
+    download = test_session.query(Download).one()
+    assert download.is_failed, download.status_code
+
+
+@pytest.mark.asyncio
 async def test_max_attempts(test_session, test_download_manager, test_downloader, await_switches):
     """A Download will only be attempted so many times, it will eventually be deleted."""
     _, session = get_db_context()


### PR DESCRIPTION
## The bug

Deferring a download only *schedules* it — `defer()` sets the status, `calculate_next_download` sets `next_download`. The only thing that acted on that schedule was `renew_recurring_downloads`, which filters on `frequency != None`.

A once-download has no frequency. So a single transient error deferred it with a `next_download` that nothing ever read, and it stayed `deferred` until someone retried it by hand. `delete_old_once_downloads` didn't clear it either — that requires a `last_successful_download`, which a download that never succeeded doesn't have.

Net effect: every transient failure added one more permanently-stuck row to the downloads list, so a failure rate that should have self-healed in three hours instead grew without bound.

## How it turned up

Two deployed WROLPis were showing a steadily growing pile of download errors. Every stuck row on both was the same shape:

```
status='deferred'  attempts=1  frequency=NULL  last_successful_download=NULL
next_download='2026-08-12 18:09:33'   <-- four days in the past
```

All of them carried the same transient upstream error (an HTTP 403 on the media stream). Re-running the exact same download by hand succeeded immediately, which is what made the missing retry the interesting half of the problem rather than the error itself.

## The fix

Add `renew_deferred_once_downloads`, called from `do_downloads` alongside the recurring renewal. It uses the same read-then-write split as `renew_recurring_downloads` so the common case (nothing due) never takes the write lock, and re-checks each row's status under the write lock since the dispatcher claims downloads constantly.

`attempts` is deliberately preserved, so `calculate_next_download`'s `3^attempts` backoff keeps growing across retries — 3h, 9h, 27h, and onward. A URL that never succeeds backs off toward never, rather than retrying forever at a fixed interval. That's why there's no explicit attempt cap: the existing backoff already self-limits, and it matches how recurring downloads behave.

## Tests

Written first, confirmed red against `master` (the deferral assertions passed; only the missing renewal failed):

- `test_deferred_once_download_is_retried` — a deferred once-download is left alone before its backoff elapses, renewed once it's due, and completes on the retry.
- `test_deferred_once_download_backoff_grows` — a second failure defers for 3^2 hours, not 3^1 again.
- `test_failed_once_download_is_not_renewed` — an unrecoverably-failed download is never renewed, however overdue.

Full backend suite: 1731 passed, 5 skipped. Frontend: 1221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)