### PR TITLE
videos: deflake event-loop-blocking search test

### DIFF
--- a/modules/videos/test/test_api.py
+++ b/modules/videos/test/test_api.py
@@ -1,5 +1,5 @@
 import asyncio
-import time
+import threading
 from unittest import mock
 import json
 from http import HTTPStatus
@@ -598,28 +598,40 @@ async def test_search_videos_does_not_block_event_loop(async_client):
     """A slow video search must not stall other requests on the same Sanic worker.
 
     The search runs a synchronous SQLite query; on a large library it takes seconds cold.  If it
-    runs on the event loop, every other request on the worker waits for it."""
-    # The first request pays the test app's startup cost; keep that out of the measurement.
+    runs on the event loop, every other request on the worker waits for it.
+
+    The search is held open with an Event and the test asserts the echo completes while the search
+    is still inside the query, rather than timing the echo against a wall-clock threshold, so the
+    test cannot flake on a loaded CI machine.  The events are only ever waited on off the event
+    loop, so a regression (query on the loop) cannot deadlock the test; it fails the ordering
+    assertion instead."""
     await async_client.get('/api/echo')
 
+    entered = threading.Event()  # the handler has reached the search query.
+    release = threading.Event()  # the test is done measuring; let the query return.
+    finished = threading.Event()  # the search query has returned.
+
     def slow_search(*_, **__):
-        time.sleep(0.5)  # a synchronous, blocking query
+        entered.set()
+        release.wait(timeout=30)
+        finished.set()
         return [], 0
 
-    async def search():
-        return await async_client.post('/api/videos/search', content=json.dumps({}))
-
-    async def echo():
-        start = time.perf_counter()
-        _, response = await async_client.get('/api/echo')
-        return response, time.perf_counter() - start
-
     with mock.patch('modules.videos.video.lib.search_videos', slow_search):
-        (_, search_response), (echo_response, echo_elapsed) = await asyncio.gather(search(), echo())
+        search_task = asyncio.create_task(
+            async_client.post('/api/videos/search', content=json.dumps({})))
+        try:
+            # Do not send the echo until the search request is provably inside the query.
+            assert await asyncio.to_thread(entered.wait, 30), 'the search request never started'
+            _, echo_response = await asyncio.wait_for(async_client.get('/api/echo'), timeout=30)
+            assert not finished.is_set(), \
+                'echo only completed after the search query returned; the search blocked the event loop'
+        finally:
+            release.set()
+        _, search_response = await search_task
 
-    assert search_response.status_code == HTTPStatus.OK
     assert echo_response.status_code == HTTPStatus.OK
-    assert echo_elapsed < 0.4, f'echo waited {echo_elapsed:.2f}s behind a blocking search'
+    assert search_response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`test_search_videos_does_not_block_event_loop` is flaky and almost always fails on CI:

```
AssertionError: echo waited 1.48s behind a blocking search
assert 1.48353162300009 < 0.4
```

The test asserted a wall-clock threshold — a concurrent echo request had to return in under 0.4s. On a loaded CI machine the echo can take longer than that from CPU starvation and scheduler noise alone, even though the event loop was never blocked. Any timing threshold keeps flaking there.

## Fix

Replace the timing assertion with an ordering assertion:

- The mocked search parks its **thread** on a `threading.Event` instead of sleeping.
- The echo is sent only once the handler is provably inside the query (an `entered` event, awaited via `asyncio.to_thread` so a broken endpoint can't deadlock the wait).
- The pass condition is that the echo completes **while the search query is still held open** (`finished` not yet set) — true under any machine load if the query is offloaded, and impossible if it runs on the event loop.
- The remaining timeouts (10–30s) are failure backstops only, never part of the pass condition.

## Verification

- Passes repeatedly (8/8 runs) against the real endpoint.
- Fails with a clear message when the endpoint is temporarily changed to call `lib.search_videos` synchronously on the loop, confirming the regression it guards against is still caught.
- Full backend suite: only the two known load-sensitive flakes failed under `-nauto`; both pass in isolation and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)