### PR TITLE
videos: a collaboration video's channel directory conflict killed the download

### DIFF
--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -1362,10 +1362,7 @@ def get_or_create_channel(session: Session, source_id: str = None, url: str = No
     else:
         channel_directory = format_videos_destination(name, tag_name, url)
 
-    # The computed directory may already belong to a Channel that no longer matches by
-    # source_id/url/name (e.g. it was renamed, or a YouTube collaboration video reports the
-    # primary uploader's channel).  Files must live in their Channel's directory, so the
-    # directory's owner wins over creating a conflicting Channel.
+    # Reuse the Channel that already owns this directory instead of creating a conflicting one.
     try:
         channel = get_channel(session, directory=channel_directory, return_dict=False)
         channel.dict()

--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -1361,6 +1361,18 @@ def get_or_create_channel(session: Session, source_id: str = None, url: str = No
         channel_directory = get_absolute_media_path(destination)
     else:
         channel_directory = format_videos_destination(name, tag_name, url)
+
+    # The computed directory may already belong to a Channel that no longer matches by
+    # source_id/url/name (e.g. it was renamed, or a YouTube collaboration video reports the
+    # primary uploader's channel).  Files must live in their Channel's directory, so the
+    # directory's owner wins over creating a conflicting Channel.
+    try:
+        channel = get_channel(session, directory=channel_directory, return_dict=False)
+        channel.dict()
+        return channel
+    except UnknownChannel:
+        pass
+
     if not channel_directory.is_dir():
         channel_directory.mkdir(parents=True)
     data = ChannelPostRequest(

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -374,7 +374,6 @@ async def test_get_or_create_channel_computed_directory_conflict(async_client, t
     channel by name (e.g. the local channel was renamed) even though its directory is already taken."""
     from wrolpi.collections import Collection
 
-    # An existing channel occupies `videos/Uploader`, but its name no longer matches.
     existing_dir = test_directory / 'videos/Uploader'
     existing_dir.mkdir(parents=True)
     collection = Collection(name='Uploader (old name)', kind='channel', directory=existing_dir)
@@ -384,10 +383,6 @@ async def test_get_or_create_channel_computed_directory_conflict(async_client, t
     test_session.add(channel)
     test_session.commit()
 
-    # A collaboration video reports channel 'Uploader' with an unknown source_id/url; no destination is
-    # provided because the download came from a channel subscription.  The computed directory
-    # (videos/Uploader) is already owned, so the owning channel is returned rather than raising
-    # UnrecoverableDownloadError from ChannelDirectoryConflict.
     result = get_or_create_channel(test_session, source_id='UCnew',
                                    url='https://www.youtube.com/channel/UCnew', name='Uploader')
     assert result.id == channel.id

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -366,6 +366,34 @@ async def test_get_or_create_channel_destination_nested_conflict(async_client, t
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_channel_computed_directory_conflict(async_client, test_session, test_directory):
+    """When no existing channel matches by source_id/url/name, but the directory that would be created
+    already belongs to a channel, that channel should be returned instead of raising.
+
+    YouTube collaboration videos report the primary uploader's channel, which may not match any local
+    channel by name (e.g. the local channel was renamed) even though its directory is already taken."""
+    from wrolpi.collections import Collection
+
+    # An existing channel occupies `videos/Uploader`, but its name no longer matches.
+    existing_dir = test_directory / 'videos/Uploader'
+    existing_dir.mkdir(parents=True)
+    collection = Collection(name='Uploader (old name)', kind='channel', directory=existing_dir)
+    test_session.add(collection)
+    test_session.flush([collection])
+    channel = Channel(collection_id=collection.id, source_id='UCold', url='https://www.youtube.com/@olduploader')
+    test_session.add(channel)
+    test_session.commit()
+
+    # A collaboration video reports channel 'Uploader' with an unknown source_id/url; no destination is
+    # provided because the download came from a channel subscription.  The computed directory
+    # (videos/Uploader) is already owned, so the owning channel is returned rather than raising
+    # UnrecoverableDownloadError from ChannelDirectoryConflict.
+    result = get_or_create_channel(test_session, source_id='UCnew',
+                                   url='https://www.youtube.com/channel/UCnew', name='Uploader')
+    assert result.id == channel.id
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_channel_existing_ignores_destination(async_client, test_session, test_directory):
     """When a channel already exists (matched by source_id), the destination parameter should be ignored."""
     from wrolpi.collections import Collection


### PR DESCRIPTION
## Problem

YouTube's new collaboration feature places one video in up to five channels' feeds, but the video's metadata (`channel`, `channel_id`, `channel_url`) always names the primary uploader only. A subscribed channel's feed can therefore yield videos whose info json names a different channel.

When downloading such a video, `get_or_create_channel` finds no local channel matching the uploader's source_id, URL, or name, so it tries to create one. If the computed directory (e.g. `videos/<uploader>`) already belongs to an existing Channel that no longer matches by name (renamed, or created under a former display name), `check_for_channel_conflicts` raises `ChannelDirectoryConflict`, which surfaces as:

```
wrolpi.errors.UnrecoverableDownloadError: Cannot create channel '...': conflicts with an existing channel
```

## Fix

In `get_or_create_channel`, after computing the would-be channel directory and before creating a new Channel, check whether that directory already belongs to an existing channel and return it if so. This mirrors the existing destination-directory fallback and follows the established rule that a directory's owner beats yt-dlp metadata — a Video's files must live in their Channel's directory.

## Testing

* New test `test_get_or_create_channel_computed_directory_conflict` reproduces the reported traceback (failed before the fix, passes after).
* Full backend suite: 1777 passed, 5 skipped.
* Frontend Jest: 70 suites, 1221 tests passed.

## Note

When the computed directory is *not* taken, a collaboration video from a subscription still creates a new channel for the primary uploader rather than joining the subscribed channel (`_get_channel` consults info_json before the download's `collection_id`). Left unchanged here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)