### PR TITLE
downloads: daily limit count was lost on restart

### DIFF
--- a/wrolpi/downloader.py
+++ b/wrolpi/downloader.py
@@ -2136,6 +2136,11 @@ class DownloadManagerConfig(ConfigFile):
                             tag_names = existing.settings.pop('tag_names')
                             existing.tag_names = existing.tag_names or tag_names
                         existing.flush()
+                    elif existing.is_complete and not existing.frequency:
+                        # Completed once-downloads are never written to the config (see `dump_config`), so their
+                        # absence does not mean the user removed them.  Keep them: their `last_download_attempt`
+                        # is what the daily download limits count, and that count must survive a restart.
+                        continue
                     else:
                         logger.warning(f'Deleting Download {existing.url} because it is no longer in the config')
                         session.delete(existing)

--- a/wrolpi/test/test_downloads_config.py
+++ b/wrolpi/test/test_downloads_config.py
@@ -376,3 +376,57 @@ class TestDownloadManagerConfigEdgeCases:
         assert str(downloads[0].destination) == '/new/destination'
         assert downloads[0].last_successful_download is None
         assert downloads[0].next_download is None
+
+
+@pytest.mark.asyncio
+async def test_import_config_preserves_completed_once_downloads(test_session, test_directory, async_client,
+                                                                test_download_manager, test_download_manager_config):
+    """A completed once-download is never written to the config, so importing the config (which happens on every
+    startup) must not delete it: its `last_download_attempt` is what the daily download limits count."""
+    from datetime import timedelta
+
+    from wrolpi.dates import now
+
+    config = get_download_manager_config()
+    config_path = config.get_file()
+
+    recurring = Download(url='https://example.com/recurring', downloader='video', frequency=604800, status='new')
+    completed = Download(url='https://example.com/completed', downloader='video', status='complete',
+                         last_download_attempt=now() - timedelta(minutes=5),
+                         last_successful_download=now() - timedelta(minutes=5))
+    # A pending once-download that the config no longer lists is still deleted (the config is the source of truth).
+    removed = Download(url='https://example.com/removed', downloader='video', status='new')
+    test_session.add_all([recurring, completed, removed])
+    test_session.commit()
+
+    config_data = {
+        'version': 0,
+        'skip_urls': [],
+        'downloads': [{
+            'url': 'https://example.com/recurring',
+            'downloader': 'video',
+            'destination': None,
+            'frequency': 604800,
+            'last_successful_download': None,
+            'next_download': None,
+            'status': 'new',
+            'sub_downloader': None,
+            'settings': None,
+            'tag_names': [],
+        }]
+    }
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, 'w') as f:
+        yaml.dump(config_data, f)
+
+    config.initialize()
+    config.import_config()
+    assert config.successful_import is True
+
+    urls = {i.url for i in test_session.query(Download)}
+    assert urls == {'https://example.com/recurring', 'https://example.com/completed'}
+
+    # The completed download still counts toward today's per-domain limit.
+    global_count, domain_counts = test_download_manager.daily_download_counts(test_session)
+    assert global_count == 1
+    assert domain_counts == {'example.com': 1}


### PR DESCRIPTION
## Problem
The download manager limits downloads per day per domain by counting `Download.last_download_attempt` since local midnight (`daily_download_counts`). Completed once-downloads are never written to `download_manager.yaml`, and `DownloadManagerConfig.import_config` (run on every API startup) deletes any DB Download not present in the config. So restarting the API service deleted exactly the rows the daily limits count from, and the count reset to zero.

## Fix
On import, a Download that is `complete` and has no `frequency` is kept instead of deleted. Pending/failed once-downloads and recurring downloads still follow the config as the source of truth (a `new` download removed from the config is still deleted).

Completed once-downloads are still cleaned up as before: the user can clear them via the API, and `delete_old_once_downloads` prunes them automatically once `last_successful_download` is more than 30 days old. The only change is that a restart no longer discards them early. This also makes the "skip already-downloaded URLs" filter in `create_downloads` reliable across restarts.

## Test
`test_import_config_preserves_completed_once_downloads` — fails before the fix (completed row deleted), passes after; asserts the completed download survives, the removed pending one is still deleted, and `daily_download_counts` still reports it.

`pytest -nauto`: 1783 passed, 5 skipped. `test_events_api_feed` flaked once under load and passes alone with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)