### PR TITLE
videos: silence the automatic channel refresh before downloads

### DIFF
--- a/modules/videos/models.py
+++ b/modules/videos/models.py
@@ -1019,7 +1019,7 @@ class Channel(ModelHelper, Base):
             external_paths = cls._get_external_file_paths(session, id_, directory)
 
         # Queue refresh immediately so caller can await the job.
-        job_id = file_worker.queue_refresh([directory] + external_paths)
+        job_id = file_worker.queue_refresh([directory] + external_paths, send_events=send_events)
 
         # Background task handles post-processing after job completes.
         async def _():

--- a/modules/videos/test/test_channel_refresh_events.py
+++ b/modules/videos/test/test_channel_refresh_events.py
@@ -1,0 +1,39 @@
+"""Tests that Channel.refresh_files() only sends Events when requested.
+
+The Channel downloader refreshes a Channel before downloading; that refresh should not
+notify the user (send_events=False), while a user-requested refresh should.
+"""
+import pytest
+
+from modules.videos.models import Channel
+from wrolpi.common import await_background_tasks
+from wrolpi.conftest import await_file_worker
+
+
+@pytest.mark.asyncio
+async def test_channel_refresh_files_send_events_false(
+        async_client, test_session, channel_factory, video_file_factory, events_fixture):
+    """Channel.refresh_files(send_events=False) must not send refresh Events."""
+    channel = channel_factory(name='MyChannel')
+    video_file_factory(channel.directory / 'video.mp4')
+
+    Channel.refresh_files(channel.id, send_events=False)
+    await await_file_worker()
+    await await_background_tasks()
+
+    events_fixture.assert_no_event('directory_refresh')
+    events_fixture.assert_no_event('files_refreshed')
+
+
+@pytest.mark.asyncio
+async def test_channel_refresh_files_send_events_default(
+        async_client, test_session, channel_factory, video_file_factory, events_fixture):
+    """Channel.refresh_files() sends refresh Events by default."""
+    channel = channel_factory(name='MyChannel')
+    video_file_factory(channel.directory / 'video.mp4')
+
+    Channel.refresh_files(channel.id)
+    await await_file_worker()
+    await await_background_tasks()
+
+    events_fixture.assert_has_event('directory_refresh')

--- a/wrolpi/files/worker.py
+++ b/wrolpi/files/worker.py
@@ -789,6 +789,7 @@ class FileTask:
     next_task_type: FileTaskType = None
     job_id: str = None  # Unique ID for tracking completion
     expand_stems: bool = True  # Whether to expand files to their FileGroup stem-mates
+    send_events: bool = True  # Whether to notify the user with Events (automatic refreshes set False)
     # For reorganize tasks: list of (source_path, dest_path) tuples
     move_mappings: list[tuple[pathlib.Path, pathlib.Path]] = None
     collection_id: int = None  # Collection being reorganized
@@ -922,13 +923,16 @@ class FileWorker:
         except ValueError:
             return str(path)
 
-    def queue_refresh(self, paths: list[pathlib.Path | str], expand_stems: bool = True) -> str:
+    def queue_refresh(self, paths: list[pathlib.Path | str], expand_stems: bool = True,
+                      send_events: bool = True) -> str:
         """Queue a refresh task for background processing.
 
         Args:
             paths: List of file or directory paths to refresh
             expand_stems: Whether to expand files to their FileGroup stem-mates.
                          Set to False when API users explicitly select specific files.
+            send_events: Whether to notify the user with Events.  Automatic refreshes
+                         (like a Channel refresh before downloading) set this to False.
 
         Returns:
             A unique job_id that can be used with wait_for_job() to track completion.
@@ -941,6 +945,7 @@ class FileWorker:
             next_task_type=FileTaskType.refresh,
             job_id=job_id,
             expand_stems=expand_stems,
+            send_events=send_events,
         )
         self._set_job_status(job_id, 'pending')
         self.public_queue.put_nowait(task)
@@ -1192,6 +1197,7 @@ class FileWorker:
                 prev_task_type=FileTaskType.count,
                 job_id=task.job_id,
                 expand_stems=task.expand_stems,
+                send_events=task.send_events,
             )
             self.private_queue.put_nowait(next_task)
         else:
@@ -1238,6 +1244,7 @@ class FileWorker:
                 FileTaskType.count,
                 task.paths,
                 next_task_type=FileTaskType.refresh,
+                send_events=task.send_events,
             )
             self.private_queue.put_nowait(count_task)
             return
@@ -1249,13 +1256,14 @@ class FileWorker:
             logger.info(f'Starting global refresh with {task.count} files')
             flags.global_refresh_active.set()
             Events.send_global_refresh_started()
-        elif dir_paths and len(dir_paths) == 1 and not file_paths:
-            relative_path = self._get_relative_path(dir_paths[0])
-            Events.send_directory_refresh(f'Refreshing: {relative_path}')
-        elif file_paths:
-            Events.send_files_refreshed(f'Refreshing {len(file_paths)} files')
-        else:
-            Events.send_files_refreshed(f'Refreshing {len(task.paths)} paths')
+        elif task.send_events:
+            if dir_paths and len(dir_paths) == 1 and not file_paths:
+                relative_path = self._get_relative_path(dir_paths[0])
+                Events.send_directory_refresh(f'Refreshing: {relative_path}')
+            elif file_paths:
+                Events.send_files_refreshed(f'Refreshing {len(file_paths)} files')
+            else:
+                Events.send_files_refreshed(f'Refreshing {len(task.paths)} paths')
 
         # Process files and directories within discovery flag context
         # This covers comparing, upserting, and deleting phases
@@ -1333,13 +1341,14 @@ class FileWorker:
             message = f'Global refresh completed in {elapsed:.1f} seconds'
             logger.info(message)
             Events.send_global_after_refresh_completed(message)
-        elif dir_paths and len(dir_paths) == 1 and not file_paths:
-            relative_path = self._get_relative_path(dir_paths[0])
-            Events.send_directory_refresh(f'Refreshed: {relative_path}')
-        elif file_paths:
-            Events.send_files_refreshed(f'Refreshed {len(file_paths)} files')
-        else:
-            Events.send_files_refreshed(f'Refreshed {len(task.paths)} paths')
+        elif task.send_events:
+            if dir_paths and len(dir_paths) == 1 and not file_paths:
+                relative_path = self._get_relative_path(dir_paths[0])
+                Events.send_directory_refresh(f'Refreshed: {relative_path}')
+            elif file_paths:
+                Events.send_files_refreshed(f'Refreshed {len(file_paths)} files')
+            else:
+                Events.send_files_refreshed(f'Refreshed {len(task.paths)} paths')
 
         # Set refresh_complete flag only when refreshing the entire media directory
         if is_global_refresh:


### PR DESCRIPTION
## Summary

Channels are refreshed before downloading, and that refresh emitted "Refreshing:"/"Refreshed:" Events the user didn't ask for. The downloader already called `Channel.refresh_files(channel.id, send_events=False)`, but the parameter was dead — it never reached the file worker, which emitted the Events unconditionally.

## Changes

- `FileTask` gains a `send_events` field (default `True`); `queue_refresh()` accepts it and the count→refresh task chain propagates it.
- `handle_refresh` skips the start/completion Events when `send_events` is `False`. Global-refresh Events are unchanged, and user-requested refreshes (files API, channel refresh button) still send Events by default.
- `Channel.refresh_files` now forwards its `send_events` argument to `queue_refresh`.

## Testing

- New `modules/videos/test/test_channel_refresh_events.py`, written to fail on the bug first: `send_events=False` produces no refresh Events; the default still does.
- Full backend suite: 1758 passed, 5 skipped.
- Frontend Jest suite: 1221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)