### PR TITLE
archive: raise archive service request limit to 500MB

### DIFF
--- a/docker/archive/main.py
+++ b/docker/archive/main.py
@@ -76,8 +76,12 @@ if not BROWSER_EXEC.is_file():
 
 # Increase response timeout, archiving can take several minutes.
 RESPONSE_TIMEOUT = 10 * 60
+# The API sends uploaded singlefiles base64-encoded in JSON (a 33% size increase).  Sanic's default
+# 100MB limit rejects large uploads with a 413 before the handler runs.
+REQUEST_MAX_SIZE = 500 * 1024 * 1024
 config = {
     'RESPONSE_TIMEOUT': RESPONSE_TIMEOUT,
+    'REQUEST_MAX_SIZE': REQUEST_MAX_SIZE,
 }
 
 app = Sanic('archive')


### PR DESCRIPTION
## Summary
- Set Sanic `REQUEST_MAX_SIZE` to 500MB in the archive docker service (default is 100MB).

## Problem
Converting an uploaded singlefile to an Archive fails on Docker deployments with:

```
KeyError: 'singlefile'  (modules/archive/lib.py request_archive)
```

The API base64-encodes the uploaded singlefile into the JSON POST to the archive container, inflating it by ~33%. An 88MB upload becomes a ~118MB request body, which Sanic rejects before the handler runs:

```
{"description":"Request Entity Too Large","status":413,"message":"Request body exceeds the size limit"}
```

That body has no `error` or `singlefile` key, hence the `KeyError`.

## Verification
- Reproduced against the archive container: a 110MB POST returns 413, a 99MB POST succeeds.
- Only Docker is affected; Debian/RPi run readability and screenshot in-process with no HTTP hop.

## Not in this PR
`request_archive` should check `response.status` so non-200 Sanic responses are reported with their real status instead of a `KeyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)