### PR TITLE
files: readable text previews in dark themes

### DIFF
--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -100,8 +100,8 @@ function getEpubViewerURL(previewFile) {
  * A component rather than part of `getIframePreviewModal` because it reads the theme: the
  * modal builders are plain functions called from an event handler, where hooks cannot run.
  */
-function IframePreview({url, gatePdf}) {
-    const {mediaFilterEnabled} = React.useContext(ThemeContext);
+export function IframePreview({url, gatePdf}) {
+    const {isDark, mediaFilterEnabled} = React.useContext(ThemeContext);
 
     /*
      * `gatePdf` only for PDFs.  Text and the EPUB viewer are documents of our own, which the
@@ -119,11 +119,12 @@ function IframePreview({url, gatePdf}) {
             <iframe title='textModal' src={url}
                     style={{
                         height: '100%', width: '100%', border: 'none',
-                        // A same-origin document inherits the page's color-scheme, so the
-                        // browser's default stylesheet paints plain text light in dark themes.
-                        // Force a light scheme so text is always black on the white background.
-                        backgroundColor: '#ffffff',
-                        colorScheme: 'light',
+                        // A same-origin document has no styles of its own; it renders with the
+                        // browser's default stylesheet for whatever color-scheme this element
+                        // declares.  Pin the scheme to the theme so text is light-on-dark under
+                        // the dark themes and black-on-white under light, never white-on-white.
+                        backgroundColor: isDark ? 'var(--panel)' : '#ffffff',
+                        colorScheme: isDark ? 'dark' : 'light',
                     }}/>
         </div>
     </MediaGate>

--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -119,8 +119,11 @@ function IframePreview({url, gatePdf}) {
             <iframe title='textModal' src={url}
                     style={{
                         height: '100%', width: '100%', border: 'none',
-                        // Use white to avoid iframe displaying with dark-theme.
+                        // A same-origin document inherits the page's color-scheme, so the
+                        // browser's default stylesheet paints plain text light in dark themes.
+                        // Force a light scheme so text is always black on the white background.
                         backgroundColor: '#ffffff',
+                        colorScheme: 'light',
                     }}/>
         </div>
     </MediaGate>

--- a/app/src/components/FilePreview.test.js
+++ b/app/src/components/FilePreview.test.js
@@ -100,3 +100,45 @@ describe('preview gate remounting (source contract)', () => {
         expect(rebuild.length).toBeGreaterThan(0);
     });
 });
+
+describe('IframePreview color scheme', () => {
+    /*
+     * The previewed file is a bare document with no styles of its own, so it renders with the
+     * browser's default stylesheet for whatever color-scheme the iframe element declares.  If
+     * the scheme does not follow the theme, one combination is always unreadable: a dark page
+     * scheme with a white iframe renders the browser's light text on white.
+     */
+    const {render} = require('@testing-library/react');
+    const {ThemeContext} = require('../contexts/contexts');
+    const {IframePreview} = require('./FilePreview');
+
+    const renderWithTheme = (isDark) => render(
+        <ThemeContext.Provider value={{isDark, mediaFilterEnabled: false}}>
+            <IframePreview url='/media/config/wrolpi.yaml'/>
+        </ThemeContext.Provider>
+    );
+
+    test('dark themes render the document dark with a dark background', () => {
+        const {container} = renderWithTheme(true);
+        const iframe = container.querySelector('iframe');
+        expect(iframe.style.colorScheme).toEqual('dark');
+    });
+
+    test('the dark background is the theme panel color', () => {
+        /*
+         * Read off the source because jsdom's CSSOM drops var() declarations entirely, so a
+         * rendered iframe in jsdom cannot show the background it gets in a real browser.
+         */
+        const fs = require('fs');
+        const path = require('path');
+        const source = fs.readFileSync(path.join(__dirname, 'FilePreview.js'), 'utf8');
+        expect(source).toContain(`backgroundColor: isDark ? 'var(--panel)' : '#ffffff'`);
+    });
+
+    test('the light theme renders the document black-on-white', () => {
+        const {container} = renderWithTheme(false);
+        const iframe = container.querySelector('iframe');
+        expect(iframe.style.colorScheme).toEqual('light');
+        expect(iframe.style.backgroundColor).toEqual('rgb(255, 255, 255)');
+    });
+});


### PR DESCRIPTION
## Problem

Text file previews (e.g. YAML configs in the Files page) were unreadable in dark themes: the preview appeared as an empty white box.

## Cause

The preview iframe forces a white background, but a same-origin plain-text document has no styles of its own — it renders with the browser's default stylesheet for whatever `color-scheme` the iframe declares, and it inherited the page's dark scheme: light text on the forced white background.

## Fix

Pin the iframe's `color-scheme` to the theme: `dark` with a `var(--panel)` background under the dark themes (dark, night, amber), `light` with a white background under the light theme. Text is light-on-dark or black-on-white, never white-on-white. The night theme's media filter tints the light text as it does any document.

## Testing

- New Jest tests assert the scheme and background follow the theme.
- Full Jest suite passes; `npm run build` succeeds.
- Verified live in Chrome on a dev WROLPi in all four themes, including after full page reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)