### PR TITLE
Fix two concurrency races: torn config reads and instant SQLite lock failures on playlist writes

### DIFF
--- a/wrolpi/collections/api.py
+++ b/wrolpi/collections/api.py
@@ -10,6 +10,7 @@ from sanic_ext.extensions.openapi import openapi
 
 from wrolpi.api_utils import json_response
 from wrolpi.common import wrol_mode_check
+from wrolpi.db import get_db_session
 from wrolpi.errors import ValidationError
 from wrolpi.schema import JSONErrorResponse
 from . import lib, schema
@@ -89,20 +90,23 @@ async def create_collection_endpoint(request: Request, body: schema.CollectionCr
 @wrol_mode_check
 async def add_collection_item_endpoint(request: Request, collection_id: int, body: schema.AddItemRequest):
     """Append (or insert at ``position``) a file/zim/url item into the collection."""
-    session = request.ctx.session
-    try:
-        item, created = lib.add_collection_item(
-            session, collection_id, item_kind=body.item_kind,
-            file_group_id=body.file_group_id, zim_id=body.zim_id, zim_entry=body.zim_entry,
-            url=body.url, title=body.title, position=body.position)
-    except UnknownCollection as e:
-        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
-    except ValidationError as e:
-        return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
+    # Not `request.ctx.session`: this reads (the Collection, the FileGroup) before it INSERTs, and a
+    # deferred transaction fails that lock upgrade *instantly* with "database is locked" if anything
+    # else wrote in between (see `get_db_session`).
+    with get_db_session(commit=True) as session:
+        try:
+            item, created = lib.add_collection_item(
+                session, collection_id, item_kind=body.item_kind,
+                file_group_id=body.file_group_id, zim_id=body.zim_id, zim_entry=body.zim_entry,
+                url=body.url, title=body.title, position=body.position)
+        except UnknownCollection as e:
+            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+        except ValidationError as e:
+            return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
 
-    # 201 when a new item was created; 200 when the item already existed (idempotent add).
-    status = HTTPStatus.CREATED if created else HTTPStatus.OK
-    return json_response({'item': item.dict()}, status=status)
+        # 201 when a new item was created; 200 when the item already existed (idempotent add).
+        status = HTTPStatus.CREATED if created else HTTPStatus.OK
+        return json_response({'item': item.dict()}, status=status)
 
 
 @collection_bp.delete('/<collection_id:int>/items/<item_id:int>')
@@ -112,11 +116,12 @@ async def add_collection_item_endpoint(request: Request, collection_id: int, bod
 @wrol_mode_check
 async def remove_collection_item_endpoint(request: Request, collection_id: int, item_id: int):
     """Remove a single item by its id and close the ordering gap."""
-    session = request.ctx.session
-    try:
-        removed = lib.remove_collection_item(session, collection_id, item_id)
-    except UnknownCollection as e:
-        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+    # Write intent (see `add_collection_item_endpoint`).
+    with get_db_session(commit=True) as session:
+        try:
+            removed = lib.remove_collection_item(session, collection_id, item_id)
+        except UnknownCollection as e:
+            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
 
     if not removed:
         return json_response({'error': f'Item {item_id} not found in collection {collection_id}'},
@@ -137,15 +142,16 @@ async def remove_collection_item_endpoint(request: Request, collection_id: int, 
 async def reorder_collection_items_endpoint(request: Request, collection_id: int,
                                             body: schema.ReorderItemsRequest):
     """Set the item order from a full list of item ids (used by drag-and-drop)."""
-    session = request.ctx.session
-    try:
-        lib.reorder_collection_items(session, collection_id, body.item_ids)
-    except UnknownCollection as e:
-        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
-    except ValueError as e:
-        return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
+    # Write intent (see `add_collection_item_endpoint`).
+    with get_db_session(commit=True) as session:
+        try:
+            lib.reorder_collection_items(session, collection_id, body.item_ids)
+        except UnknownCollection as e:
+            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+        except ValueError as e:
+            return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
 
-    data = lib.get_collection_with_stats(session, collection_id)
+        data = lib.get_collection_with_stats(session, collection_id)
     return json_response({'collection': data})
 
 

--- a/wrolpi/collections/api.py
+++ b/wrolpi/collections/api.py
@@ -90,23 +90,20 @@ async def create_collection_endpoint(request: Request, body: schema.CollectionCr
 @wrol_mode_check
 async def add_collection_item_endpoint(request: Request, collection_id: int, body: schema.AddItemRequest):
     """Append (or insert at ``position``) a file/zim/url item into the collection."""
-    # Not `request.ctx.session`: this reads (the Collection, the FileGroup) before it INSERTs, and a
-    # deferred transaction fails that lock upgrade *instantly* with "database is locked" if anything
-    # else wrote in between (see `get_db_session`).
-    with get_db_session(commit=True) as session:
-        try:
+    try:
+        # Read-then-write, so the session must begin as a writer (see `get_db_session`).
+        with get_db_session(commit=True) as session:
             item, created = lib.add_collection_item(
                 session, collection_id, item_kind=body.item_kind,
                 file_group_id=body.file_group_id, zim_id=body.zim_id, zim_entry=body.zim_entry,
                 url=body.url, title=body.title, position=body.position)
-        except UnknownCollection as e:
-            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
-        except ValidationError as e:
-            return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
-
-        # 201 when a new item was created; 200 when the item already existed (idempotent add).
-        status = HTTPStatus.CREATED if created else HTTPStatus.OK
-        return json_response({'item': item.dict()}, status=status)
+            # 201 when a new item was created; 200 when the item already existed (idempotent add).
+            status = HTTPStatus.CREATED if created else HTTPStatus.OK
+            return json_response({'item': item.dict()}, status=status)
+    except UnknownCollection as e:
+        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+    except ValidationError as e:
+        return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
 
 
 @collection_bp.delete('/<collection_id:int>/items/<item_id:int>')
@@ -116,12 +113,11 @@ async def add_collection_item_endpoint(request: Request, collection_id: int, bod
 @wrol_mode_check
 async def remove_collection_item_endpoint(request: Request, collection_id: int, item_id: int):
     """Remove a single item by its id and close the ordering gap."""
-    # Write intent (see `add_collection_item_endpoint`).
-    with get_db_session(commit=True) as session:
-        try:
+    try:
+        with get_db_session(commit=True) as session:
             removed = lib.remove_collection_item(session, collection_id, item_id)
-        except UnknownCollection as e:
-            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+    except UnknownCollection as e:
+        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
 
     if not removed:
         return json_response({'error': f'Item {item_id} not found in collection {collection_id}'},
@@ -142,16 +138,14 @@ async def remove_collection_item_endpoint(request: Request, collection_id: int, 
 async def reorder_collection_items_endpoint(request: Request, collection_id: int,
                                             body: schema.ReorderItemsRequest):
     """Set the item order from a full list of item ids (used by drag-and-drop)."""
-    # Write intent (see `add_collection_item_endpoint`).
-    with get_db_session(commit=True) as session:
-        try:
+    try:
+        with get_db_session(commit=True) as session:
             lib.reorder_collection_items(session, collection_id, body.item_ids)
-        except UnknownCollection as e:
-            return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
-        except ValueError as e:
-            return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
-
-        data = lib.get_collection_with_stats(session, collection_id)
+            data = lib.get_collection_with_stats(session, collection_id)
+    except UnknownCollection as e:
+        return json_response({'error': str(e)}, status=HTTPStatus.NOT_FOUND)
+    except ValueError as e:
+        return json_response({'error': str(e)}, status=HTTPStatus.BAD_REQUEST)
     return json_response({'collection': data})
 
 

--- a/wrolpi/collections/test/test_playlist_items.py
+++ b/wrolpi/collections/test/test_playlist_items.py
@@ -157,6 +157,44 @@ async def test_add_file_item(async_client, test_session, test_directory):
 
 
 @pytest.mark.asyncio
+async def test_item_write_endpoints_use_write_intent_sessions(async_client, test_session):
+    """The item write endpoints (add/remove/reorder) must open their sessions with
+    `get_db_session(commit=True)` so the transaction begins as a writer (BEGIN IMMEDIATE).
+
+    These handlers read (the Collection, the FileGroup) before their first write; a deferred
+    transaction upgrading at that write fails instantly with "database is locked" whenever another
+    connection wrote in between, bypassing `busy_timeout` (see `get_db_session`)."""
+    from unittest import mock
+    from wrolpi.collections import api as collections_api
+    from wrolpi.db import get_db_session
+
+    _, response = await async_client.post('/api/collections', json={'name': 'Locks'})
+    cid = response.json['collection']['id']
+
+    commit_kwargs = list()
+
+    def recording_get_db_session(*args, **kwargs):
+        commit_kwargs.append(kwargs.get('commit', args[0] if args else False))
+        return get_db_session(*args, **kwargs)
+
+    with mock.patch.object(collections_api, 'get_db_session', recording_get_db_session):
+        _, response = await async_client.post(f'/api/collections/{cid}/items',
+                                              json={'item_kind': 'url', 'url': '/u/a', 'title': 'a'})
+        assert response.status_code == HTTPStatus.CREATED, response.json
+        item_id = response.json['item']['id']
+
+        _, response = await async_client.put(f'/api/collections/{cid}/items/order',
+                                             json={'item_ids': [item_id]})
+        assert response.status_code == HTTPStatus.OK, response.json
+
+        _, response = await async_client.delete(f'/api/collections/{cid}/items/{item_id}')
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+    assert len(commit_kwargs) == 3, 'Each item write endpoint must open its own session'
+    assert all(commit is True for commit in commit_kwargs)
+
+
+@pytest.mark.asyncio
 async def test_reorder_and_remove_items(async_client, test_session):
     """Items can be reordered by id and removed, with positions kept contiguous."""
     _, response = await async_client.post('/api/collections', json={'name': 'Order'})

--- a/wrolpi/collections/test/test_playlist_items.py
+++ b/wrolpi/collections/test/test_playlist_items.py
@@ -158,12 +158,9 @@ async def test_add_file_item(async_client, test_session, test_directory):
 
 @pytest.mark.asyncio
 async def test_item_write_endpoints_use_write_intent_sessions(async_client, test_session):
-    """The item write endpoints (add/remove/reorder) must open their sessions with
-    `get_db_session(commit=True)` so the transaction begins as a writer (BEGIN IMMEDIATE).
-
-    These handlers read (the Collection, the FileGroup) before their first write; a deferred
-    transaction upgrading at that write fails instantly with "database is locked" whenever another
-    connection wrote in between, bypassing `busy_timeout` (see `get_db_session`)."""
+    """The item write endpoints (add/remove/reorder) each open their session with
+    `get_db_session(commit=True)` — the deferred `request.ctx.session` reads before its first
+    write, which SQLite fails instantly on concurrent writes (see `get_db_session`)."""
     from unittest import mock
     from wrolpi.collections import api as collections_api
     from wrolpi.db import get_db_session

--- a/wrolpi/common.py
+++ b/wrolpi/common.py
@@ -648,8 +648,7 @@ class ConfigFile:
 
         # Only one process can write to a config.
         with api_app.shared_ctx.config_save_lock:
-            # The version check reads the file, so it must hold the lock: another worker may be
-            # saving this config right now, and its version must not be overwritten.
+            # The version check reads the file, so it must hold the lock.
             if file.exists() and overwrite is False:
                 version = self.read_config_file(file).get('version')
                 if version and version > self.version:
@@ -791,11 +790,8 @@ class ConfigFile:
 
 
 def write_config_data(config: dict, config_file: pathlib.Path, width: int = 90):
-    """Write a config dict to a YAML file.  Decimals are converted to str; all other Python objects are rejected.
-
-    The write is atomic (temporary file, then rename): another process reading the config can only
-    ever see the complete old contents or the complete new contents, never a truncated file.  The
-    Sanic workers are separate processes, so in-process locks cannot provide this guarantee.
+    """Write a config dict to a YAML file atomically (readers never see a truncated config).
+    Decimals are converted to str; all other Python objects are rejected.
 
     Shared by `ConfigFile` and `MultiFileConfig` so both serialize configs identically (Decimal-safe, fsync'd)."""
 
@@ -805,23 +801,24 @@ def write_config_data(config: dict, config_file: pathlib.Path, width: int = 90):
 
     _ConfigDumper.add_representer(Decimal, lambda dumper, data: dumper.represent_str(str(data)))
 
-    # The temporary file must be on the same filesystem as the config for the rename to be atomic.
+    # Same directory as the config so the rename is atomic.
     fd, temporary_path = tempfile.mkstemp(dir=config_file.parent, prefix=f'{config_file.name}.', suffix='.tmp')
     try:
-        # mkstemp creates the file 0600; the rename keeps the temporary file's permissions, so give
-        # it the config's existing mode (or the usual 0644 for a new config).
+        # The rename keeps the temporary file's 0600, so give it the config's mode.
         mode = config_file.stat().st_mode & 0o777 if config_file.exists() else 0o644
         os.chmod(temporary_path, mode)
         with os.fdopen(fd, 'wt') as fh:
+            fd = None  # The file object owns the descriptor now.
             try:
                 yaml.dump(config, fh, Dumper=_ConfigDumper, width=width, sort_keys=True)
             except yaml.representer.RepresenterError as e:
                 raise ValueError(f'Config contains a Python object that cannot be serialized: {e}') from e
-            # Wait for data to be written before the rename publishes it.
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(temporary_path, config_file)
     except BaseException:
+        if fd is not None:
+            os.close(fd)
         pathlib.Path(temporary_path).unlink(missing_ok=True)
         raise
 

--- a/wrolpi/common.py
+++ b/wrolpi/common.py
@@ -639,11 +639,6 @@ class ConfigFile:
                           f' during import: {rel_path}'
                 Events.send_config_save_failed(message)
                 raise RuntimeError(message)
-            version = self.read_config_file(file).get('version')
-            if version and version > self.version:
-                message = f'Refusing to overwrite newer config ({rel_path}): {version} > {self.version}'
-                Events.send_config_save_failed(message)
-                raise RuntimeError(message)
 
         # Don't overwrite a real config while testing.
         if PYTEST and not is_tempfile(file):
@@ -653,6 +648,14 @@ class ConfigFile:
 
         # Only one process can write to a config.
         with api_app.shared_ctx.config_save_lock:
+            # The version check reads the file, so it must hold the lock: another worker may be
+            # saving this config right now, and its version must not be overwritten.
+            if file.exists() and overwrite is False:
+                version = self.read_config_file(file).get('version')
+                if version and version > self.version:
+                    message = f'Refusing to overwrite newer config ({rel_path}): {version} > {self.version}'
+                    Events.send_config_save_failed(message)
+                    raise RuntimeError(message)
             try:
                 # Config directory may not exist (parents=True for nested file_names like inventory/catalog.yaml).
                 if not file.parent.is_dir():
@@ -790,6 +793,10 @@ class ConfigFile:
 def write_config_data(config: dict, config_file: pathlib.Path, width: int = 90):
     """Write a config dict to a YAML file.  Decimals are converted to str; all other Python objects are rejected.
 
+    The write is atomic (temporary file, then rename): another process reading the config can only
+    ever see the complete old contents or the complete new contents, never a truncated file.  The
+    Sanic workers are separate processes, so in-process locks cannot provide this guarantee.
+
     Shared by `ConfigFile` and `MultiFileConfig` so both serialize configs identically (Decimal-safe, fsync'd)."""
 
     class _ConfigDumper(yaml.CSafeDumper):
@@ -798,14 +805,25 @@ def write_config_data(config: dict, config_file: pathlib.Path, width: int = 90):
 
     _ConfigDumper.add_representer(Decimal, lambda dumper, data: dumper.represent_str(str(data)))
 
-    with config_file.open('wt') as fh:
-        try:
-            yaml.dump(config, fh, Dumper=_ConfigDumper, width=width, sort_keys=True)
-        except yaml.representer.RepresenterError as e:
-            raise ValueError(f'Config contains a Python object that cannot be serialized: {e}') from e
-        # Wait for data to be written before releasing lock.
-        fh.flush()
-        os.fsync(fh.fileno())
+    # The temporary file must be on the same filesystem as the config for the rename to be atomic.
+    fd, temporary_path = tempfile.mkstemp(dir=config_file.parent, prefix=f'{config_file.name}.', suffix='.tmp')
+    try:
+        # mkstemp creates the file 0600; the rename keeps the temporary file's permissions, so give
+        # it the config's existing mode (or the usual 0644 for a new config).
+        mode = config_file.stat().st_mode & 0o777 if config_file.exists() else 0o644
+        os.chmod(temporary_path, mode)
+        with os.fdopen(fd, 'wt') as fh:
+            try:
+                yaml.dump(config, fh, Dumper=_ConfigDumper, width=width, sort_keys=True)
+            except yaml.representer.RepresenterError as e:
+                raise ValueError(f'Config contains a Python object that cannot be serialized: {e}') from e
+            # Wait for data to be written before the rename publishes it.
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temporary_path, config_file)
+    except BaseException:
+        pathlib.Path(temporary_path).unlink(missing_ok=True)
+        raise
 
 
 def read_config_data(file: pathlib.Path) -> dict:

--- a/wrolpi/test/test_common.py
+++ b/wrolpi/test/test_common.py
@@ -1076,6 +1076,67 @@ async def test_config_valid(async_client, test_wrolpi_config):
     assert config.is_valid() is True
 
 
+@pytest.mark.asyncio
+async def test_write_config_data_failure_preserves_existing_file(async_client, test_wrolpi_config):
+    """A failed config write must leave the existing config file untouched.
+
+    The write must also be atomic (temp file + rename) so a concurrent reader can never observe a
+    truncated config."""
+    test_wrolpi_config.write_text('version: 5\nwrol_mode: true\n')
+
+    # `object()` cannot be serialized; the key sorts last so YAML would emit partial output first.
+    with pytest.raises(ValueError):
+        common.write_config_data({'version': 6, 'zzz': object()}, test_wrolpi_config)
+
+    # The original file survives the failed write.
+    assert common.read_config_data(test_wrolpi_config) == {'version': 5, 'wrol_mode': True}
+
+    # A successful write replaces the contents and leaves no temporary file behind.
+    common.write_config_data({'version': 6}, test_wrolpi_config)
+    assert common.read_config_data(test_wrolpi_config) == {'version': 6}
+    leftovers = [i for i in test_wrolpi_config.parent.iterdir()
+                 if i.name.startswith(test_wrolpi_config.name) and i.name != test_wrolpi_config.name]
+    assert not leftovers, f'Temporary files were left behind: {leftovers}'
+
+
+@pytest.mark.asyncio
+async def test_save_version_check_runs_under_config_save_lock(async_client, test_wrolpi_config):
+    """`ConfigFile.save` must read the config file for its version check only while holding
+    `config_save_lock`, otherwise it can read a config another process is writing."""
+    from wrolpi.api_utils import api_app
+
+    config = get_wrolpi_config()
+    config.dump_config()
+
+    class RecordingLock:
+        def __init__(self, lock):
+            self.lock = lock
+            self.held = False
+
+        def __enter__(self):
+            self.lock.__enter__()
+            self.held = True
+
+        def __exit__(self, *args):
+            self.held = False
+            return self.lock.__exit__(*args)
+
+    recording_lock = RecordingLock(api_app.shared_ctx.config_save_lock)
+    lock_held_during_read = list()
+    real_read_config_file = config.read_config_file
+
+    def recording_read_config_file(*args, **kwargs):
+        lock_held_during_read.append(recording_lock.held)
+        return real_read_config_file(*args, **kwargs)
+
+    with mock.patch.object(api_app.shared_ctx, 'config_save_lock', recording_lock), \
+            mock.patch.object(config, 'read_config_file', recording_read_config_file):
+        config.dump_config()
+
+    assert lock_held_during_read, 'The version check never read the config file'
+    assert all(lock_held_during_read), 'The config file was read without holding config_save_lock'
+
+
 @pytest.mark.parametrize('name,expected_name', [
     ('foo', 'foo'),
     (pathlib.Path('foo'), pathlib.Path('foo')),

--- a/wrolpi/test/test_common.py
+++ b/wrolpi/test/test_common.py
@@ -1078,25 +1078,27 @@ async def test_config_valid(async_client, test_wrolpi_config):
 
 @pytest.mark.asyncio
 async def test_write_config_data_failure_preserves_existing_file(async_client, test_wrolpi_config):
-    """A failed config write must leave the existing config file untouched.
+    """A failed config write must leave the existing config file untouched, and no write may leave
+    a temporary file behind."""
 
-    The write must also be atomic (temp file + rename) so a concurrent reader can never observe a
-    truncated config."""
+    def temporary_leftovers() -> list:
+        return [i for i in test_wrolpi_config.parent.iterdir()
+                if i.name.startswith(test_wrolpi_config.name) and i.name != test_wrolpi_config.name]
+
     test_wrolpi_config.write_text('version: 5\nwrol_mode: true\n')
 
     # `object()` cannot be serialized; the key sorts last so YAML would emit partial output first.
     with pytest.raises(ValueError):
         common.write_config_data({'version': 6, 'zzz': object()}, test_wrolpi_config)
 
-    # The original file survives the failed write.
+    # The original file survives the failed write, and no temporary file is left behind.
     assert common.read_config_data(test_wrolpi_config) == {'version': 5, 'wrol_mode': True}
+    assert not temporary_leftovers()
 
     # A successful write replaces the contents and leaves no temporary file behind.
     common.write_config_data({'version': 6}, test_wrolpi_config)
     assert common.read_config_data(test_wrolpi_config) == {'version': 6}
-    leftovers = [i for i in test_wrolpi_config.parent.iterdir()
-                 if i.name.startswith(test_wrolpi_config.name) and i.name != test_wrolpi_config.name]
-    assert not leftovers, f'Temporary files were left behind: {leftovers}'
+    assert not temporary_leftovers()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two race conditions observed in production logs on a multi-worker Docker deployment:

### 1. `InvalidConfig: config/download_manager.yaml` during a background save

`write_config_data()` truncated the config file in place before dumping YAML into it, so any concurrent reader (another Sanic worker's version check, config import) could observe an empty or partial file. The version check in `ConfigFile.save()` also read the file *before* acquiring `config_save_lock`, so it raced the worker currently writing.

**Fix:** config writes now go to a temporary file in the same directory (fsync'd) and are renamed into place with `os.replace` — a reader can only ever see the complete old or complete new contents. The temporary file inherits the config's permissions and is removed on failure. The version check moved inside `config_save_lock`.

### 2. `sqlite3.OperationalError: database is locked` on `INSERT INTO collection_item`

The playlist item endpoints (add/remove/reorder) used the deferred `request.ctx.session`. They read (the Collection, the FileGroup) before their first write, and SQLite fails a deferred transaction's lock upgrade *instantly* — bypassing `busy_timeout` — whenever another connection wrote in between. Under background write load (tag config saves and directory sync), an add-to-playlist request failed with a 500.

**Fix:** these endpoints now open their sessions with `get_db_session(commit=True)` so the transaction begins as a writer (`BEGIN IMMEDIATE`) and `busy_timeout` (30s) absorbs contention — the same fix `post_download` already received for the identical failure shape.

Other collection write endpoints (create, tag, delete) still use the deferred session and are theoretically exposed to the same failure; kept out of scope to keep this fix targeted.

## Tests

- `test_write_config_data_failure_preserves_existing_file` — a failed write leaves the existing config untouched and a successful write leaves no temporary file behind (failed before: the file was truncated).
- `test_save_version_check_runs_under_config_save_lock` — the version-check read happens while holding the save lock (failed before).
- `test_item_write_endpoints_use_write_intent_sessions` — add/remove/reorder each open a `commit=True` session (failed before).
- Full backend suite: 1761 passed, 5 skipped. Frontend Jest: 1221 passed. No migrations, no frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)