### PR TITLE
files: left-align the preview toolbar

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -266,6 +266,10 @@ pre.wrap-text {
     flex-wrap: wrap;
     align-items: center;
     gap: 0.5em;
+    /* Fill the actions row: `.wrolpi-modal-actions` packs its children to the right, which
+       is where a confirming button belongs but strands this toolbar.  At full width the
+       toolbar's own layout wins and everything reads from the left. */
+    flex: 1 1 100%;
 }
 
 .preview-toolbar-group {
@@ -279,6 +283,14 @@ pre.wrap-text {
     /* rem so the basis grows with the tags it holds. */
     flex: 1 1 12.5rem;
     min-width: 0;
+}
+
+/* On a phone the tags selector always gets its own line rather than squeezing in beside
+   the buttons.  700px is the app's `tablet` breakpoint (`AppMedia` in contexts.js). */
+@media (max-width: 699px) {
+    .preview-toolbar-tags {
+        flex-basis: 100%;
+    }
 }
 
 /* Caps preview content to fit inside the file-preview Modal.

--- a/app/src/Tags.js
+++ b/app/src/Tags.js
@@ -583,7 +583,9 @@ export function AddTagsButton({
         <IconButton
             icon={active ? 'tags' : 'tag'}
             label={active ? 'Tags applied' : 'Add tag'}
-            role='primary'
+            // Violet is the tagging color everywhere: the file browser's Tag button already
+            // wears it, so this button matches rather than reading as a generic primary action.
+            color='violet'
             onClick={handleOpen}
             type='button'
             disabled={disabled}

--- a/app/src/components/FilePreview.js
+++ b/app/src/components/FilePreview.js
@@ -558,7 +558,7 @@ export function FilePreviewProvider({children}) {
 
         // Single flex toolbar — same button order at every viewport size.
         // `flex-wrap: wrap` lets the tags selector drop to a second line on narrow screens
-        // while the button groups stay together and in order: [file actions] [tags] [open/close].
+        // while the buttons stay together, Open first: [open + file actions] [tags].
         setPreviewModal(<Modal size='fullscreen'
                                open={true}
                                onClose={e => handleClose(e)}
@@ -567,6 +567,7 @@ export function FilePreviewProvider({children}) {
             <Modal.Actions>
                 <div className='preview-toolbar'>
                     <div className='preview-toolbar-group'>
+                        {openButton}
                         {downloadButton}
                         {directoryButton}
                         <ShareButton/>
@@ -576,9 +577,6 @@ export function FilePreviewProvider({children}) {
                                                  title='Add to Playlist'/>}
                     </div>
                     <div className='preview-toolbar-tags'>{tagsDisplay}</div>
-                    <div className='preview-toolbar-group'>
-                        {openButton}
-                    </div>
                 </div>
             </Modal.Actions>
             {content}

--- a/app/src/components/Nav.js
+++ b/app/src/components/Nav.js
@@ -432,7 +432,7 @@ export function NavBar() {
         <NavIconWrapper>{driveHealthIcon}</NavIconWrapper>
         <NavIconWrapper>{powerIcon}</NavIconWrapper>
         <NavIconWrapper>{warningIcon}</NavIconWrapper>
-        <NavIconWrapper><ShareButton/></NavIconWrapper>
+        <NavIconWrapper><ShareButton asIcon/></NavIconWrapper>
         <NavIconWrapper><HotspotStatusIcon/></NavIconWrapper>
         <NavIconWrapper><DarkModeToggle/></NavIconWrapper>
     </React.Fragment>;

--- a/app/src/components/Share.js
+++ b/app/src/components/Share.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {Button, Header, Icon, Modal} from "./ui";
+import {Button, Header, Icon, IconButton, Modal} from "./ui";
 import QRCode from "react-qr-code";
 import {sendNotification} from "../api";
 
@@ -20,7 +20,11 @@ export const ShareEveryoneButton = ({url, size, onClick}) => {
     </Button>
 }
 
-export const ShareButton = () => {
+/*
+ * `asIcon` is for the navbar corner, where the trigger sits beside other bare glyphs and a
+ * boxed button would not match; everywhere else it is a real button, matching its siblings.
+ */
+export const ShareButton = ({asIcon = false}) => {
     const [open, setOpen] = React.useState(false);
 
     const handleOpen = (e) => {
@@ -56,8 +60,10 @@ export const ShareButton = () => {
                 <Button role='cancel' onClick={handleClose}>Close</Button>
             </Modal.Actions>
         </Modal>
-        <a href='#' onClick={handleOpen}>
-            <Icon name='share' size='large'/>
-        </a>
+        {asIcon
+            ? <a href='#' onClick={handleOpen}>
+                <Icon name='share' size='large'/>
+            </a>
+            : <IconButton icon='share' label='Share' size='small' onClick={handleOpen}/>}
     </>
 }

--- a/app/src/components/ui/ui-layout.cy.js
+++ b/app/src/components/ui/ui-layout.cy.js
@@ -3941,7 +3941,7 @@ describe('the icon-only triggers in the navbar corner are reachable', () => {
      * classes I expected the components to have, so reverting SearchIconButton to the old
      * `item` left it green -- it was measuring my markup, not the app's.
      */
-    const corner = <NavIconWrapper><ShareButton/></NavIconWrapper>;
+    const corner = <NavIconWrapper><ShareButton asIcon/></NavIconWrapper>;
 
     const triggers = {
         share: '.wrolpi-navbar-icon a',


### PR DESCRIPTION
## Problem

The buttons at the bottom of the file preview modal were packed against the right edge: the modal actions row right-aligns its children, which suits a confirming button but stranded this toolbar.

## Changes

- The preview toolbar fills the actions row, so its buttons read from the left on desktop and mobile.
- The Open button joins the Download/folder/share button row instead of sitting in its own trailing group.
- On phones (below the 700px tablet breakpoint) the tags selector always takes its own line instead of squeezing in beside the buttons.
- The add-tag button is violet, matching the file browser's Tag button — tagging wears violet everywhere.
- The share trigger is a real IconButton wherever it sits beside other buttons; the navbar corner keeps its bare glyph via a new `asIcon` prop.

## Testing

- Full Jest suite passes; `npm run build` succeeds; the `ui-layout` cypress component spec (which mounts the real ShareButton in the navbar) passes.
- Verified live in Chrome on a dev WROLPi at desktop and phone (390px) widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)