### PR TITLE
videos: codec download preferences with transcode and strict-fail options

### DIFF
--- a/app/src/components/CodecSettings.test.js
+++ b/app/src/components/CodecSettings.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {CodecSettingsForm} from './Download';
+import {createTestForm, renderUI} from '../test-utils';
+
+/** createTestForm implements getCustomProps but not getSelectionProps (used by
+ * MultiSelectField); the shapes are compatible for these tests. */
+const createCodecForm = (initialData) => {
+    const form = createTestForm(initialData);
+    form.getSelectionProps = form.getCustomProps;
+    return form;
+};
+
+describe('CodecSettingsForm', () => {
+    it('renders codec selectors and toggles', () => {
+        const form = createCodecForm({settings: {video_codecs: ['h264'], audio_codecs: []}});
+
+        renderUI(<CodecSettingsForm form={form}/>);
+
+        expect(screen.getByText('Video Codecs')).toBeInTheDocument();
+        expect(screen.getByText('Audio Codecs')).toBeInTheDocument();
+        expect(screen.getByText('Transcode to preferred codecs')).toBeInTheDocument();
+        expect(screen.getByText('Fail if codecs unavailable')).toBeInTheDocument();
+    });
+
+    it('disables the strict toggle while transcode is enabled', () => {
+        const form = createCodecForm({settings: {transcode: true, strict_codecs: false}});
+
+        renderUI(<CodecSettingsForm form={form}/>);
+
+        const toggles = screen.getAllByTestId('toggle');
+        const [transcodeToggle, strictToggle] = toggles.map(i => i.querySelector('input') || i);
+        expect(transcodeToggle).toBeChecked();
+        expect(strictToggle).toBeDisabled();
+    });
+
+    it('enables the strict toggle while transcode is disabled', async () => {
+        const form = createCodecForm({settings: {transcode: false, strict_codecs: false}});
+
+        renderUI(<CodecSettingsForm form={form}/>);
+
+        const toggles = screen.getAllByTestId('toggle');
+        const [, strictToggle] = toggles.map(i => i.querySelector('input') || i);
+        expect(strictToggle).not.toBeDisabled();
+
+        await userEvent.click(strictToggle);
+        expect(form.formData.settings.strict_codecs).toBe(true);
+    });
+});

--- a/app/src/components/Download.cy.js
+++ b/app/src/components/Download.cy.js
@@ -186,7 +186,10 @@ describe('<EditRSSDownloadForm />', () => {
                     "720p",
                     "480p",
                     "maximum"
-                ]
+                ],
+                video_codecs: ["h264"],
+                audio_codecs: ["aac"],
+                transcode: true,
             },
             sub_downloader: "video",
             tag_names: ['Automotive'],
@@ -265,6 +268,9 @@ describe('<EditRSSDownloadForm />', () => {
                 video_format: 'mp4',
                 minimum_duration: null,
                 maximum_duration: null,
+                video_codecs: ['h264'],
+                audio_codecs: ['aac'],
+                transcode: true,
             });
         });
     });

--- a/app/src/components/Download.js
+++ b/app/src/components/Download.js
@@ -26,11 +26,13 @@ import {
     defaultAudioFormatOption,
     defaultVideoFormatOption,
     defaultVideoResolutionOptions,
+    downloadAudioCodecOptions,
     downloadAudioFormatOptions,
     Downloaders,
     downloadFormatOptions,
     downloadOrderOptions,
     downloadResolutionOptions,
+    downloadVideoCodecOptions,
     extendedFrequencyOptions,
     frequencyOptions,
     weeklyOption
@@ -434,6 +436,72 @@ export function AudioFormatSelectorForm({form, name = 'audio_format', path = 'se
     </div>
 }
 
+export function VideoCodecSelectorForm({form, name = 'video_codecs', path = 'settings.video_codecs'}) {
+    return <div>
+        <InfoHeader
+            headerSize='h5'
+            headerContent='Video Codecs'
+            popupContent='Prefer these video codecs, in order.  A preferred codec at a lower resolution is
+             chosen over other codecs at a higher resolution.  Leave empty to accept any codec.'
+            for_='video_codecs_input'
+        />
+        <MultiSelectField
+            form={form}
+            name={name}
+            path={path}
+            options={downloadVideoCodecOptions}
+        />
+    </div>
+}
+
+export function AudioCodecSelectorForm({form, name = 'audio_codecs', path = 'settings.audio_codecs'}) {
+    return <div>
+        <InfoHeader
+            headerSize='h5'
+            headerContent='Audio Codecs'
+            popupContent='Prefer these audio codecs, in order.  Leave empty to accept any codec.'
+            for_='audio_codecs_input'
+        />
+        <MultiSelectField
+            form={form}
+            name={name}
+            path={path}
+            options={downloadAudioCodecOptions}
+        />
+    </div>
+}
+
+/** Codec preference selectors with the transcode/strict toggles.  Strict is moot while transcode
+ * is enabled (the transcode guarantees the codec), so it is disabled then. */
+export function CodecSettingsForm({form, codecsPathPrefix = 'settings.'}) {
+    const [transcodeProps] = form.getCustomProps({name: 'transcode', path: `${codecsPathPrefix}transcode`});
+    const [strictProps] = form.getCustomProps({name: 'strict_codecs', path: `${codecsPathPrefix}strict_codecs`});
+    return <Stack gap='md'>
+        <Group grow align='flex-start' wrap='wrap'>
+            <VideoCodecSelectorForm form={form} path={`${codecsPathPrefix}video_codecs`}/>
+            <AudioCodecSelectorForm form={form} path={`${codecsPathPrefix}audio_codecs`}/>
+        </Group>
+        <Group grow align='flex-start' wrap='wrap'>
+            <Toggle
+                label='Transcode to preferred codecs'
+                checked={!!transcodeProps.value}
+                disabled={form.disabled}
+                onChange={transcodeProps.onChange}
+                info='If no preferred codec is available, convert the video after downloading.
+                 Transcoding is slow and slightly reduces quality.'
+            />
+            <Toggle
+                label='Fail if codecs unavailable'
+                checked={!!strictProps.value}
+                disabled={form.disabled || !!transcodeProps.value}
+                onChange={strictProps.onChange}
+                info='Fail the download when no preferred codec is available, instead of falling
+                 back to any codec.  Not necessary when transcoding is enabled.'
+            />
+        </Group>
+    </Stack>
+}
+
 function VideoDurationLimit({form, name, path, label, helpContent, placeholder, helpPosition}) {
     return <NumberField
         form={form}
@@ -478,6 +546,7 @@ function AdvancedVideoSettings({form, isVideoLevel = false, isConfigLoaded = tru
 
     return <SimpleAccordion title='Advanced Settings'>
         <Stack gap='md'>
+            <CodecSettingsForm form={form}/>
             <Group grow align='flex-start' wrap='wrap'>
                 <AudioOnlyToggleLikeVideoSetting form={form} name='writesubtitles' path='settings.writesubtitles'
                                                  label='Download subtitles' icon='closed captioning'/>

--- a/app/src/components/Vars.js
+++ b/app/src/components/Vars.js
@@ -143,6 +143,21 @@ export const downloadAudioFormatOptions = [
 
 export const defaultAudioFormatOption = 'mp3';
 
+export const downloadVideoCodecOptions = [
+    {key: 'h264', text: 'h264 (avc1)', value: 'h264'},
+    {key: 'vp9', text: 'vp9', value: 'vp9'},
+    {key: 'av1', text: 'av1', value: 'av1'},
+    {key: 'vp8', text: 'vp8', value: 'vp8'},
+    {key: 'hevc', text: 'hevc (h265)', value: 'hevc'},
+];
+
+export const downloadAudioCodecOptions = [
+    {key: 'aac', text: 'aac', value: 'aac'},
+    {key: 'opus', text: 'opus', value: 'opus'},
+    {key: 'mp3', text: 'mp3', value: 'mp3'},
+    {key: 'vorbis', text: 'vorbis', value: 'vorbis'},
+];
+
 export const Downloaders = {
     Archive: 'archive',
     File: 'file',

--- a/app/src/components/Videos.js
+++ b/app/src/components/Videos.js
@@ -64,7 +64,7 @@ import {QueryContext} from "../contexts/contexts";
 import _ from "lodash";
 import {defaultFileOrder, defaultSearchOrder} from "./Vars";
 import {InputForm, ToggleForm, useForm} from "../hooks/useForm";
-import {VideoFormatSelectorForm, VideoResolutionSelectorForm} from "./Download";
+import {CodecSettingsForm, VideoFormatSelectorForm, VideoResolutionSelectorForm} from "./Download";
 import {BatchReorganizeModal} from "./collections/BatchReorganizeModal";
 
 export function VideoWrapper() {
@@ -350,6 +350,10 @@ export function VideosSettingsPage() {
         download_missing_video_comments: false,
         user_agent: '',
         sleep_requests: 0.75,
+        video_codecs: [],
+        audio_codecs: [],
+        transcode: false,
+        strict_codecs: false,
     };
 
     const configSubmitter = async () => {
@@ -396,6 +400,7 @@ export function VideosSettingsPage() {
                     />
                     <VideoFileNameForm form={configForm}/>
                 </div>
+                <CodecSettingsForm form={configForm} codecsPathPrefix=''/>
                 <div style={settingsGridStyle}>
                     <ToggleForm
                         form={configForm}

--- a/modules/videos/downloader.py
+++ b/modules/videos/downloader.py
@@ -36,7 +36,7 @@ from wrolpi.files.worker import file_worker
 from wrolpi.vars import PYTEST, YTDLP_CACHE_DIR
 from .channel.lib import create_channel, get_channel
 from .common import get_no_channel_directory, update_view_counts_and_censored, \
-    ffmpeg_video_complete
+    ffmpeg_video_complete, get_or_create_ffprobe_json
 from .errors import UnknownChannel, ChannelDirectoryConflict, ChannelNameConflict, ChannelURLConflict, \
     ChannelSourceIdConflict
 from .cookies import cookies_unlocked, cookies_for_download
@@ -45,6 +45,8 @@ from .lib import get_videos_downloader_config, get_effective_video_settings, CHA
 from .models import Video, Channel
 from .normalize_video_url import normalize_video_url
 from .schema import ChannelPostRequest
+from .transcode import codecs_match, get_transcode_target, transcode_video_file, \
+    TRANSCODE_VIDEO_TARGETS, TRANSCODE_AUDIO_TARGETS
 from .video.lib import download_video_info_json
 
 logger = logger.getChild(__name__)
@@ -153,20 +155,118 @@ VIDEO_RESOLUTION_MAP = {
     'maximum': ['bestvideo*+bestaudio/best'],
 }
 
+# yt-dlp `vcodec`/`acodec` values vary by extractor (avc1.64001f, vp09.00.10.08, mp4a.40.2, ...);
+# match them by prefix regex.  These are used inside `-f` bracket filters, so they must never
+# contain a comma or a forward slash.
+VIDEO_CODEC_YT_DLP_PATTERNS = {
+    'h264': r'^(avc|h264)',
+    'hevc': r'^(hev|hvc|h265|hevc)',
+    'vp9': r'^vp0?9',
+    'av1': r'^av0?1',
+    'vp8': r'^vp0?8',
+}
+AUDIO_CODEC_YT_DLP_PATTERNS = {
+    'aac': r'^(aac|mp4a\.40)',
+    'opus': r'^opus',
+    'mp3': r'^(mp3|mp4a\.69|mp4a\.6b)',
+    'vorbis': r'^vorbis',
+}
+RESOLUTION_HEIGHTS = {'360p': 360, '480p': 480, '720p': 720, '1080p': 1080,
+                      '1440p': 1440, '2160p': 2160, 'maximum': None}
+
 # VTT is the only format that a browser can use to display captions on a <video/>.
 DEFAULT_CAPTION_FORMAT = 'vtt'
 DEFAULT_POSTER_FORMAT = 'jpg'
 DEFAULT_CHANNEL_DOWNLOAD_ORDER = 'newest'
 
 
-def format_selector(video_resolutions: List[str]) -> str:
-    """Flatten the requested resolutions into a single yt-dlp `-f` format selector.
+def format_selector(video_resolutions: List[str], video_codecs: List[str] = None,
+                    audio_codecs: List[str] = None, strict_codecs: bool = False) -> str:
+    """Flatten the requested resolutions (and codec preferences) into a single yt-dlp `-f`
+    format selector.
 
     The selectors are joined with "/" so yt-dlp downloads only the first one that matches.
     Joining with "," would instead ask yt-dlp to download *every* matching selector, which
     downloads (and post-processes) the same video once per match.
+
+    Codec preference is codec-major: a preferred codec at a lower resolution beats a
+    non-preferred codec at a higher resolution.  Unless `strict_codecs`, the legacy
+    resolution selectors are appended as a fallback so a video is still downloaded when no
+    preferred codec is available.
     """
-    return '/'.join(j for i in video_resolutions for j in VIDEO_RESOLUTION_MAP[i])
+    legacy = '/'.join(j for i in video_resolutions for j in VIDEO_RESOLUTION_MAP[i])
+    if not video_codecs and not audio_codecs:
+        return legacy
+
+    audio_selectors = [f"bestaudio[acodec~='{AUDIO_CODEC_YT_DLP_PATTERNS[i]}']" for i in audio_codecs or []]
+    if not strict_codecs or not audio_codecs:
+        audio_selectors.append('bestaudio')
+
+    video_filters = [f"[vcodec~='{VIDEO_CODEC_YT_DLP_PATTERNS[i]}']" for i in video_codecs] \
+        if video_codecs else ['']
+    selectors = []
+    for video_filter in video_filters:
+        for resolution in video_resolutions:
+            height = RESOLUTION_HEIGHTS[resolution]
+            dimensions = [f'[height={height}]', f'[width={height}]'] if height else ['']
+            for dimension in dimensions:
+                for audio_selector in audio_selectors:
+                    selectors.append(f'bestvideo{dimension}{video_filter}+{audio_selector}')
+    if not strict_codecs:
+        selectors.append(legacy)
+    return '/'.join(selectors)
+
+
+async def enforce_codecs(video_path: pathlib.Path, video_paths: List[pathlib.Path], effective: dict) \
+        -> Tuple[pathlib.Path, List[pathlib.Path]]:
+    """Verify the downloaded file's codecs against the effective codec preferences.
+
+    The format selector already prefers matching sources, but the legacy fallback selectors (and
+    lying extractor metadata) can still deliver a non-preferred codec.  On mismatch: transcode when
+    enabled, fail permanently when strict, otherwise keep the file (best-effort preference).
+
+    Runs before the Video record is created and holds no DB session, so ffmpeg may run for a long
+    time without blocking writers.
+    """
+    video_codecs = effective.get('video_codecs') or []
+    audio_codecs = effective.get('audio_codecs') or []
+    transcode = effective.get('transcode', False)
+    strict_codecs = effective.get('strict_codecs', False) and not transcode
+
+    data, _ = await get_or_create_ffprobe_json(video_path)
+    video_match, audio_match = codecs_match(data, video_codecs, audio_codecs)
+    if video_match and audio_match:
+        return video_path, video_paths
+
+    if transcode:
+        target_vcodec = None if video_match else get_transcode_target(video_codecs, TRANSCODE_VIDEO_TARGETS)
+        target_acodec = None if audio_match else get_transcode_target(audio_codecs, TRANSCODE_AUDIO_TARGETS)
+        if not target_vcodec and not target_acodec:
+            logger.warning(f'Cannot transcode {video_path}: none of the preferred codecs'
+                           f' (video={video_codecs}, audio={audio_codecs}) is a supported transcode target')
+            return video_path, video_paths
+        try:
+            from wrolpi.events import Events
+            Events.send_user_notify(f'Transcoding {video_path.name}')
+        except Exception:
+            # Events are best-effort; never let them break a download.
+            logger.debug(f'Failed to send transcode event for {video_path}', exc_info=True)
+        new_path = await transcode_video_file(video_path, target_vcodec, target_acodec,
+                                              container=effective.get('video_format') or 'mp4')
+        await get_or_create_ffprobe_json(new_path)  # Refresh the sidecar for the new streams.
+        video_paths = [new_path if i == video_path else i for i in video_paths]
+        return new_path, video_paths
+
+    if strict_codecs:
+        actual_video = [i.get('codec_name') for i in data.get('streams', []) if i.get('codec_type') == 'video']
+        actual_audio = [i.get('codec_name') for i in data.get('streams', []) if i.get('codec_type') == 'audio']
+        raise UnrecoverableDownloadError(
+            f'Downloaded video has codecs (video={actual_video}, audio={actual_audio}) but strict codecs'
+            f' (video={video_codecs}, audio={audio_codecs}) was required and transcoding is disabled')
+
+    logger.warning(f'{video_path} does not match preferred codecs'
+                   f' (video={video_codecs}, audio={audio_codecs}); keeping it as downloaded')
+    return video_path, video_paths
 
 
 def get_youtube_video_id(url: str) -> Optional[str]:
@@ -936,6 +1036,11 @@ class VideoDownloader(Downloader, ABC):
         effective = get_effective_video_settings(settings)
         audio_only = effective.get('audio_only', False)
         audio_format = effective.get('audio_format', 'mp3')
+        video_codecs = effective.get('video_codecs') or []
+        audio_codecs = effective.get('audio_codecs') or []
+        transcode = effective.get('transcode', False)
+        # Transcoding guarantees the codec, so strict is only meaningful without it.
+        strict_codecs = effective.get('strict_codecs', False) and not transcode
 
         # download_for_log carries .id (for progress) and .url (for log messages).
         # Falling back to a stub keeps unit tests viable.
@@ -943,7 +1048,8 @@ class VideoDownloader(Downloader, ABC):
 
         try:
             video_resolutions = effective['video_resolutions']
-            video_resolutions_str = format_selector(video_resolutions)
+            video_resolutions_str = format_selector(video_resolutions, video_codecs=video_codecs,
+                                                    audio_codecs=audio_codecs, strict_codecs=strict_codecs)
             video_format = effective['video_format']
             video_path, entry = prepare_video_filename(url, out_dir, video_resolutions_str, video_format,
                                                       audio_only=audio_only, audio_format=audio_format)
@@ -971,7 +1077,14 @@ class VideoDownloader(Downloader, ABC):
                 '--extractor-args', 'youtube:max_comments=all,20,all,10;comment_sort=top',
             )
             if audio_only:
-                cmd = (*cmd, '-f', 'bestaudio', '-x', '--audio-format', audio_format)
+                audio_selector = 'bestaudio'
+                if audio_codecs:
+                    audio_selectors = [f"bestaudio[acodec~='{AUDIO_CODEC_YT_DLP_PATTERNS[i]}']"
+                                       for i in audio_codecs]
+                    if not strict_codecs:
+                        audio_selectors.append('bestaudio')
+                    audio_selector = '/'.join(audio_selectors)
+                cmd = (*cmd, '-f', audio_selector, '-x', '--audio-format', audio_format)
             else:
                 cmd = (*cmd,
                        '-f', video_resolutions_str,
@@ -1022,6 +1135,11 @@ class VideoDownloader(Downloader, ABC):
                 error = f'{stdout}\n\n\n{stderr}\n\nvideo downloader process exited with {result.return_code}'
                 if _bot_blocked(error):
                     raise BotBlockedDownloadError(f'Bot detection or invalid cookies: {error}')
+                if strict_codecs and 'Requested format is not available' in error:
+                    # The source will not grow new formats; do not retry.
+                    raise UnrecoverableDownloadError(
+                        f'None of the requested codecs (video={video_codecs}, audio={audio_codecs}) are'
+                        f' available for this video, and transcoding is disabled: {url}')
                 return DownloadResult(success=False, error=error, location=location)
 
             output_format = audio_output_extension(audio_format) if audio_only else video_format
@@ -1060,6 +1178,9 @@ class VideoDownloader(Downloader, ABC):
             video_paths = glob_shared_stem(video_path)
             video_paths = self._delete_part_files(video_path, video_paths)
             video_paths = self.normalize_video_file_names(video_path, video_paths)
+
+            if not audio_only and (video_codecs or audio_codecs):
+                video_path, video_paths = await enforce_codecs(video_path, video_paths, effective)
 
             if is_youtube_url(url):
                 # YouTube auto-captions pin the text to the bottom-left; center them at the source.  Runs

--- a/modules/videos/lib.py
+++ b/modules/videos/lib.py
@@ -569,6 +569,10 @@ class VideoDownloaderConfigValidator:
     sleep_requests: float = 0.75
     audio_only: bool = False
     audio_format: str = 'mp3'
+    video_codecs: List[str] = field(default_factory=list)
+    audio_codecs: List[str] = field(default_factory=list)
+    transcode: bool = False
+    strict_codecs: bool = False
 
     def __post_init__(self):
         allowed_fields = {i.name for i in dataclasses.fields(VideoDownloaderConfigYtDlpOptionsValidator)}
@@ -600,6 +604,10 @@ class VideoDownloaderConfig(ConfigFile):
         sleep_requests=0.75,
         audio_only=False,
         audio_format='mp3',
+        video_codecs=[],
+        audio_codecs=[],
+        transcode=False,
+        strict_codecs=False,
     )
     validator = VideoDownloaderConfigValidator
 
@@ -715,6 +723,38 @@ class VideoDownloaderConfig(ConfigFile):
     def audio_format(self, value: str):
         self.update({**self._config, 'audio_format': value})
 
+    @property
+    def video_codecs(self) -> List[str]:
+        return self._config.get('video_codecs', [])
+
+    @video_codecs.setter
+    def video_codecs(self, value: List[str]):
+        self.update({**self._config, 'video_codecs': value})
+
+    @property
+    def audio_codecs(self) -> List[str]:
+        return self._config.get('audio_codecs', [])
+
+    @audio_codecs.setter
+    def audio_codecs(self, value: List[str]):
+        self.update({**self._config, 'audio_codecs': value})
+
+    @property
+    def transcode(self) -> bool:
+        return self._config.get('transcode', False)
+
+    @transcode.setter
+    def transcode(self, value: bool):
+        self.update({**self._config, 'transcode': value})
+
+    @property
+    def strict_codecs(self) -> bool:
+        return self._config.get('strict_codecs', False)
+
+    @strict_codecs.setter
+    def strict_codecs(self, value: bool):
+        self.update({**self._config, 'strict_codecs': value})
+
     def import_config(self, file: pathlib.Path = None, send_events=False):
         super().import_config(file, send_events)
         self.successful_import = True
@@ -744,6 +784,7 @@ INHERITABLE_VIDEO_SETTINGS = {
     'video_resolutions', 'video_format', 'writesubtitles', 'writeautomaticsub',
     'writethumbnail', 'writeinfojson', 'yt_dlp_extra_args', 'sleep_requests',
     'user_agent', 'continue_dl', 'nooverwrites', 'audio_only', 'audio_format',
+    'video_codecs', 'audio_codecs', 'transcode', 'strict_codecs',
 }
 
 # Subset of inheritable settings allowed at channel/RSS level.
@@ -767,6 +808,10 @@ def _extract_global_inheritable(config: VideoDownloaderConfig) -> dict:
         'nooverwrites': config.nooverwrites,
         'audio_only': config.audio_only,
         'audio_format': config.audio_format,
+        'video_codecs': config.video_codecs,
+        'audio_codecs': config.audio_codecs,
+        'transcode': config.transcode,
+        'strict_codecs': config.strict_codecs,
     }
 
 

--- a/modules/videos/test/test_downloader.py
+++ b/modules/videos/test/test_downloader.py
@@ -1027,6 +1027,10 @@ async def test_channel_passes_all_inheritable_settings_to_video(test_session, ch
         'writesubtitles': False,
         'sleep_requests': 3.0,
         'user_agent': 'TestBot/1.0',
+        'video_codecs': ['h264'],
+        'audio_codecs': ['aac'],
+        'transcode': True,
+        'strict_codecs': True,
     }
 
     download = Download(
@@ -1056,7 +1060,8 @@ async def test_channel_passes_all_inheritable_settings_to_video(test_session, ch
         result = channel_downloader.finalize_download(test_session, download, executed)
 
     # Verify all channel-level inheritable settings are passed through
-    for key in ('video_resolutions', 'video_format', 'writesubtitles', 'sleep_requests', 'user_agent'):
+    for key in ('video_resolutions', 'video_format', 'writesubtitles', 'sleep_requests', 'user_agent',
+                'video_codecs', 'audio_codecs', 'transcode', 'strict_codecs'):
         assert key in result.settings, f'{key} missing from DownloadResult.settings'
         assert result.settings[key] == channel_settings[key], \
             f'{key}: expected {channel_settings[key]}, got {result.settings[key]}'
@@ -1499,3 +1504,231 @@ def test_prepare_uses_existing_video_location(test_session, video_factory):
 def test_is_youtube_url(url, expected):
     """is_youtube_url matches YouTube hosts (and subdomains) but rejects lookalike hosts."""
     assert is_youtube_url(url) is expected
+
+
+def test_format_selector_with_codecs():
+    """Codec preferences generate codec-major selectors: a preferred codec at a lower resolution
+    beats a non-preferred codec at a higher resolution.  The legacy resolution selectors are
+    appended as a fallback unless strict."""
+    from modules.videos.downloader import VIDEO_CODEC_YT_DLP_PATTERNS, AUDIO_CODEC_YT_DLP_PATTERNS
+
+    h264 = VIDEO_CODEC_YT_DLP_PATTERNS['h264']
+    aac = AUDIO_CODEC_YT_DLP_PATTERNS['aac']
+    legacy = format_selector(['1080p', '720p'])
+
+    selector = format_selector(['1080p', '720p'], video_codecs=['h264'], audio_codecs=['aac'])
+    expected = '/'.join([
+        f"bestvideo[height=1080][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[height=1080][vcodec~='{h264}']+bestaudio",
+        f"bestvideo[width=1080][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[width=1080][vcodec~='{h264}']+bestaudio",
+        f"bestvideo[height=720][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[height=720][vcodec~='{h264}']+bestaudio",
+        f"bestvideo[width=720][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[width=720][vcodec~='{h264}']+bestaudio",
+        legacy,
+    ])
+    assert selector == expected
+    assert ',' not in selector
+
+    # Strict drops the any-codec audio fallbacks and the legacy tail.
+    strict = format_selector(['1080p', '720p'], video_codecs=['h264'], audio_codecs=['aac'],
+                             strict_codecs=True)
+    expected_strict = '/'.join([
+        f"bestvideo[height=1080][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[width=1080][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[height=720][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+        f"bestvideo[width=720][vcodec~='{h264}']+bestaudio[acodec~='{aac}']",
+    ])
+    assert strict == expected_strict
+    assert ',' not in strict
+
+    # Codec-major: every h264 selector comes before the first vp9 selector.
+    vp9 = VIDEO_CODEC_YT_DLP_PATTERNS['vp9']
+    two = format_selector(['1080p'], video_codecs=['h264', 'vp9'], strict_codecs=True)
+    assert two.rindex(h264) < two.index(vp9)
+    assert two.count('bestvideo') == 4  # (height + width) x 2 codecs, one audio selector each.
+
+    # No codecs at all: byte-identical to the legacy selector.
+    assert format_selector(['1080p', '720p']) == legacy
+
+    # Only audio codecs: video is unfiltered but audio is preferred.
+    audio_only_pref = format_selector(['720p'], audio_codecs=['opus'])
+    assert "bestvideo[height=720]+bestaudio[acodec~='^opus']" in audio_only_pref
+    assert audio_only_pref.endswith(format_selector(['720p']))
+
+    # 'maximum' has no dimension filter.
+    maximum = format_selector(['maximum'], video_codecs=['h264'], strict_codecs=True)
+    assert maximum == f"bestvideo[vcodec~='{h264}']+bestaudio"
+
+
+def test_format_selector_codec_patterns_are_safe():
+    """Codec regex patterns are embedded in `-f` bracket filters; a comma would make yt-dlp
+    download every matching format, and a slash would break the fallback chain."""
+    from modules.videos.downloader import VIDEO_CODEC_YT_DLP_PATTERNS, AUDIO_CODEC_YT_DLP_PATTERNS
+
+    for pattern in (*VIDEO_CODEC_YT_DLP_PATTERNS.values(), *AUDIO_CODEC_YT_DLP_PATTERNS.values()):
+        assert ',' not in pattern
+        assert '/' not in pattern
+
+
+@pytest.mark.asyncio
+async def test_video_download_requests_codec_format(test_session, test_directory, mock_video_extract_info,
+                                                    video_download_manager, mock_video_process_runner,
+                                                    image_file, simple_channel, test_videos_downloader_config):
+    """Codec settings change the `-f` selector; the legacy selectors remain as fallbacks."""
+    simple_channel.source_id = example_video_json['channel_id']
+    simple_channel.directory = test_directory / 'videos/channel name'
+    simple_channel.directory.mkdir(parents=True)
+
+    video_path = simple_channel.directory / 'a video.mp4'
+    shutil.copy(PROJECT_DIR / 'test/big_buck_bunny_720p_1mb.mp4', video_path)
+    image_file.rename(video_path.with_suffix('.jpg'))
+
+    url = 'https://www.youtube.com/watch?v=31jPEBiAC3c'
+    settings = {'video_codecs': ['h264'], 'audio_codecs': ['aac']}
+
+    with mock.patch('modules.videos.downloader.prepare_video_filename') as mock_prepare_filename:
+        mock_video_extract_info.return_value = example_video_json
+        mock_prepare_filename.return_value = (video_path, {'id': 'foo'})
+
+        video_download_manager.create_download(test_session, url, video_downloader.name, settings=settings)
+        await video_download_manager.wait_for_all_downloads()
+
+        mock_video_process_runner.assert_called_once()
+        download, cmd, out_dir = mock_video_process_runner.call_args[0]
+
+    format_arg = cmd[cmd.index('-f') + 1]
+    resolutions = get_videos_downloader_config().video_resolutions
+    assert format_arg == format_selector(resolutions, video_codecs=['h264'], audio_codecs=['aac'])
+    assert "vcodec~=" in format_arg
+    # The legacy selectors are still offered as a fallback (strict is off).
+    assert format_arg.endswith(format_selector(resolutions))
+
+
+@pytest.mark.asyncio
+async def test_strict_codecs_unavailable_fails_download(test_session, test_directory, mock_video_extract_info,
+                                                        video_download_manager, mock_video_process_runner,
+                                                        image_file, simple_channel,
+                                                        test_videos_downloader_config):
+    """With strict_codecs, yt-dlp's "Requested format is not available" fails the download
+    permanently (the source will never grow new formats)."""
+    from wrolpi.cmd import CommandResult
+
+    simple_channel.source_id = example_video_json['channel_id']
+    simple_channel.directory = test_directory / 'videos/channel name'
+    simple_channel.directory.mkdir(parents=True)
+    video_path = simple_channel.directory / 'a video.mp4'
+
+    url = 'https://www.youtube.com/watch?v=31jPEBiAC3c'
+    settings = {'video_codecs': ['h264'], 'strict_codecs': True}
+
+    mock_video_process_runner.return_value = CommandResult(
+        return_code=1, cancelled=False, stdout=b'',
+        stderr=b'ERROR: [youtube] 31jPEBiAC3c: Requested format is not available.', elapsed=0)
+
+    with mock.patch('modules.videos.downloader.prepare_video_filename') as mock_prepare_filename:
+        mock_video_extract_info.return_value = example_video_json
+        mock_prepare_filename.return_value = (video_path, {'id': 'foo'})
+
+        video_download_manager.create_download(test_session, url, video_downloader.name, settings=settings)
+        await video_download_manager.wait_for_all_downloads()
+
+    download = test_session.query(Download).one()
+    assert download.is_failed, f'Download should have failed permanently, got {download.status}'
+    assert 'transcoding is disabled' in download.error
+
+
+@pytest.mark.asyncio
+async def test_codecs_unavailable_defers_without_strict(test_session, test_directory, mock_video_extract_info,
+                                                        video_download_manager, mock_video_process_runner,
+                                                        image_file, simple_channel,
+                                                        test_videos_downloader_config):
+    """The same yt-dlp failure without strict_codecs is deferred (retried), as before."""
+    from wrolpi.cmd import CommandResult
+
+    simple_channel.source_id = example_video_json['channel_id']
+    simple_channel.directory = test_directory / 'videos/channel name'
+    simple_channel.directory.mkdir(parents=True)
+    video_path = simple_channel.directory / 'a video.mp4'
+
+    url = 'https://www.youtube.com/watch?v=31jPEBiAC3c'
+
+    mock_video_process_runner.return_value = CommandResult(
+        return_code=1, cancelled=False, stdout=b'',
+        stderr=b'ERROR: [youtube] 31jPEBiAC3c: Requested format is not available.', elapsed=0)
+
+    with mock.patch('modules.videos.downloader.prepare_video_filename') as mock_prepare_filename:
+        mock_video_extract_info.return_value = example_video_json
+        mock_prepare_filename.return_value = (video_path, {'id': 'foo'})
+
+        video_download_manager.create_download(test_session, url, video_downloader.name,
+                                               settings={'video_codecs': ['h264']})
+        await video_download_manager.wait_for_all_downloads()
+
+    download = test_session.query(Download).one()
+    assert download.is_deferred, f'Download should defer without strict_codecs, got {download.status}'
+
+
+@pytest.mark.asyncio
+async def test_enforce_codecs():
+    """enforce_codecs transcodes, fails, or keeps the file depending on the effective settings."""
+    import pathlib
+    from modules.videos.downloader import enforce_codecs
+
+    video_path = pathlib.Path('/tmp/video.webm')
+    poster_path = pathlib.Path('/tmp/video.jpg')
+    video_paths = [video_path, poster_path]
+    vp9_ffprobe = {'streams': [
+        {'codec_type': 'video', 'codec_name': 'vp9'},
+        {'codec_type': 'audio', 'codec_name': 'opus'},
+    ]}
+
+    with mock.patch('modules.videos.downloader.get_or_create_ffprobe_json',
+                    new_callable=mock.AsyncMock) as mock_ffprobe, \
+            mock.patch('modules.videos.downloader.transcode_video_file',
+                       new_callable=mock.AsyncMock) as mock_transcode:
+        mock_ffprobe.return_value = (vp9_ffprobe, None)
+
+        # Codecs match: nothing happens.
+        effective = {'video_codecs': ['vp9'], 'audio_codecs': ['opus']}
+        result = await enforce_codecs(video_path, video_paths, effective)
+        assert result == (video_path, video_paths)
+        mock_transcode.assert_not_called()
+
+        # Mismatch with neither transcode nor strict: file is kept.
+        effective = {'video_codecs': ['h264']}
+        result = await enforce_codecs(video_path, video_paths, effective)
+        assert result == (video_path, video_paths)
+        mock_transcode.assert_not_called()
+
+        # Mismatch with strict: permanent failure.
+        effective = {'video_codecs': ['h264'], 'strict_codecs': True}
+        with pytest.raises(UnrecoverableDownloadError):
+            await enforce_codecs(video_path, video_paths, effective)
+        mock_transcode.assert_not_called()
+
+        # Mismatch with transcode: the file is transcoded and the paths updated.
+        new_path = video_path.with_suffix('.mp4')
+        mock_transcode.return_value = new_path
+        effective = {'video_codecs': ['h264'], 'audio_codecs': ['aac'], 'transcode': True,
+                     'video_format': 'mp4'}
+        result = await enforce_codecs(video_path, video_paths, effective)
+        assert result == (new_path, [new_path, poster_path])
+        mock_transcode.assert_called_once_with(video_path, 'h264', 'aac', container='mp4')
+
+        # Transcode wins over strict.
+        mock_transcode.reset_mock()
+        mock_transcode.return_value = new_path
+        effective = {'video_codecs': ['h264'], 'transcode': True, 'strict_codecs': True,
+                     'video_format': 'mp4'}
+        result = await enforce_codecs(video_path, video_paths, effective)
+        assert result[0] == new_path
+        mock_transcode.assert_called_once()
+
+        # No supported transcode target: file is kept, no error.
+        mock_transcode.reset_mock()
+        effective = {'video_codecs': ['av1'], 'transcode': True}
+        result = await enforce_codecs(video_path, video_paths, effective)
+        assert result == (video_path, video_paths)
+        mock_transcode.assert_not_called()

--- a/modules/videos/test/test_lib.py
+++ b/modules/videos/test/test_lib.py
@@ -542,6 +542,54 @@ async def test_get_download_defaults_endpoint(async_client, test_directory, test
     assert 'writesubtitles' in data
     assert 'continue_dl' in data
     assert 'nooverwrites' in data
+    assert 'video_codecs' in data
+    assert 'audio_codecs' in data
+    assert 'transcode' in data
+    assert 'strict_codecs' in data
     # Should NOT contain global-only settings
     assert 'file_name_format' not in data
     assert 'quiet' not in data
+
+
+def test_codec_config_properties(test_directory, test_videos_downloader_config):
+    """The codec settings default to off and round-trip through the config."""
+    config = lib.get_videos_downloader_config()
+    assert config.video_codecs == []
+    assert config.audio_codecs == []
+    assert config.transcode is False
+    assert config.strict_codecs is False
+
+    config.video_codecs = ['h264', 'vp9']
+    config.audio_codecs = ['aac']
+    config.transcode = True
+    config.strict_codecs = True
+    assert config.video_codecs == ['h264', 'vp9']
+    assert config.audio_codecs == ['aac']
+    assert config.transcode is True
+    assert config.strict_codecs is True
+
+    effective = lib.get_effective_video_settings()
+    assert effective['video_codecs'] == ['h264', 'vp9']
+    assert effective['transcode'] is True
+
+    # A download-level override wins.
+    effective = lib.get_effective_video_settings({'video_codecs': ['av1'], 'transcode': False})
+    assert effective['video_codecs'] == ['av1']
+    assert effective['transcode'] is False
+    assert effective['audio_codecs'] == ['aac']
+
+
+def test_download_settings_codec_validation():
+    """DownloadSettings accepts only known codec names."""
+    from wrolpi.schema import DownloadSettings
+    from wrolpi.errors import ValidationError
+
+    settings = DownloadSettings(video_codecs=['h264', 'vp9'], audio_codecs=['aac'],
+                                transcode=True, strict_codecs=True)
+    assert settings.video_codecs == ['h264', 'vp9']
+
+    with pytest.raises(ValidationError):
+        DownloadSettings(video_codecs=['divx'])
+
+    with pytest.raises(ValidationError):
+        DownloadSettings(audio_codecs=['wma'])

--- a/modules/videos/test/test_transcode.py
+++ b/modules/videos/test/test_transcode.py
@@ -1,0 +1,156 @@
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+
+from modules.videos.transcode import codecs_match, get_stream_codec_names, get_transcode_target, \
+    transcode_video_file, TRANSCODE_VIDEO_TARGETS, TRANSCODE_AUDIO_TARGETS
+from wrolpi.cmd import CommandResult
+
+
+def test_get_stream_codec_names():
+    """Embedded thumbnail streams (mjpeg/png) are not video."""
+    data = {'streams': [
+        {'codec_type': 'video', 'codec_name': 'vp9'},
+        {'codec_type': 'video', 'codec_name': 'mjpeg'},
+        {'codec_type': 'audio', 'codec_name': 'opus'},
+    ]}
+    assert get_stream_codec_names(data, 'video') == ['vp9']
+    assert get_stream_codec_names(data, 'audio') == ['opus']
+    assert get_stream_codec_names({}, 'video') == []
+    assert get_stream_codec_names(None, 'video') == []
+
+
+@pytest.mark.parametrize('video_codecs,audio_codecs,expected', [
+    ([], [], (True, True)),  # No preference always matches.
+    (['vp9'], ['opus'], (True, True)),
+    (['h264'], [], (False, True)),
+    (['h264', 'vp9'], [], (True, True)),  # Any preferred codec matches.
+    ([], ['aac'], (True, False)),
+    (['h264'], ['aac'], (False, False)),
+])
+def test_codecs_match(video_codecs, audio_codecs, expected):
+    data = {'streams': [
+        {'codec_type': 'video', 'codec_name': 'vp9'},
+        {'codec_type': 'audio', 'codec_name': 'opus'},
+    ]}
+    assert codecs_match(data, video_codecs, audio_codecs) == expected
+
+
+def test_codecs_match_missing_stream():
+    """A missing stream matches: an audio-only file has no video stream to enforce."""
+    data = {'streams': [{'codec_type': 'audio', 'codec_name': 'mp3'}]}
+    assert codecs_match(data, ['h264'], ['mp3']) == (True, True)
+
+
+def test_get_transcode_target():
+    """The first preferred codec which is a supported target is the target."""
+    assert get_transcode_target(['h264', 'vp9'], TRANSCODE_VIDEO_TARGETS) == 'h264'
+    assert get_transcode_target(['vp9', 'h264'], TRANSCODE_VIDEO_TARGETS) == 'h264'
+    assert get_transcode_target(['vp9', 'av1'], TRANSCODE_VIDEO_TARGETS) is None
+    assert get_transcode_target([], TRANSCODE_VIDEO_TARGETS) is None
+    assert get_transcode_target(['opus', 'aac'], TRANSCODE_AUDIO_TARGETS) == 'opus'
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file(test_directory):
+    """A webm is transcoded to an mp4 with the same stem; the original file and its stale
+    ffprobe sidecar are removed."""
+    video_path = test_directory / 'video.webm'
+    video_path.write_bytes(b'fake video data')
+    sidecar = test_directory / 'video.ffprobe.json'
+    sidecar.write_text(json.dumps({'streams': []}))
+
+    async def fake_run_command(cmd, **kwargs):
+        # ffmpeg writes the temporary output file.
+        pathlib.Path(cmd[-1]).write_bytes(b'transcoded data')
+        return CommandResult(return_code=0, cancelled=False, stdout=b'', stderr=b'', elapsed=1)
+
+    with mock.patch('modules.videos.transcode.run_command', side_effect=fake_run_command) as mock_run:
+        result = await transcode_video_file(video_path, target_vcodec='h264', target_acodec='aac',
+                                            container='mp4')
+
+    assert result == test_directory / 'video.mp4'
+    assert result.is_file() and result.read_bytes() == b'transcoded data'
+    assert not video_path.exists(), 'The original webm should be deleted'
+    assert not sidecar.exists(), 'The stale ffprobe sidecar should be deleted'
+    assert not (test_directory / 'video.transcode.mp4').exists(), 'The temporary file should be renamed'
+
+    cmd = mock_run.call_args[0][0]
+    assert '-c:v' in cmd and cmd[cmd.index('-c:v') + 1] == 'libx264'
+    assert '-c:a' in cmd and cmd[cmd.index('-c:a') + 1] == 'aac'
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file_copies_matching_stream(test_directory):
+    """Only the mismatching stream is re-encoded; the other stream is copied."""
+    video_path = test_directory / 'video.mp4'
+    video_path.write_bytes(b'fake video data')
+
+    async def fake_run_command(cmd, **kwargs):
+        pathlib.Path(cmd[-1]).write_bytes(b'transcoded data')
+        return CommandResult(return_code=0, cancelled=False, stdout=b'', stderr=b'', elapsed=1)
+
+    with mock.patch('modules.videos.transcode.run_command', side_effect=fake_run_command) as mock_run:
+        result = await transcode_video_file(video_path, target_vcodec='h264', container='mp4')
+
+    assert result == video_path, 'Same container: the file is replaced in place'
+    cmd = mock_run.call_args[0][0]
+    assert cmd[cmd.index('-c:v') + 1] == 'libx264'
+    assert cmd[cmd.index('-c:a') + 1] == 'copy'
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file_forces_supported_container(test_directory):
+    """webm cannot contain h264/aac; the container is forced to mp4."""
+    video_path = test_directory / 'video.webm'
+    video_path.write_bytes(b'fake video data')
+
+    async def fake_run_command(cmd, **kwargs):
+        pathlib.Path(cmd[-1]).write_bytes(b'transcoded data')
+        return CommandResult(return_code=0, cancelled=False, stdout=b'', stderr=b'', elapsed=1)
+
+    with mock.patch('modules.videos.transcode.run_command', side_effect=fake_run_command):
+        result = await transcode_video_file(video_path, target_vcodec='h264', container='webm')
+
+    assert result == test_directory / 'video.mp4'
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file_failure_removes_tmp(test_directory):
+    """A failed ffmpeg leaves the original file untouched and no temporary file behind."""
+    video_path = test_directory / 'video.webm'
+    video_path.write_bytes(b'fake video data')
+
+    async def fake_run_command(cmd, **kwargs):
+        pathlib.Path(cmd[-1]).write_bytes(b'partial data')
+        return CommandResult(return_code=1, cancelled=False, stdout=b'', stderr=b'boom', elapsed=1)
+
+    with mock.patch('modules.videos.transcode.run_command', side_effect=fake_run_command):
+        with pytest.raises(RuntimeError):
+            await transcode_video_file(video_path, target_vcodec='h264')
+
+    assert video_path.is_file(), 'The original file must survive a failed transcode'
+    assert not (test_directory / 'video.transcode.mp4').exists()
+    assert not (test_directory / 'video.mp4').exists()
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file_disk_space_guard(test_directory):
+    """Transcoding is refused when the disk is nearly full."""
+    video_path = test_directory / 'video.webm'
+    video_path.write_bytes(b'fake video data' * 1000)
+
+    fake_usage = mock.Mock(free=video_path.stat().st_size)  # Less than 1.5x the source size.
+    with mock.patch('modules.videos.transcode.shutil.disk_usage', return_value=fake_usage), \
+            mock.patch('modules.videos.transcode.run_command') as mock_run:
+        with pytest.raises(RuntimeError, match='free space'):
+            await transcode_video_file(video_path, target_vcodec='h264')
+    mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_transcode_video_file_requires_target():
+    with pytest.raises(RuntimeError, match='target codec'):
+        await transcode_video_file(pathlib.Path('/tmp/video.mp4'))

--- a/modules/videos/transcode.py
+++ b/modules/videos/transcode.py
@@ -1,0 +1,143 @@
+import pathlib
+import shutil
+from typing import List, Optional, Tuple
+
+from wrolpi.captions import FFMPEG_BIN
+from wrolpi.cmd import run_command
+from wrolpi.common import logger
+from wrolpi.vars import DEFAULT_FILE_PERMISSIONS
+
+logger = logger.getChild(__name__)
+
+# ffprobe `codec_name` values that satisfy each user-selectable codec preference.
+FFPROBE_VIDEO_CODEC_NAMES = {
+    'h264': {'h264'},
+    'hevc': {'hevc', 'h265'},
+    'vp9': {'vp9'},
+    'av1': {'av1'},
+    'vp8': {'vp8'},
+}
+FFPROBE_AUDIO_CODEC_NAMES = {
+    'aac': {'aac'},
+    'opus': {'opus'},
+    'mp3': {'mp3'},
+    'vorbis': {'vorbis'},
+}
+
+# Codecs which can be a transcode *target*, mapped to their ffmpeg encoder args.  Encoding VP9/AV1
+# in software is impractically slow on a Raspberry Pi, so only widely-playable targets are offered;
+# these maps are the extension point for adding more targets later.
+TRANSCODE_VIDEO_TARGETS = {
+    'h264': ('-c:v', 'libx264', '-preset', 'medium', '-crf', '23'),
+}
+TRANSCODE_AUDIO_TARGETS = {
+    'aac': ('-c:a', 'aac', '-b:a', '192k'),
+    'opus': ('-c:a', 'libopus', '-b:a', '128k'),
+    'mp3': ('-c:a', 'libmp3lame', '-q:a', '2'),
+}
+
+# Containers that can hold an h264/aac transcode result.  webm cannot.
+TRANSCODE_CONTAINERS = ('mp4', 'mkv')
+
+TRANSCODE_TIMEOUT = 4 * 60 * 60  # A long video on a Raspberry Pi can take hours.
+
+# Transcoding writes a whole new copy of the video next to the original.
+MINIMUM_FREE_SPACE_RATIO = 1.5
+
+
+def get_stream_codec_names(ffprobe_data: dict, codec_type: str) -> List[str]:
+    """Return the codec_name of every stream of the given type ('video' or 'audio').
+
+    Embedded thumbnails appear as mjpeg/png video streams; they are not real video."""
+    streams = (ffprobe_data or {}).get('streams') or []
+    names = [s.get('codec_name') for s in streams if s.get('codec_type') == codec_type]
+    if codec_type == 'video':
+        names = [i for i in names if i not in ('mjpeg', 'png')]
+    return [i for i in names if i]
+
+
+def codecs_match(ffprobe_data: dict, video_codecs: List[str], audio_codecs: List[str]) \
+        -> Tuple[bool, bool]:
+    """Return (video matches, audio matches) for the codec preferences.
+
+    An empty preference list always matches.  A missing stream also matches (an audio-only file
+    has no video stream to enforce)."""
+    video_match = True
+    if video_codecs:
+        names = get_stream_codec_names(ffprobe_data, 'video')
+        if names:
+            acceptable = set().union(*(FFPROBE_VIDEO_CODEC_NAMES.get(i, {i}) for i in video_codecs))
+            video_match = any(i in acceptable for i in names)
+    audio_match = True
+    if audio_codecs:
+        names = get_stream_codec_names(ffprobe_data, 'audio')
+        if names:
+            acceptable = set().union(*(FFPROBE_AUDIO_CODEC_NAMES.get(i, {i}) for i in audio_codecs))
+            audio_match = any(i in acceptable for i in names)
+    return video_match, audio_match
+
+
+def get_transcode_target(preferences: List[str], targets: dict) -> Optional[str]:
+    """The first preferred codec that is a supported transcode target, or None."""
+    for codec in preferences or []:
+        if codec in targets:
+            return codec
+    return None
+
+
+async def transcode_video_file(video_path: pathlib.Path,
+                               target_vcodec: Optional[str] = None,
+                               target_acodec: Optional[str] = None,
+                               container: str = 'mp4') -> pathlib.Path:
+    """Transcode a video file in place (same stem, possibly a new container extension).
+
+    Only the stream(s) with a target are re-encoded; the other stream is copied.  The output is
+    written to a temporary file in the same directory, then atomically renamed over the final
+    path.  The original file is deleted if the extension changed.  Returns the final path.
+
+    @raise RuntimeError: when ffmpeg fails, or there is not enough free disk space.
+    """
+    if not FFMPEG_BIN:
+        raise RuntimeError('ffmpeg was not found')
+    if not target_vcodec and not target_acodec:
+        raise RuntimeError('Refusing to transcode without a target codec')
+    if container not in TRANSCODE_CONTAINERS:
+        logger.info(f'Forcing mp4 container for transcode of {video_path} ({container} is not supported)')
+        container = 'mp4'
+
+    source_size = video_path.stat().st_size
+    free = shutil.disk_usage(video_path.parent).free
+    if free < MINIMUM_FREE_SPACE_RATIO * source_size:
+        raise RuntimeError(
+            f'Not enough free space to transcode {video_path} ({free} bytes free, source is {source_size} bytes)')
+
+    video_args = TRANSCODE_VIDEO_TARGETS[target_vcodec] if target_vcodec else ('-c:v', 'copy')
+    audio_args = TRANSCODE_AUDIO_TARGETS[target_acodec] if target_acodec else ('-c:a', 'copy')
+
+    final_path = video_path.with_suffix(f'.{container}')
+    tmp_path = video_path.with_suffix(f'.transcode.{container}')
+    cmd = (FFMPEG_BIN, '-y',
+           '-i', video_path,
+           '-map', '0:v:0', '-map', '0:a:0',
+           *video_args,
+           *audio_args,
+           '-movflags', '+faststart',
+           str(tmp_path))
+    logger.warning(f'Transcoding {video_path} to {final_path} (video={target_vcodec}, audio={target_acodec})')
+    try:
+        result = await run_command(cmd, cwd=video_path.parent, timeout=TRANSCODE_TIMEOUT)
+        if result.return_code != 0:
+            raise RuntimeError(
+                f'ffmpeg exited with {result.return_code} while transcoding {video_path}:'
+                f'\n{result.stderr.decode()[-2000:]}')
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    # The old ffprobe sidecar describes the old streams.
+    video_path.with_suffix('.ffprobe.json').unlink(missing_ok=True)
+    tmp_path.rename(final_path)
+    if final_path != video_path:
+        video_path.unlink()
+    final_path.chmod(DEFAULT_FILE_PERMISSIONS)
+    return final_path

--- a/wrolpi/schema.py
+++ b/wrolpi/schema.py
@@ -323,6 +323,10 @@ class DownloadSettings:
     nooverwrites: Optional[bool] = None
     audio_only: Optional[bool] = None
     audio_format: Optional[str] = None
+    video_codecs: Optional[List[str]] = None
+    audio_codecs: Optional[List[str]] = None
+    transcode: Optional[bool] = None
+    strict_codecs: Optional[bool] = None
 
     def __post_init__(self):
         if self.excluded_urls and self.excluded_urls.endswith(','):
@@ -359,6 +363,14 @@ class DownloadSettings:
         valid_resolutions = ('360p', '480p', '720p', '1080p', '1440p', '2160p', 'maximum')
         if not all(i in valid_resolutions for i in self.video_resolutions):
             raise ValidationError(f'Download order must be one of 360p, 480p, 720p, 1080p, 1440p, 2160p, or maximum.')
+
+        valid_video_codecs = ('h264', 'vp9', 'av1', 'vp8', 'hevc')
+        if not all(i in valid_video_codecs for i in self.video_codecs or []):
+            raise ValidationError(f'Video codecs must be of: {", ".join(valid_video_codecs)}')
+
+        valid_audio_codecs = ('aac', 'opus', 'mp3', 'vorbis')
+        if not all(i in valid_audio_codecs for i in self.audio_codecs or []):
+            raise ValidationError(f'Audio codecs must be of: {", ".join(valid_audio_codecs)}')
 
 
 @dataclass


### PR DESCRIPTION
## What

Adds download-time control over video/audio encodings to the video, channel, and RSS downloaders, alongside the existing Video Resolutions selector:

* **Video Codecs / Audio Codecs** — ordered preference lists (video: h264, vp9, av1, vp8, hevc; audio: aac, opus, mp3, vorbis). Codec preference is **codec-major**: a preferred codec at a lower resolution is chosen over another codec at a higher resolution.
* **Transcode** — when no preferred codec is available at the source, the downloaded file is re-encoded with ffmpeg after download. Only the mismatching stream is re-encoded (the other is copied). Transcode targets are extensible maps (`TRANSCODE_VIDEO_TARGETS`/`TRANSCODE_AUDIO_TARGETS`), currently h264 (libx264) and aac/opus/mp3 — software VP9/AV1 encoding is impractical on a Raspberry Pi.
* **Fail if codecs unavailable** — when enabled (and transcode is not), a download with no matching format fails permanently instead of falling back; yt-dlp's "Requested format is not available" is treated as unrecoverable. Transcode makes strict moot, so the UI disables the strict toggle while transcode is on and the backend ignores it.

All four settings are inheritable (global config → channel/RSS → video) via `INHERITABLE_VIDEO_SETTINGS`, editable on the download forms (Advanced Settings), and on the Videos settings page.

## Invariants

* Empty codec lists produce a **byte-identical** yt-dlp command to before — existing behavior is unchanged unless codecs are selected.
* Generated format selectors contain no commas (one download per video) and codec patterns contain no `/`.
* The post-download ffprobe check runs before the Video record is created and holds no DB session, so a long ffmpeg run never blocks writers.
* A failed transcode leaves the original file untouched and no temporary file behind; a container change (webm→mp4) keeps the same stem so the FileGroup stays intact.
* Transcoding refuses to start with less than 1.5× the source size free on disk.

## Testing

* Backend: full suite `pytest -nauto` — 1807 passed. New tests cover selector generation, strict/defer outcomes, codec enforcement, transcode mechanics (tmp-then-rename, container force, disk guard), config round-trips, schema validation, and channel inheritance.
* Frontend: Jest 1229 passed (new `CodecSettings.test.js`), Cypress `Download.cy.js` 12 passed, plain `npm run build` clean.
* Verified the `[vcodec~='regex']` selector syntax parses in the pinned yt-dlp (2026.07.04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)